### PR TITLE
Add interactive candidate selection to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Caratteristiche principali:
 * Matching **esatto → fuzzy** con soglia configurabile
 * Risoluzione **interattiva** delle ambiguità
 * **Backup** automatici e **report** dettagliati
-* Modalità **CLI** (`patch-gui apply`) con opzioni `--dry-run`, `--threshold`, `--backup`
+* Modalità **CLI** (`patch-gui apply`) con opzioni `--dry-run`, `--threshold`, `--backup`, `--non-interactive`
 
 ---
 
@@ -97,11 +97,14 @@ python -m patch_gui apply --root /percorso/al/progetto diff.patch
 # Esempi di opzioni
 patch-gui apply --root . --dry-run --threshold 0.90 diff.patch
 git diff | patch-gui apply --root . --backup ~/diff_backups -
+# per disabilitare le richieste interattive in caso di ambiguità
+patch-gui apply --root . --non-interactive diff.patch
 ```
 
 * `--dry-run` esegue solo l'analisi lasciando i file invariati.
 * `--threshold` imposta la soglia fuzzy (default 0.85).
 * `--backup` permette di scegliere la cartella base dei backup (di default `<root>/.diff_backups`).
+* `--non-interactive` mantiene il comportamento storico: se il percorso è ambiguo il file viene saltato senza richiesta su STDIN.
 * L'uscita riassume i risultati e restituisce codice `0` solo se tutti gli hunk vengono applicati.
 
 ---
@@ -181,7 +184,7 @@ patch-gui
 
 * **Soglia fuzzy**: regola la tolleranza nel confronto del contesto (Algorithm: `difflib.SequenceMatcher`).
 * **EOL**: preserva lo stile originale del file (LF/CRLF) al salvataggio.
-* **Ricerca file**: tenta prima il percorso relativo esatto (ripulendo prefissi `a/`/`b/`), altrimenti ricerca **per nome** in modo ricorsivo; in caso di multipli chiede quale usare.
+* **Ricerca file**: tenta prima il percorso relativo esatto (ripulendo prefissi `a/`/`b/`), altrimenti ricerca **per nome** in modo ricorsivo; in caso di multipli chiede quale usare (la CLI può essere resa non interattiva con `--non-interactive`).
 * **Formati supportati**: file di testo in generale (JS, TS, HTML, CSS, MD, Rust, …).
 * **Logging**:
   * `PATCH_GUI_LOG_LEVEL` controlla la verbosità (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`, oppure valori numerici come `20`). Il default è `INFO`.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -111,6 +111,7 @@ def test_apply_patchset_reports_ambiguous_candidates(tmp_path) -> None:
         project,
         dry_run=True,
         threshold=0.85,
+        interactive=False,
     )
 
     assert len(session.results) == 1
@@ -122,6 +123,34 @@ def test_apply_patchset_reports_ambiguous_candidates(tmp_path) -> None:
     report = session.to_txt()
     assert "src/app/sample.txt" in report
     assert "tests/app/sample.txt" in report
+
+
+def test_apply_patchset_interactive_candidate_selection(monkeypatch, tmp_path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+
+    src_dir = project / "src/app"
+    tests_dir = project / "tests/app"
+    src_dir.mkdir(parents=True)
+    tests_dir.mkdir(parents=True)
+
+    (src_dir / "sample.txt").write_text("old line\n", encoding="utf-8")
+    (tests_dir / "sample.txt").write_text("old line\n", encoding="utf-8")
+
+    monkeypatch.setattr("builtins.input", lambda _: "2")
+
+    session = cli.apply_patchset(
+        PatchSet(AMBIGUOUS_DIFF),
+        project,
+        dry_run=True,
+        threshold=0.85,
+    )
+
+    assert len(session.results) == 1
+    file_result = session.results[0]
+    assert file_result.skipped_reason is None
+    assert file_result.relative_to_root == "tests/app/sample.txt"
+    assert file_result.hunks_applied == file_result.hunks_total == 1
 
 
 def test_apply_patchset_skipped_reason_lists_candidates(tmp_path) -> None:
@@ -141,6 +170,7 @@ def test_apply_patchset_skipped_reason_lists_candidates(tmp_path) -> None:
         project,
         dry_run=True,
         threshold=0.85,
+        interactive=False,
     )
 
     assert len(session.results) == 1


### PR DESCRIPTION
## Summary
- add an interactive prompt to choose among multiple candidate files when applying patches via CLI
- add the `--non-interactive` flag to restore the previous behaviour
- update documentation and automated tests for the new workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9682cfa6c8326b2af29430b23d47c