### PR TITLE
Add pytest configuration and unit tests for patch processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ python -m patch_gui
 
 ---
 
+## Test
+
+Per eseguire la suite automatizzata del progetto:
+
+```bash
+pytest
+```
+
+---
+
 ## Guida all'uso
 
 1. **Root progetto** → seleziona la cartella base: i percorsi nei diff saranno risolti relativamente a questa root.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+pythonpath = .

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Test configuration for avoiding GUI dependencies during imports."""
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+PACKAGE_NAME = "patch_gui"
+
+if PACKAGE_NAME not in sys.modules:
+    package = types.ModuleType(PACKAGE_NAME)
+    package.__path__ = [str(Path(__file__).resolve().parents[1] / PACKAGE_NAME)]
+    sys.modules[PACKAGE_NAME] = package

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pytest
+
+from patch_gui.patcher import HunkView, apply_hunk_at_position, find_candidates
+
+
+def test_find_candidates_returns_exact_match_first() -> None:
+    file_lines = ["line1\n", "line2\n", "line3\n"]
+    before_lines = ["line2\n"]
+    assert find_candidates(file_lines, before_lines, threshold=0.5) == [(1, 1.0)]
+
+
+def test_find_candidates_returns_sorted_fuzzy_matches() -> None:
+    file_lines = ["abc\n", "dxf\n", "zzz\n", "ab\n", "def\n"]
+    before_lines = ["abc\n", "def\n"]
+    result = find_candidates(file_lines, before_lines, threshold=0.5)
+    assert result == [(3, pytest.approx(0.9333333333)), (0, pytest.approx(0.875))]
+
+
+def test_find_candidates_with_empty_before_lines_returns_empty() -> None:
+    assert find_candidates(["line\n"], [], threshold=0.5) == []
+
+
+def test_apply_hunk_at_position_replaces_expected_window() -> None:
+    file_lines = ["a\n", "b\n", "c\n"]
+    hv = HunkView(header="@@ -2 +2 @@", before_lines=["b\n"], after_lines=["B\n"])
+    result = apply_hunk_at_position(file_lines, hv, pos=1)
+    assert result == ["a\n", "B\n", "c\n"]
+
+
+def test_apply_hunk_at_position_raises_when_window_exceeds_length() -> None:
+    file_lines = ["a\n", "b\n"]
+    hv = HunkView(header="@@ -2,2 +2,2 @@", before_lines=["b\n", "c\n"], after_lines=["B\n"])
+    with pytest.raises(IndexError):
+        apply_hunk_at_position(file_lines, hv, pos=1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from patch_gui.utils import preprocess_patch_text
+
+
+def test_preprocess_patch_text_normalizes_newlines_without_wrapper() -> None:
+    raw = """--- a/file.txt\r\n+++ b/file.txt\r\n-old\r\n+new\r\n"""
+    expected = """--- a/file.txt\n+++ b/file.txt\n-old\n+new\n"""
+    assert preprocess_patch_text(raw) == expected
+
+
+def test_preprocess_patch_text_extracts_begin_patch_blocks() -> None:
+    raw = (
+        "*** Begin Patch\n"
+        "*** Update File: foo.txt\n"
+        "@@\n"
+        "-old line\n"
+        "+new line\n"
+        "*** Update File: bar/baz.txt\n"
+        "@@ -1 +1 @@ suffix\n"
+        "-foo\n"
+        "+bar\n"
+        "*** End Patch\n"
+    )
+    expected = (
+        "--- a/foo.txt\n"
+        "+++ b/foo.txt\n"
+        "@@ -1,1 +1,1 @@\n"
+        "-old line\n"
+        "+new line\n"
+        "--- a/bar/baz.txt\n"
+        "+++ b/bar/baz.txt\n"
+        "@@ -1 +1 @@ suffix\n"
+        "-foo\n"
+        "+bar\n"
+    )
+    assert preprocess_patch_text(raw) == expected


### PR DESCRIPTION
## Summary
- add a pytest configuration file and test bootstrap that avoids importing the GUI stack
- cover the preprocess_patch_text helper with cases for newline normalization and "*** Begin Patch" parsing
- exercise find_candidates and apply_hunk_at_position along with README instructions for running pytest

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c91d6085bc8326bdfe0c0afe394207