### PR TITLE
Normalize hunk line counts before parsing diffs

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -256,7 +256,7 @@ def test_load_patch_invalid_diff_raises_clierror(tmp_path: Path) -> None:
 
     message = str(excinfo.value)
     assert "Diff non valido" in message
-    assert "@@ -1 +1 @@" in message
+    assert "@@ -1,0 +1,0 @@" in message
 
 
 def test_run_cli_requires_root_argument(


### PR DESCRIPTION
## Summary
- recompute hunk lengths in `preprocess_patch_text` so malformed headers are rewritten before parsing
- normalize output from "*** Begin Patch" blocks with the same logic to keep counts consistent
- extend tests to cover the new normalization and update CLI expectations for parse errors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c98880e34883269fe9b9f0a1aa2121