### PR TITLE
Handle decode fallback signaling

### DIFF
--- a/patch_gui/app.py
+++ b/patch_gui/app.py
@@ -289,7 +289,14 @@ class PatchApplyWorker(QtCore.QThread):
             fr.skipped_reason = f"Impossibile leggere file: {e}"
             return fr
 
-        content_str, file_encoding = decode_bytes(raw)
+        content_str, file_encoding, used_fallback = decode_bytes(raw)
+        if used_fallback:
+            logger.warning(
+                "Decodifica del file %s eseguita con fallback UTF-8 (encoding %s); "
+                "alcuni caratteri potrebbero essere sostituiti.",
+                path,
+                file_encoding,
+            )
         orig_eol = "\r\n" if "\r\n" in content_str else "\n"
         lines = normalize_newlines(content_str).splitlines(keepends=True)
 
@@ -776,7 +783,14 @@ class MainWindow(QtWidgets.QMainWindow):
             fr.skipped_reason = f"Impossibile leggere file: {e}"
             return fr
 
-        content_str, file_encoding = decode_bytes(raw)
+        content_str, file_encoding, used_fallback = decode_bytes(raw)
+        if used_fallback:
+            logger.warning(
+                "Decodifica del file %s eseguita con fallback UTF-8 (encoding %s); "
+                "alcuni caratteri potrebbero essere sostituiti.",
+                path,
+                file_encoding,
+            )
         orig_eol = "\r\n" if "\r\n" in content_str else "\n"
         lines = normalize_newlines(content_str).splitlines(keepends=True)
 

--- a/patch_gui/utils.py
+++ b/patch_gui/utils.py
@@ -53,15 +53,15 @@ def detect_encoding(data: bytes) -> Tuple[str, bool]:
     return "utf-8", True
 
 
-def decode_bytes(data: bytes) -> Tuple[str, str]:
-    """Decode ``data`` using the detected encoding with UTF-8 fallback."""
+def decode_bytes(data: bytes) -> Tuple[str, str, bool]:
+    """Decode ``data`` and return the text, encoding, and fallback flag."""
 
     encoding, used_fallback = detect_encoding(data)
     if used_fallback:
         text = data.decode(encoding, errors="replace")
     else:
         text = data.decode(encoding)
-    return text, encoding
+    return text, encoding, used_fallback
 
 
 def write_text_preserving_encoding(path: Path, text: str, encoding: str) -> None:


### PR DESCRIPTION
## Summary
- expose a fallback flag from utils.decode_bytes to signal replacements
- warn from CLI and GUI workflows when file decoding resorts to the UTF-8 fallback
- extend utils and CLI tests to exercise the new fallback handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c96eb8f1388326a142d639b279e314