### PR TITLE
Add CLI support and dispatch logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Caratteristiche principali:
 * Matching **esatto → fuzzy** con soglia configurabile
 * Risoluzione **interattiva** delle ambiguità
 * **Backup** automatici e **report** dettagliati
+* Modalità **CLI** (`patch-gui apply`) con opzioni `--dry-run`, `--threshold`, `--backup`
 
 ---
 
@@ -84,6 +85,23 @@ patch-gui
 # oppure
 python -m patch_gui
 ```
+
+### Modalità CLI (senza GUI)
+
+```bash
+patch-gui apply --root /percorso/al/progetto diff.patch
+# oppure
+python -m patch_gui apply --root /percorso/al/progetto diff.patch
+
+# Esempi di opzioni
+patch-gui apply --root . --dry-run --threshold 0.90 diff.patch
+git diff | patch-gui apply --root . --backup ~/diff_backups -
+```
+
+* `--dry-run` esegue solo l'analisi lasciando i file invariati.
+* `--threshold` imposta la soglia fuzzy (default 0.85).
+* `--backup` permette di scegliere la cartella base dei backup (di default `<root>/.diff_backups`).
+* L'uscita riassume i risultati e restituisce codice `0` solo se tutti gli hunk vengono applicati.
 
 ---
 

--- a/patch_gui/__main__.py
+++ b/patch_gui/__main__.py
@@ -1,11 +1,16 @@
 """Command-line entry point for Patch GUI."""
 
+from __future__ import annotations
+
+import sys
+
 from .diff_applier_gui import main
 
 
 def run() -> None:
-    """Launch the Patch GUI application."""
-    main()
+    """Entry point used by the ``patch-gui`` console script."""
+
+    sys.exit(main())
 
 
 if __name__ == "__main__":

--- a/patch_gui/cli.py
+++ b/patch_gui/cli.py
@@ -1,0 +1,360 @@
+"""Command-line helpers to apply unified diff patches without launching the GUI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+from unidiff import PatchSet
+from unidiff.errors import UnidiffParseError
+
+from .patcher import (
+    ApplySession,
+    FileResult,
+    HunkDecision,
+    HunkView,
+    apply_hunk_at_position,
+    build_hunk_view,
+    find_candidates,
+)
+from .utils import APP_NAME, BACKUP_DIR, REPORT_JSON, REPORT_TXT, normalize_newlines, preprocess_patch_text
+
+__all__ = [
+    "CLIError",
+    "apply_patchset",
+    "build_parser",
+    "load_patch",
+    "run_cli",
+]
+
+
+class CLIError(Exception):
+    """Raised for recoverable CLI usage errors."""
+
+
+def build_parser(parser: Optional[argparse.ArgumentParser] = None) -> argparse.ArgumentParser:
+    """Create or enrich an ``ArgumentParser`` with CLI options."""
+
+    if parser is None:
+        parser = argparse.ArgumentParser(
+            prog="patch-gui apply",
+            description=(
+                f"{APP_NAME}: applica una patch unified diff usando le stesse euristiche "
+                "della GUI, ma dalla riga di comando."
+            ),
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        )
+    else:
+        parser.description = (
+            f"{APP_NAME}: applica una patch unified diff usando le stesse euristiche "
+            "della GUI, ma dalla riga di comando."
+        )
+        parser.formatter_class = argparse.ArgumentDefaultsHelpFormatter
+    parser.add_argument(
+        "patch",
+        help="Percorso del file diff da applicare (usa '-' per leggere da STDIN).",
+    )
+    parser.add_argument(
+        "--root",
+        required=True,
+        help="Root del progetto su cui applicare la patch.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Simula l'applicazione senza modificare i file o creare backup.",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=_threshold_value,
+        default=0.85,
+        help="Soglia (0-1) per il matching fuzzy del contesto.",
+    )
+    parser.add_argument(
+        "--backup",
+        help=(
+            "Cartella base per backup e report; di default viene utilizzato "
+            "'<root>/%s'." % BACKUP_DIR
+        ),
+    )
+    return parser
+
+
+def load_patch(source: str) -> PatchSet:
+    """Load and parse a diff/patch file from ``source`` (path or ``'-'`` for stdin)."""
+
+    if source == "-":
+        text = sys.stdin.read()
+    else:
+        path = Path(source)
+        if not path.exists():
+            raise CLIError(f"File diff non trovato: {path}")
+        try:
+            text = path.read_text(encoding="utf-8")
+        except Exception as exc:  # pragma: no cover - extremely rare I/O error types
+            raise CLIError(f"Impossibile leggere {path}: {exc}") from exc
+
+    processed = preprocess_patch_text(text)
+    try:
+        patch = PatchSet(processed)
+    except UnidiffParseError as exc:
+        raise CLIError(f"Diff non valido: {exc}") from exc
+    except Exception as exc:  # pragma: no cover - defensive guard for unexpected errors
+        raise CLIError(f"Errore imprevisto nel parsing del diff: {exc}") from exc
+    return patch
+
+
+def apply_patchset(
+    patch: PatchSet,
+    project_root: Path,
+    *,
+    dry_run: bool,
+    threshold: float,
+    backup_base: Optional[Path] = None,
+) -> ApplySession:
+    """Apply ``patch`` to ``project_root`` and return the :class:`ApplySession`."""
+
+    root = project_root.expanduser().resolve()
+    if not root.exists() or not root.is_dir():
+        raise CLIError(f"Root del progetto non valida: {project_root}")
+
+    backup_dir = _prepare_backup_dir(root, backup_base, dry_run)
+    session = ApplySession(
+        project_root=root,
+        backup_dir=backup_dir,
+        dry_run=dry_run,
+        threshold=threshold,
+        started_at=time.time(),
+    )
+
+    for pf in patch:
+        rel = _relative_path_from_patch(pf)
+        fr = _apply_file_patch(root, pf, rel, session)
+        session.results.append(fr)
+
+    if not dry_run:
+        _write_reports(session)
+
+    return session
+
+
+def run_cli(argv: Sequence[str] | None = None) -> int:
+    """Parse ``argv`` and execute the CLI workflow."""
+
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    try:
+        patch = load_patch(args.patch)
+        backup_base = Path(args.backup).expanduser() if args.backup else None
+        session = apply_patchset(
+            patch,
+            Path(args.root),
+            dry_run=args.dry_run,
+            threshold=args.threshold,
+            backup_base=backup_base,
+        )
+    except CLIError as exc:
+        parser.exit(1, f"Errore: {exc}\n")
+
+    print(session.to_txt())
+    if args.dry_run:
+        print("\nModalità dry-run: nessun file è stato modificato e non sono stati creati backup.")
+    else:
+        print(f"\nBackup e report salvati in: {session.backup_dir}")
+
+    return 0 if _session_completed(session) else 1
+
+
+def _threshold_value(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as exc:  # pragma: no cover - argparse already handles typical errors
+        raise argparse.ArgumentTypeError("La soglia deve essere un numero decimale.") from exc
+    if not 0 < parsed <= 1:
+        raise argparse.ArgumentTypeError("La soglia deve essere compresa tra 0 (escluso) e 1 (incluso).")
+    return parsed
+
+
+def _prepare_backup_dir(project_root: Path, backup_base: Optional[Path], dry_run: bool) -> Path:
+    base = backup_base if backup_base is not None else project_root / BACKUP_DIR
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    backup_dir = base / timestamp
+    if not dry_run:
+        backup_dir.mkdir(parents=True, exist_ok=True)
+    return backup_dir
+
+
+def _relative_path_from_patch(pf) -> str:
+    rel = pf.path or pf.target_file or pf.source_file or ""
+    return rel.strip()
+
+
+def _apply_file_patch(project_root: Path, pf, rel_path: str, session: ApplySession) -> FileResult:
+    fr = FileResult(file_path=Path(), relative_to_root=rel_path)
+    fr.hunks_total = len(pf)
+
+    if getattr(pf, "is_binary_file", False):
+        fr.skipped_reason = "Patch binaria non supportata in modalità CLI"
+        return fr
+
+    candidates = list(_locate_candidates(project_root, rel_path))
+    if not candidates:
+        fr.skipped_reason = "File non trovato nella root del progetto"
+        return fr
+    if len(candidates) > 1:
+        fr.skipped_reason = (
+            "Più file trovati per il percorso indicato; risolvi l'ambiguità manualmente."
+        )
+        return fr
+
+    path = candidates[0]
+    fr.file_path = path
+    try:
+        fr.relative_to_root = str(path.relative_to(project_root))
+    except ValueError:
+        fr.relative_to_root = str(path)
+
+    try:
+        raw = path.read_bytes()
+    except Exception as exc:
+        fr.skipped_reason = f"Impossibile leggere il file: {exc}"
+        return fr
+
+    content = raw.decode("utf-8", errors="replace")
+    orig_eol = "\r\n" if "\r\n" in content else "\n"
+    lines = normalize_newlines(content).splitlines(keepends=True)
+
+    if not session.dry_run:
+        _backup_file(project_root, path, session.backup_dir)
+
+    modified = False
+
+    for hunk in pf:
+        hv = build_hunk_view(hunk)
+        decision = HunkDecision(hunk_header=hv.header, strategy="")
+
+        applied = _try_apply_hunk(lines, hv, decision, session, exact_threshold=1.0)
+        if applied is not None:
+            lines, success = applied
+            if success:
+                fr.hunks_applied += 1
+                modified = True
+            fr.decisions.append(decision)
+            continue
+
+        applied = _try_apply_hunk(lines, hv, decision, session, exact_threshold=session.threshold)
+        if applied is not None:
+            lines, success = applied
+            if success:
+                fr.hunks_applied += 1
+                modified = True
+            fr.decisions.append(decision)
+            continue
+
+        context_lines = [ln for ln in hv.before_lines if not ln.startswith(("+", "-"))]
+        cand = find_candidates(lines, context_lines, threshold=session.threshold)
+        if cand:
+            decision.strategy = "ambiguous"
+            decision.candidates = cand
+            decision.message = (
+                "Solo il contesto coincide. Usa la GUI o regola la soglia per applicare questo hunk."
+            )
+            fr.decisions.append(decision)
+            continue
+
+        decision.strategy = "failed"
+        decision.message = "Nessun candidato compatibile trovato sopra la soglia impostata."
+        fr.decisions.append(decision)
+
+    if not session.dry_run and modified:
+        new_text = "".join(lines).replace("\n", orig_eol)
+        path.write_text(new_text, encoding="utf-8")
+
+    return fr
+
+
+def _try_apply_hunk(
+    lines: List[str],
+    hv: HunkView,
+    decision: HunkDecision,
+    session: ApplySession,
+    *,
+    exact_threshold: float,
+) -> Optional[Tuple[List[str], bool]]:
+    candidates = find_candidates(lines, hv.before_lines, threshold=exact_threshold)
+    if not candidates:
+        return None
+    if len(candidates) > 1 and exact_threshold < 1.0:
+        decision.strategy = "ambiguous"
+        decision.candidates = candidates
+        decision.message = (
+            "Più posizioni trovate sopra la soglia. La CLI non può scegliere automaticamente."
+        )
+        return (lines, False)
+
+    pos, score = candidates[0]
+    try:
+        new_lines = apply_hunk_at_position(lines, hv, pos)
+    except Exception as exc:  # pragma: no cover - safeguard against unexpected errors
+        decision.strategy = "failed"
+        decision.message = f"Errore durante l'applicazione del hunk: {exc}"
+        return (lines, False)
+
+    decision.strategy = "exact" if exact_threshold == 1.0 else "fuzzy"
+    decision.selected_pos = pos
+    decision.similarity = score
+    return (new_lines, True)
+
+
+def _locate_candidates(project_root: Path, rel_path: str) -> Iterable[Path]:
+    rel = rel_path.strip()
+    if rel.startswith("a/") or rel.startswith("b/"):
+        rel = rel[2:]
+    if not rel:
+        return []
+
+    exact = project_root / rel
+    if exact.exists():
+        return [exact]
+
+    name = Path(rel).name
+    matches = [p for p in project_root.rglob(name) if p.is_file()]
+    if not matches:
+        return []
+
+    suffix_matches = [p for p in matches if str(p.relative_to(project_root)).endswith(rel)]
+    if len(suffix_matches) == 1:
+        return suffix_matches
+    return sorted(matches)
+
+
+def _backup_file(project_root: Path, path: Path, backup_root: Path) -> None:
+    rel = path.relative_to(project_root)
+    dest = backup_root / rel
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(path, dest)
+
+
+def _write_reports(session: ApplySession) -> None:
+    session.backup_dir.mkdir(parents=True, exist_ok=True)
+    (session.backup_dir / REPORT_JSON).write_text(
+        json.dumps(session.to_json(), ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    (session.backup_dir / REPORT_TXT).write_text(session.to_txt(), encoding="utf-8")
+
+
+def _session_completed(session: ApplySession) -> bool:
+    for fr in session.results:
+        if fr.skipped_reason:
+            return False
+        if fr.hunks_total and fr.hunks_applied != fr.hunks_total:
+            return False
+    return True

--- a/patch_gui/diff_applier_gui.py
+++ b/patch_gui/diff_applier_gui.py
@@ -1,10 +1,89 @@
-"""Entry point wrapper for the Patch GUI application."""
+"""Entry point that dispatches between the GUI and CLI workflows."""
+
 from __future__ import annotations
 
-from .app import main
+import argparse
+import sys
+from typing import Sequence
+
+from . import cli
+from .utils import APP_NAME
 
 __all__ = ["main"]
 
+CLI_FLAGS = {"--dry-run", "--threshold", "--backup", "--root"}
+CLI_PREFIXES = ("--threshold=", "--backup=")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Dispatch to the GUI or CLI depending on the provided arguments."""
+
+    args = list(sys.argv[1:] if argv is None else argv)
+
+    if not args:
+        return _launch_gui()
+
+    if args[0] == "gui":
+        if any(opt in {"-h", "--help"} for opt in args[1:]):
+            _print_gui_help()
+            return 0
+        return _launch_gui()
+
+    if args[0] == "apply":
+        return cli.run_cli(args[1:])
+
+    if any(opt in {"-h", "--help"} for opt in args):
+        _print_help()
+        return 0
+
+    if _looks_like_cli(args):
+        return cli.run_cli(args)
+
+    return _launch_gui()
+
+
+def _looks_like_cli(args: Sequence[str]) -> bool:
+    if not args:
+        return False
+    first = args[0]
+    if not first.startswith("-"):
+        return True
+    for opt in args:
+        if opt in CLI_FLAGS:
+            return True
+        if opt.startswith(CLI_PREFIXES):
+            return True
+    return False
+
+
+def _launch_gui() -> int:
+    from .app import main as gui_main
+
+    gui_main()
+    return 0
+
+
+def _print_gui_help() -> None:
+    print("Uso: patch-gui gui", file=sys.stdout)
+    print("Apre l'interfaccia grafica dell'applicazione.", file=sys.stdout)
+
+
+def _print_help() -> None:
+    parser = argparse.ArgumentParser(
+        prog="patch-gui",
+        description=f"{APP_NAME} – avvia la GUI (default) oppure applica una patch via CLI.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "command",
+        nargs="?",
+        choices=["gui", "apply"],
+        help="Comando da eseguire (default: gui).",
+    )
+    parser.print_help()
+    print("\nOpzioni CLI:", file=sys.stdout)
+    cli.build_parser().print_help()
+
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from unidiff import PatchSet
+
+from patch_gui import cli
+from patch_gui.utils import BACKUP_DIR, REPORT_JSON, REPORT_TXT
+
+SAMPLE_DIFF = """--- a/sample.txt
++++ b/sample.txt
+@@ -1,2 +1,2 @@
+-old line
++new line
+ line2
+"""
+
+
+def _create_project(tmp_path: Path) -> Path:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "sample.txt").write_text("old line\nline2\n", encoding="utf-8")
+    return project
+
+
+def test_apply_patchset_dry_run(tmp_path) -> None:
+    project = _create_project(tmp_path)
+
+    session = cli.apply_patchset(
+        PatchSet(SAMPLE_DIFF),
+        project,
+        dry_run=True,
+        threshold=0.85,
+    )
+
+    target = project / "sample.txt"
+    assert target.read_text(encoding="utf-8") == "old line\nline2\n"
+    assert session.dry_run is True
+    assert not session.backup_dir.exists()
+    assert len(session.results) == 1
+
+    file_result = session.results[0]
+    assert file_result.skipped_reason is None
+    assert file_result.hunks_applied == file_result.hunks_total == 1
+
+
+def test_apply_patchset_real_run_creates_backup(tmp_path) -> None:
+    project = _create_project(tmp_path)
+    target = project / "sample.txt"
+    original = target.read_text(encoding="utf-8")
+
+    session = cli.apply_patchset(
+        PatchSet(SAMPLE_DIFF),
+        project,
+        dry_run=False,
+        threshold=0.85,
+    )
+
+    assert target.read_text(encoding="utf-8") == "new line\nline2\n"
+    assert session.backup_dir.parent.name == BACKUP_DIR
+    assert session.backup_dir.exists()
+
+    backup_copy = session.backup_dir / "sample.txt"
+    assert backup_copy.exists()
+    assert backup_copy.read_text(encoding="utf-8") == original
+
+    json_report = session.backup_dir / REPORT_JSON
+    text_report = session.backup_dir / REPORT_TXT
+    assert json_report.exists()
+    assert text_report.exists()
+
+    data = json.loads(json_report.read_text(encoding="utf-8"))
+    assert data["files"][0]["hunks_applied"] == 1
+
+    file_result = session.results[0]
+    assert file_result.hunks_applied == file_result.hunks_total == 1


### PR DESCRIPTION
## Summary
- add a reusable CLI module to load unified diffs, apply them with backup/dry-run/threshold controls and emit reports
- update the package entry points to dispatch between the GUI and the new CLI workflow and print combined help text
- document the CLI usage in the README and cover it with new pytest cases

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c91f5915688326b6c54ab823cdb6b2