### PR TITLE
Package project structure and add pyproject

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,21 +51,10 @@ Nella root del progetto:
 python3 -m venv .venv
 source .venv/bin/activate
 pip install --upgrade pip
-pip install -r requirements.txt
+pip install .
 ```
 
-Se non usi `requirements.txt`, installa direttamente:
-
-```bash
-pip install PySide6 unidiff
-```
-
-Crea/aggiorna `requirements.txt` (opzionale):
-
-```txt
-PySide6
-unidiff
-```
+> Il comando `pip install .` usa il `pyproject.toml` del progetto per installare automaticamente dipendenze e entry point CLI.
 
 ### VS Code – selezione interprete (WSL)
 
@@ -90,7 +79,9 @@ unidiff
 
 ```bash
 source .venv/bin/activate
-python diff_applier_gui.py
+patch-gui
+# oppure
+python -m patch_gui
 ```
 
 ---

--- a/USAGE.md
+++ b/USAGE.md
@@ -8,9 +8,11 @@ Questa guida passo‑passo descrive il workflow tipico per applicare una patch c
    ```bash
    source .venv/bin/activate
    ```
-2. Avvia la GUI:
+2. Avvia la GUI (tramite entry point installato):
    ```bash
-   python diff_applier_gui.py
+   patch-gui
+   # oppure
+   python -m patch_gui
    ```
 
 ## Workflow dettagliato

--- a/patch_gui/__init__.py
+++ b/patch_gui/__init__.py
@@ -1,0 +1,7 @@
+"""Patch GUI package initialization."""
+
+from .diff_applier_gui import main
+
+__all__ = ["main"]
+
+__version__ = "0.1.0"

--- a/patch_gui/__main__.py
+++ b/patch_gui/__main__.py
@@ -1,0 +1,12 @@
+"""Command-line entry point for Patch GUI."""
+
+from .diff_applier_gui import main
+
+
+def run() -> None:
+    """Launch the Patch GUI application."""
+    main()
+
+
+if __name__ == "__main__":
+    run()

--- a/patch_gui/diff_applier_gui.py
+++ b/patch_gui/diff_applier_gui.py
@@ -17,7 +17,9 @@ Dipendenze:
 - unidiff
 
 Esecuzione:
-  python diff_applier_gui.py
+  patch-gui
+  # oppure
+  python -m patch_gui
 
 Nota: testato su Linux/WSL. Su Windows via WSLg dovrebbe aprire la GUI.
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=67", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "patch-gui"
+version = "0.1.0"
+description = "PySide6 desktop application for applying unified diffs interactively."
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = [
+    "PySide6",
+    "unidiff",
+]
+
+[project.scripts]
+patch-gui = "patch_gui.__main__:run"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["patch_gui*"]


### PR DESCRIPTION
## Summary
- add a `pyproject.toml` that defines package metadata, dependencies, and the `patch-gui` console entry point
- move the application under the `patch_gui` package and expose a module entry point
- refresh README/USAGE instructions to install with `pip install .` and launch via the new CLI

## Testing
- python -m compileall patch_gui

------
https://chatgpt.com/codex/tasks/task_e_68c91759a0e88326b2f34436a4eefa52