### PR TITLE
docs: improve readme and add usage guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .venv
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,8 +1,29 @@
 # Patch GUI – Diff Applier (PySide6)
 
-Applicazione desktop (GUI) in **Python + PySide6/Qt** per applicare patch **unified diff** (anche nel formato `*** Begin Patch / *** Update File`) a file di progetto. Supporta caricamento da **file**, **clipboard**, **textarea**, ricerca ricorsiva dei file target, **dry‑run/anteprima**, matching **esatto→fuzzy**, risoluzione **interattiva** delle ambiguità, **backup** automatici e **report** dettagliati.
+Applicazione desktop (GUI) in **Python + PySide6/Qt** per applicare patch **unified diff** (anche `*** Begin Patch` / `*** Update File`) a file di progetto.
+
+Caratteristiche principali:
+
+* Caricamento da **file**, **clipboard** o **textarea**
+* Ricerca ricorsiva dei file target
+* Modalità **dry‑run** con anteprima
+* Matching **esatto → fuzzy** con soglia configurabile
+* Risoluzione **interattiva** delle ambiguità
+* **Backup** automatici e **report** dettagliati
 
 ---
+
+## Indice
+
+* [Requisiti](#requisiti)
+* [Installazione](#installazione-consigliata-con-virtualenv)
+* [Avvio rapido](#avvio-rapido)
+* [Guida all'uso](#guida-alluso)
+* [Opzioni/Dettagli tecnici](#opzionidettagli-tecnici)
+* [Risoluzione problemi](#risoluzione-problemi)
+* [Struttura backup/report](#struttura-backupreport)
+* [Note](#note)
+* [Licenza](#licenza)
 
 ## Requisiti
 
@@ -65,7 +86,7 @@ unidiff
 
 ---
 
-## Avvio
+## Avvio rapido
 
 ```bash
 source .venv/bin/activate
@@ -74,7 +95,7 @@ python diff_applier_gui.py
 
 ---
 
-## Come funziona
+## Guida all'uso
 
 1. **Root progetto** → seleziona la cartella base: i percorsi nei diff saranno risolti relativamente a questa root.
 2. **Carica diff**:
@@ -102,6 +123,7 @@ python diff_applier_gui.py
    * `apply-report.json` (strutturato),
    * `apply-report.txt` (leggibile).
 7. **Ripristino**: pulsante **Ripristina da backup…** → seleziona il timestamp → i file vengono ripristinati.
+Per una guida passo-passo con esempi consulta [USAGE.md](USAGE.md).
 
 ---
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,50 @@
+# Guida all'uso di Patch GUI
+
+Questa guida passo‑passo descrive il workflow tipico per applicare una patch con l'interfaccia grafica.
+
+## Avvio dell'applicazione
+
+1. Attiva l'ambiente virtuale (se usato):
+   ```bash
+   source .venv/bin/activate
+   ```
+2. Avvia la GUI:
+   ```bash
+   python diff_applier_gui.py
+   ```
+
+## Workflow dettagliato
+
+1. **Seleziona la root del progetto**
+   - Clicca su **Sfoglia** accanto al campo *Root progetto* e scegli la cartella che contiene i file da patchare.
+   - Tutti i percorsi presenti nei diff verranno risolti relativamente a questa root.
+2. **Carica il diff**
+   - Usa **Apri .diff** per scegliere un file contenente il diff,
+   - Oppure **Incolla da appunti**,
+   - Oppure incolla manualmente il testo nel riquadro e clicca **Analizza testo diff**.
+   - Sono supportati sia i diff standard di Git sia i blocchi `*** Begin Patch` / `*** Update File`.
+3. **Analizza il diff**
+   - Nel pannello sinistro vengono elencati i file e gli hunk trovati.
+   - Selezionando un elemento puoi vedere il contesto e le modifiche.
+4. **Configura l'esecuzione**
+   - La modalità **Dry‑run** è abilitata di default e consente di simulare l'applicazione senza modificare i file.
+   - Imposta la **Soglia fuzzy** (es. `0.85`) per controllare la tolleranza nel matching del contesto.
+5. **Applica la patch**
+   - Con Dry‑run attivo clicca **Applica patch** per vedere l'anteprima dei risultati.
+   - Quando sei soddisfatto, disattiva Dry‑run e premi nuovamente **Applica patch** per modificare realmente i file.
+6. **Gestisci eventuali ambiguità**
+   - Se la patch può essere applicata in più punti plausibili, viene aperto un dialog che mostra tutte le opzioni con il relativo contesto.
+   - Scegli manualmente il posizionamento corretto.
+7. **Consulta backup e report**
+   - Ogni esecuzione reale crea una cartella `./.diff_backups/<timestamp>/` con copie dei file originali.
+   - Nella stessa cartella vengono generati anche `apply-report.json` e `apply-report.txt` con i dettagli dell'operazione.
+8. **Ripristina da backup**
+   - Usa il pulsante **Ripristina da backup…** e seleziona il timestamp desiderato per ripristinare i file originali.
+
+## Suggerimenti utili
+
+- La soglia fuzzy più alta aumenta la precisione ma potrebbe non trovare patch leggermente disallineate.
+- I file binari vengono ignorati automaticamente.
+- Per diff molto grandi l'analisi può richiedere tempo; attendi il completamento prima di chiudere la finestra.
+
+Per una panoramica delle opzioni tecniche e delle dipendenze consulta il [README](README.md).


### PR DESCRIPTION
## Summary
- expand README with feature overview, table of contents, and clearer usage section
- add standalone USAGE.md guide with step-by-step instructions
- ignore Python cache artifacts in .gitignore

## Testing
- `python -m py_compile diff_applier_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7ef999d4c8326abf7c9cb67bc3181