### PR TITLE
Enable report generation during CLI dry-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ patch-gui apply --root . --dry-run --log-level debug diff.patch
 patch-gui apply --root . --non-interactive diff.patch
 ```
 
-* `--dry-run` esegue solo l'analisi lasciando i file invariati.
+* `--dry-run` esegue solo l'analisi lasciando i file invariati; i report possono comunque
+  essere generati (a meno di `--no-report`) per consultare l'esito della simulazione.
 * `--threshold` imposta la soglia fuzzy (default 0.85).
 * `--backup` permette di scegliere la cartella base dei backup (di default `<root>/.diff_backups`).
 * `--report-json` / `--report-txt` impostano il percorso dei report generati (default `<backup>/apply-report.json` e `<backup>/apply-report.txt`).
@@ -156,6 +157,8 @@ pytest
 
    * `apply-report.json` (strutturato),
    * `apply-report.txt` (leggibile).
+   Anche in dry‑run, se i report non sono disattivati, questi file vengono creati (senza
+   backup dei file) per documentare la simulazione.
 7. **Ripristino**: pulsante **Ripristina da backup…** → seleziona il timestamp → i file vengono ripristinati.
 Per una guida passo-passo con esempi consulta [USAGE.md](USAGE.md).
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -41,7 +41,9 @@ Questa guida passo‑passo descrive il workflow tipico per applicare una patch c
    - Scegli manualmente il posizionamento corretto.
 7. **Consulta backup e report**
    - Ogni esecuzione reale crea una cartella `./.diff_backups/<timestamp>/` con copie dei file originali.
-   - Nella stessa cartella vengono generati anche `apply-report.json` e `apply-report.txt` con i dettagli dell'operazione.
+   - I report `apply-report.json` e `apply-report.txt` vengono generati nella stessa
+     cartella anche in dry‑run (se non disattivati) per documentare l'esito della
+     simulazione.
 8. **Ripristina da backup**
    - Usa il pulsante **Ripristina da backup…** e seleziona il timestamp desiderato per ripristinare i file originali.
 

--- a/patch_gui/cli.py
+++ b/patch_gui/cli.py
@@ -199,13 +199,12 @@ def apply_patchset(
         fr = _apply_file_patch(root, pf, rel, session, interactive=interactive)
         session.results.append(fr)
 
-    if not dry_run:
-        _write_reports(
-            session,
-            report_json=report_json,
-            report_txt=report_txt,
-            enable_reports=write_report_files,
-        )
+    _write_reports(
+        session,
+        report_json=report_json,
+        report_txt=report_txt,
+        enable_reports=write_report_files,
+    )
 
     return session
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -57,7 +57,14 @@ def test_apply_patchset_dry_run(tmp_path: Path) -> None:
     target = project / "sample.txt"
     assert target.read_text(encoding="utf-8") == "old line\nline2\n"
     assert session.dry_run is True
-    assert not session.backup_dir.exists()
+    assert session.backup_dir.exists()
+    assert session.report_json_path is not None
+    assert session.report_txt_path is not None
+    assert session.report_json_path.exists()
+    assert session.report_txt_path.exists()
+    assert session.report_json_path.parent == session.backup_dir
+    assert session.report_txt_path.parent == session.backup_dir
+    assert not (session.backup_dir / "sample.txt").exists()
     assert len(session.results) == 1
 
     file_result = session.results[0]


### PR DESCRIPTION
## Summary
- allow the CLI apply flow to always write reports so they are available in dry-run sessions
- update README/USAGE to explain that reports can be generated even when running dry-run
- extend CLI tests to cover report files being created with dry_run=True

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c99400e98083268bcadb47c1dd7492