### PR TITLE
Support non-UTF-8 patches in CLI

### DIFF
--- a/patch_gui/cli.py
+++ b/patch_gui/cli.py
@@ -105,7 +105,8 @@ def load_patch(source: str) -> PatchSet:
         if not path.exists():
             raise CLIError(f"File diff non trovato: {path}")
         try:
-            text = path.read_text(encoding="utf-8")
+            raw = path.read_bytes()
+            text, _ = decode_bytes(raw)
         except Exception as exc:  # pragma: no cover - extremely rare I/O error types
             raise CLIError(f"Impossibile leggere {path}: {exc}") from exc
 


### PR DESCRIPTION
## Summary
- decode diff files in `load_patch` using the shared `decode_bytes` helper so non-UTF-8 inputs load correctly
- add a CLI test covering the application of a UTF-16 encoded patch and verifying backups

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c954ce56c8832682755ea90d757294