### PR TITLE
Improve WSL rendering and add detection tests

### DIFF
--- a/patch_gui/platform.py
+++ b/patch_gui/platform.py
@@ -1,0 +1,30 @@
+"""Platform detection helpers used by the GUI."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+__all__ = ["running_under_wsl"]
+
+_WSL_INDICATOR_FILES = (
+    Path("/proc/sys/kernel/osrelease"),
+    Path("/proc/version"),
+)
+
+
+def running_under_wsl() -> bool:
+    """Return ``True`` when executing inside a Windows Subsystem for Linux distro."""
+
+    if os.getenv("WSL_DISTRO_NAME"):
+        return True
+
+    for marker in _WSL_INDICATOR_FILES:
+        try:
+            contents = marker.read_text(encoding="utf-8", errors="ignore").lower()
+        except OSError:
+            continue
+        if "microsoft" in contents or "wsl" in contents:
+            return True
+
+    return False

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -1,0 +1,38 @@
+"""Tests for platform-specific helpers in :mod:`patch_gui.platform`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from patch_gui import platform
+
+
+@pytest.mark.parametrize("env_value", ["Ubuntu", "Debian"])
+def test_running_under_wsl_detects_env(monkeypatch: pytest.MonkeyPatch, env_value: str) -> None:
+    monkeypatch.setenv("WSL_DISTRO_NAME", env_value)
+    assert platform.running_under_wsl()
+    monkeypatch.delenv("WSL_DISTRO_NAME", raising=False)
+
+
+def test_running_under_wsl_detects_kernel_release(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("WSL_DISTRO_NAME", raising=False)
+
+    def fake_read_text(self: Path, *args, **kwargs) -> str:
+        if str(self) == "/proc/sys/kernel/osrelease":
+            return "5.15.133.1-microsoft-standard-WSL2"
+        raise OSError
+
+    monkeypatch.setattr(platform.Path, "read_text", fake_read_text)
+    assert platform.running_under_wsl()
+
+
+def test_running_under_wsl_returns_false_when_no_markers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("WSL_DISTRO_NAME", raising=False)
+
+    def fake_read_text(self: Path, *args, **kwargs) -> str:
+        raise OSError
+
+    monkeypatch.setattr(platform.Path, "read_text", fake_read_text)
+    assert not platform.running_under_wsl()


### PR DESCRIPTION
## Summary
- add a platform helper to detect when the app runs under WSL
- enable Qt High DPI workarounds in the GUI when WSL is detected so the layout is rendered correctly
- cover the new detection logic with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c986f850848326b038d30df866bbe3