### PR TITLE
Preserve original encodings when applying patches

### DIFF
--- a/patch_gui/app.py
+++ b/patch_gui/app.py
@@ -30,8 +30,10 @@ from .utils import (
     BACKUP_DIR,
     REPORT_JSON,
     REPORT_TXT,
+    decode_bytes,
     normalize_newlines,
     preprocess_patch_text,
+    write_text_preserving_encoding,
 )
 
 
@@ -285,7 +287,7 @@ class PatchApplyWorker(QtCore.QThread):
             fr.skipped_reason = f"Impossibile leggere file: {e}"
             return fr
 
-        content_str = raw.decode("utf-8", errors="replace")
+        content_str, file_encoding = decode_bytes(raw)
         orig_eol = "\r\n" if "\r\n" in content_str else "\n"
         lines = normalize_newlines(content_str).splitlines(keepends=True)
 
@@ -362,7 +364,7 @@ class PatchApplyWorker(QtCore.QThread):
         if not self.session.dry_run:
             new_text = "".join(lines)
             new_text = new_text.replace("\n", orig_eol)
-            path.write_text(new_text, encoding="utf-8")
+            write_text_preserving_encoding(path, new_text, file_encoding)
 
         return fr
 
@@ -753,7 +755,7 @@ class MainWindow(QtWidgets.QMainWindow):
             fr.skipped_reason = f"Impossibile leggere file: {e}"
             return fr
 
-        content_str = raw.decode("utf-8", errors="replace")
+        content_str, file_encoding = decode_bytes(raw)
         orig_eol = "\r\n" if "\r\n" in content_str else "\n"
         lines = normalize_newlines(content_str).splitlines(keepends=True)
 
@@ -834,7 +836,7 @@ class MainWindow(QtWidgets.QMainWindow):
         if not session.dry_run:
             new_text = "".join(lines)
             new_text = new_text.replace("\n", orig_eol)
-            path.write_text(new_text, encoding="utf-8")
+            write_text_preserving_encoding(path, new_text, file_encoding)
 
         return fr
 

--- a/patch_gui/cli.py
+++ b/patch_gui/cli.py
@@ -23,7 +23,16 @@ from .patcher import (
     build_hunk_view,
     find_candidates,
 )
-from .utils import APP_NAME, BACKUP_DIR, REPORT_JSON, REPORT_TXT, normalize_newlines, preprocess_patch_text
+from .utils import (
+    APP_NAME,
+    BACKUP_DIR,
+    REPORT_JSON,
+    REPORT_TXT,
+    decode_bytes,
+    normalize_newlines,
+    preprocess_patch_text,
+    write_text_preserving_encoding,
+)
 
 __all__ = [
     "CLIError",
@@ -227,7 +236,7 @@ def _apply_file_patch(project_root: Path, pf, rel_path: str, session: ApplySessi
         fr.skipped_reason = f"Impossibile leggere il file: {exc}"
         return fr
 
-    content = raw.decode("utf-8", errors="replace")
+    content, file_encoding = decode_bytes(raw)
     orig_eol = "\r\n" if "\r\n" in content else "\n"
     lines = normalize_newlines(content).splitlines(keepends=True)
 
@@ -275,7 +284,7 @@ def _apply_file_patch(project_root: Path, pf, rel_path: str, session: ApplySessi
 
     if not session.dry_run and modified:
         new_text = "".join(lines).replace("\n", orig_eol)
-        path.write_text(new_text, encoding="utf-8")
+        write_text_preserving_encoding(path, new_text, file_encoding)
 
     return fr
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
     "PySide6",
+    "charset-normalizer>=3.3.2",
     "unidiff",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PySide6==6.7.3
+charset-normalizer==3.3.2
 unidiff==0.7.5


### PR DESCRIPTION
## Summary
- add encoding detection helpers that leverage charset-normalizer with UTF-8 fallback
- use the detected encoding when reading and writing files in both GUI and CLI patch application flows
- record the new charset-normalizer dependency for packaging and installs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c93dd8f76483268bfdc057da5b4862