### PR TITLE
Document logging configuration variables in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,18 @@ patch-gui
 * **EOL**: preserva lo stile originale del file (LF/CRLF) al salvataggio.
 * **Ricerca file**: tenta prima il percorso relativo esatto (ripulendo prefissi `a/`/`b/`), altrimenti ricerca **per nome** in modo ricorsivo; in caso di multipli chiede quale usare.
 * **Formati supportati**: file di testo in generale (JS, TS, HTML, CSS, MD, Rust, …).
+* **Logging**:
+  * `PATCH_GUI_LOG_LEVEL` controlla la verbosità (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`, oppure valori numerici come `20`). Il default è `INFO`.
+  * `PATCH_GUI_LOG_FILE` imposta il percorso del file di log (valori come `~/logs/patch_gui.log`). In assenza della variabile viene usato `~/.patch_gui.log`.
+
+  ```bash
+  # Avvio della GUI con log dettagliati nel percorso di default (~/.patch_gui.log)
+  PATCH_GUI_LOG_LEVEL=DEBUG patch-gui
+
+  # Modalità CLI con log in una posizione personalizzata
+  PATCH_GUI_LOG_FILE="$HOME/logs/patch_gui-app.log" PATCH_GUI_LOG_LEVEL=WARNING \
+    patch-gui apply --root . diff.patch
+  ```
 
 ---
 


### PR DESCRIPTION
## Summary
- document the PATCH_GUI_LOG_LEVEL and PATCH_GUI_LOG_FILE environment variables in the technical options section
- note the supported log levels and default log file path
- add shell examples showing how to configure logging for the GUI and CLI entry points

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c954e7311c832697f32ac0b8ea4c86