### PR TITLE
Handle non-UTF-8 diff files in CLI

### DIFF
--- a/patch_gui/cli.py
+++ b/patch_gui/cli.py
@@ -105,7 +105,8 @@ def load_patch(source: str) -> PatchSet:
         if not path.exists():
             raise CLIError(f"File diff non trovato: {path}")
         try:
-            text = path.read_text(encoding="utf-8")
+            raw = path.read_bytes()
+            text, _ = decode_bytes(raw)
         except Exception as exc:  # pragma: no cover - extremely rare I/O error types
             raise CLIError(f"Impossibile leggere {path}: {exc}") from exc
 


### PR DESCRIPTION
## Summary
- decode diff files in `load_patch` using `decode_bytes` so non-UTF-8 diffs can be parsed
- add a CLI test that applies a UTF-16 encoded diff and verifies the resulting file contents

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c956d88f0883268b1aaceec421df40