### PR TITLE
Make PySide6 optional and document CLI-only install

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,13 @@ Nella root del progetto:
 python3 -m venv .venv
 source .venv/bin/activate
 pip install --upgrade pip
-pip install .
+pip install .  # solo CLI
+# oppure (per includere la GUI PySide6)
+pip install .[gui]
 ```
 
-> Il comando `pip install .` usa il `pyproject.toml` del progetto per installare automaticamente dipendenze e entry point CLI.
+> Il comando `pip install .` installa la sola CLI (dipendenze minime).
+> Usa `pip install .[gui]` per aggiungere PySide6 e l'interfaccia grafica.
 
 ### VS Code – selezione interprete (WSL)
 
@@ -82,10 +85,12 @@ pip install .
 
 ```bash
 source .venv/bin/activate
-patch-gui
+patch-gui  # richiede l'extra 'gui'
 # oppure
 python -m patch_gui
 ```
+
+> Se hai installato solo la CLI (`pip install .`), usa direttamente `patch-gui apply ...`.
 
 ### Modalità CLI (senza GUI)
 
@@ -266,7 +271,7 @@ Aggiungi l’italiano e alcune parole tecniche:
 
 Le versioni correnti verificate per l'applicazione sono:
 
-* `PySide6==6.7.3` (Qt for Python 6.7 LTS, compatibile con Python 3.10–3.12 e con fix di stabilità per i dialoghi su Linux)
+* `PySide6==6.7.3` (extra opzionale `gui`: Qt for Python 6.7 LTS, compatibile con Python 3.10–3.12 e con fix di stabilità per i dialoghi su Linux)
 * `unidiff==0.7.5`
 
 ### Procedura per aggiornare PySide6 / unidiff

--- a/USAGE.md
+++ b/USAGE.md
@@ -15,6 +15,8 @@ Questa guida passo‑passo descrive il workflow tipico per applicare una patch c
    python -m patch_gui
    ```
 
+   > La GUI richiede l'installazione con l'extra `gui` (`pip install .[gui]` oppure `pip install patch-gui[gui]`).
+
 ## Workflow dettagliato
 
 1. **Seleziona la root del progetto**

--- a/patch_gui/__init__.py
+++ b/patch_gui/__init__.py
@@ -1,7 +1,17 @@
 """Patch GUI package initialization."""
 
-from .diff_applier_gui import main
+from __future__ import annotations
 
-__all__ = ["main"]
+from typing import Sequence
+
+__all__ = ["main", "__version__"]
 
 __version__ = "0.1.0"
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point that dispatches to the CLI/GUI implementation."""
+
+    from .diff_applier_gui import main as _main
+
+    return _main(argv)

--- a/patch_gui/i18n.py
+++ b/patch_gui/i18n.py
@@ -10,7 +10,10 @@ import tempfile
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from PySide6 import QtCore
+try:  # pragma: no cover - optional dependency may be missing in CLI-only installations
+    from PySide6 import QtCore
+except ImportError:  # pragma: no cover - executed when PySide6 is not installed
+    QtCore = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +31,11 @@ def install_translators(
     ``None`` the system locale is used. Compiled ``.qm`` files are stored in the Qt cache
     directory (or ``tempfile.gettempdir()`` as a fallback).
     """
+
+    if QtCore is None:
+        raise RuntimeError(
+            "PySide6 non è installato: le traduzioni della GUI richiedono l'extra 'gui'."
+        )
 
     sources = _translation_sources()
     if not sources:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,13 @@ description = "PySide6 desktop application for applying unified diffs interactiv
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
-    "PySide6",
     "charset-normalizer>=3.3.2",
     "unidiff",
+]
+
+[project.optional-dependencies]
+gui = [
+    "PySide6",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- move PySide6 into an optional `gui` extra and lazy-load the GUI entry point
- guard Qt-dependent modules so the CLI works when PySide6 is absent
- document the difference between CLI-only (`pip install .`) and GUI (`pip install .[gui]`) installs

## Testing
- pytest
- python -m compileall patch_gui

------
https://chatgpt.com/codex/tasks/task_e_68c96ac2797c8326967334a21a484c26