### PR TITLE
Add gettext translation support for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ Per una guida passo-passo con esempi consulta [USAGE.md](USAGE.md).
 ## Internazionalizzazione
 
 Il progetto utilizza file di traduzione Qt (`.ts`) nella cartella `patch_gui/translations/`.
+Le stringhe della CLI e dell'entry point testuale sono gestite con `gettext`
+(`patch_gui/localization.py`) e hanno l'inglese come lingua predefinita.
 Durante la fase di build (`pip install .`, `python -m build`, ecc.) viene eseguito
 automaticamente lo script `python -m build_translations`, che invoca `lrelease` (o
 `pyside6-lrelease`) per generare i corrispondenti file binari `.qm` nella stessa
@@ -186,11 +188,13 @@ l'interfaccia resta in inglese.
    quando si esegue `python -m build`, `pip install .`, ecc.
 
 Per forzare una lingua specifica senza cambiare il locale di sistema puoi impostare la
-variabile d'ambiente `PATCH_GUI_LANG` prima di lanciare l'applicazione, ad esempio:
+variabile d'ambiente `PATCH_GUI_LANG` prima di lanciare applicazione o CLI, ad esempio:
 
 ```bash
 export PATCH_GUI_LANG=it
 patch-gui
+# oppure
+PATCH_GUI_LANG=it patch-gui apply --root . diff.patch
 ```
 
 ---

--- a/patch_gui/cli.py
+++ b/patch_gui/cli.py
@@ -12,6 +12,7 @@ from typing import Any, List, Optional, Sequence, Tuple
 from unidiff import PatchSet
 from unidiff.errors import UnidiffParseError
 
+from .localization import gettext as _
 from .patcher import (
     ApplySession,
     FileResult,
@@ -55,82 +56,74 @@ class CLIError(Exception):
 def build_parser(parser: Optional[argparse.ArgumentParser] = None) -> argparse.ArgumentParser:
     """Create or enrich an ``ArgumentParser`` with CLI options."""
 
+    description = _(
+        "{app_name}: apply a unified diff patch using the same heuristics as the GUI, "
+        "but from the command line."
+    ).format(app_name=APP_NAME)
     if parser is None:
         parser = argparse.ArgumentParser(
             prog="patch-gui apply",
-            description=(
-                f"{APP_NAME}: applica una patch unified diff usando le stesse euristiche "
-                "della GUI, ma dalla riga di comando."
-            ),
+            description=description,
             formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         )
     else:
-        parser.description = (
-            f"{APP_NAME}: applica una patch unified diff usando le stesse euristiche "
-            "della GUI, ma dalla riga di comando."
-        )
+        parser.description = description
         parser.formatter_class = argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument(
         "patch",
-        help="Percorso del file diff da applicare (usa '-' per leggere da STDIN).",
+        help=_("Path to the diff file to apply ('-' reads from STDIN)."),
     )
     parser.add_argument(
         "--root",
         required=True,
-        help="Root del progetto su cui applicare la patch.",
+        help=_("Project root where the patch should be applied."),
     )
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Simula l'applicazione senza modificare i file o creare backup.",
+        help=_("Simulate the execution without modifying files or creating backups."),
     )
     parser.add_argument(
         "--threshold",
         type=_threshold_value,
         default=0.85,
-        help="Soglia (0-1) per il matching fuzzy del contesto.",
+        help=_("Matching threshold (0-1) for fuzzy context alignment."),
     )
     parser.add_argument(
         "--backup",
-        help=(
-            "Cartella base per backup e report; di default viene utilizzato "
-            "'<root>/%s'." % BACKUP_DIR
-        ),
+        help=_("Base directory for backups and reports; defaults to '<root>/%s'.")
+        % BACKUP_DIR,
     )
     parser.add_argument(
         "--report-json",
-        help=(
-            "Percorso del report JSON generato; di default '<backup>/%s'."
-            % REPORT_JSON
-        ),
+        help=_("Path of the generated JSON report; defaults to '<backup>/%s'.")
+        % REPORT_JSON,
     )
     parser.add_argument(
         "--report-txt",
-        help=(
-            "Percorso del report testuale generato; di default '<backup>/%s'."
-            % REPORT_TXT
-        ),
+        help=_("Path of the generated text report; defaults to '<backup>/%s'.")
+        % REPORT_TXT,
     )
     parser.add_argument(
         "--no-report",
         action="store_true",
-        help="Non creare i file di report JSON/TXT.",
+        help=_("Do not create JSON/TXT report files."),
     )
     parser.add_argument(
         "--non-interactive",
         action="store_true",
         help=(
-            "Disabilita le richieste interattive su STDIN e mantiene il "
-            "comportamento precedente in caso di ambiguità."
+            _(
+                "Disable interactive prompts on STDIN and keep the historical behaviour "
+                "when multiple matches exist."
+            )
         ),
     )
     parser.add_argument(
         "--log-level",
         default="warning",
         choices=_LOG_LEVEL_CHOICES,
-        help=(
-            "Livello di logging da inviare su stdout (debug, info, warning, error, critical)."
-        ),
+        help=_("Logging level to emit on stdout (debug, info, warning, error, critical)."),
     )
     return parser
 
@@ -143,27 +136,29 @@ def load_patch(source: str) -> PatchSet:
     else:
         path = Path(source)
         if not path.exists():
-            raise CLIError(f"File diff non trovato: {path}")
+            raise CLIError(_("Diff file not found: {path}").format(path=path))
         try:
             raw = path.read_bytes()
             text, encoding, used_fallback = decode_bytes(raw)
             if used_fallback:
                 logger.warning(
-                    "Decodifica del diff %s eseguita con fallback UTF-8 (encoding %s); "
-                    "il contenuto potrebbe contenere caratteri sostituiti.",
+                    _(
+                        "Decoded diff %s using fallback UTF-8 (original encoding %s); "
+                        "the content may contain substituted characters."
+                    ),
                     path,
                     encoding,
                 )
         except Exception as exc:  # pragma: no cover - extremely rare I/O error types
-            raise CLIError(f"Impossibile leggere {path}: {exc}") from exc
+            raise CLIError(_("Cannot read {path}: {error}").format(path=path, error=exc)) from exc
 
     processed = preprocess_patch_text(text)
     try:
         patch = PatchSet(processed)
     except UnidiffParseError as exc:
-        raise CLIError(f"Diff non valido: {exc}") from exc
+        raise CLIError(_("Invalid diff: {error}").format(error=exc)) from exc
     except Exception as exc:  # pragma: no cover - defensive guard for unexpected errors
-        raise CLIError(f"Errore imprevisto nel parsing del diff: {exc}") from exc
+        raise CLIError(_("Unexpected error while parsing the diff: {error}").format(error=exc)) from exc
     return patch
 
 
@@ -183,7 +178,7 @@ def apply_patchset(
 
     root = project_root.expanduser().resolve()
     if not root.exists() or not root.is_dir():
-        raise CLIError(f"Root del progetto non valida: {project_root}")
+        raise CLIError(_("Invalid project root: {path}").format(path=project_root))
 
     backup_dir = prepare_backup_dir(root, dry_run=dry_run, backup_base=backup_base)
     session = ApplySession(
@@ -218,7 +213,7 @@ def run_cli(argv: Sequence[str] | None = None) -> int:
 
     if args.no_report and (args.report_json or args.report_txt):
         parser.error(
-            "Le opzioni --report-json/--report-txt non sono compatibili con --no-report."
+            _("The --report-json/--report-txt options are incompatible with --no-report.")
         )
 
     level_name = args.log_level.upper()
@@ -247,22 +242,24 @@ def run_cli(argv: Sequence[str] | None = None) -> int:
             write_report_files=not args.no_report,
         )
     except CLIError as exc:
-        parser.exit(1, f"Errore: {exc}\n")
+        parser.exit(1, _("Error: {message}\n").format(message=exc))
 
     print(session.to_txt())
     if args.dry_run:
-        print("\nModalità dry-run: nessun file è stato modificato e non sono stati creati backup.")
+        print(_("\nDry-run mode: no files were modified and no backups were created."))
     else:
-        print(f"\nBackup salvati in: {session.backup_dir}")
+        print(_("\nBackups saved to: {path}").format(path=session.backup_dir))
         if session.report_json_path or session.report_txt_path:
             details = []
             if session.report_json_path:
-                details.append(f"JSON: {session.report_json_path}")
+                details.append(
+                    _("JSON: {path}").format(path=session.report_json_path)
+                )
             if session.report_txt_path:
-                details.append(f"Testo: {session.report_txt_path}")
-            print("Report salvati in: " + ", ".join(details))
+                details.append(_("Text: {path}").format(path=session.report_txt_path))
+            print(_("Reports saved to: {details}").format(details=", ".join(details)))
         else:
-            print("Report disattivati (--no-report)")
+            print(_("Reports disabled (--no-report)"))
 
     return 0 if _session_completed(session) else 1
 
@@ -271,9 +268,11 @@ def _threshold_value(value: str) -> float:
     try:
         parsed = float(value)
     except ValueError as exc:  # pragma: no cover - argparse already handles typical errors
-        raise argparse.ArgumentTypeError("La soglia deve essere un numero decimale.") from exc
+        raise argparse.ArgumentTypeError(_("Threshold must be a decimal number.")) from exc
     if not 0 < parsed <= 1:
-        raise argparse.ArgumentTypeError("La soglia deve essere compresa tra 0 (escluso) e 1 (incluso).")
+        raise argparse.ArgumentTypeError(
+            _("Threshold must be between 0 (exclusive) and 1 (inclusive).")
+        )
     return parsed
 
 
@@ -294,12 +293,12 @@ def _apply_file_patch(
     fr.hunks_total = len(pf)
 
     if getattr(pf, "is_binary_file", False):
-        fr.skipped_reason = "Patch binaria non supportata in modalità CLI"
+        fr.skipped_reason = _("Binary patches are not supported in CLI mode")
         return fr
 
     candidates = find_file_candidates(project_root, rel_path)
     if not candidates:
-        fr.skipped_reason = "File non trovato nella root del progetto"
+        fr.skipped_reason = _("File not found in the project root")
         return fr
     if len(candidates) > 1:
         if not interactive:
@@ -321,14 +320,16 @@ def _apply_file_patch(
     try:
         raw = path.read_bytes()
     except Exception as exc:
-        fr.skipped_reason = f"Impossibile leggere il file: {exc}"
+        fr.skipped_reason = _("Cannot read the file: {error}").format(error=exc)
         return fr
 
     content, file_encoding, used_fallback = decode_bytes(raw)
     if used_fallback:
         logger.warning(
-            "Decodifica del file %s eseguita con fallback UTF-8 (encoding %s); "
-            "alcuni caratteri potrebbero essere sostituiti.",
+            _(
+                "Decoded file %s using fallback UTF-8 (original encoding %s); "
+                "some characters may be substituted."
+            ),
             path,
             file_encoding,
         )
@@ -363,13 +364,12 @@ def _prompt_candidate_selection(project_root: Path, candidates: Sequence[Path]) 
         except ValueError:
             display_paths.append(str(path))
 
-    print("Sono stati trovati più file che corrispondono al percorso della patch:")
+    print(_("Multiple files match the patch path:"))
     for idx, value in enumerate(display_paths, start=1):
         print(f"  {idx}) {value}")
-    prompt = (
-        f"Seleziona il numero del file da utilizzare (1-{len(candidates)}). "
-        "Premi Invio o digita 's' per saltare: "
-    )
+    prompt = _(
+        "Select the number of the file to use (1-{count}). Press Enter or type 's' to skip: "
+    ).format(count=len(candidates))
 
     while True:
         try:
@@ -386,13 +386,13 @@ def _prompt_candidate_selection(project_root: Path, candidates: Sequence[Path]) 
         try:
             index = int(choice)
         except ValueError:
-            print("Input non valido. Inserire un numero o lasciare vuoto per annullare.")
+            print(_("Invalid input. Enter a number or leave empty to cancel."))
             continue
 
         if 1 <= index <= len(candidates):
             return candidates[index - 1]
 
-        print("Numero fuori dall'intervallo indicato. Riprova.")
+        print(_("Number out of range. Try again."))
 
 
 def _ambiguous_paths_message(project_root: Path, candidates: Sequence[Path]) -> str:
@@ -405,12 +405,12 @@ def _ambiguous_paths_message(project_root: Path, candidates: Sequence[Path]) -> 
             shown.append(str(path))
     remaining = len(candidates) - max_display
     if remaining > 0:
-        shown.append(f"… (+{remaining} altri)")
+        shown.append(_("… (+{count} more)").format(count=remaining))
     joined = ", ".join(shown)
-    return (
-        "Più file trovati per il percorso indicato; risolvi l'ambiguità manualmente. "
-      f"Candidati: {joined}"
-  )
+    return _(
+        "Multiple files found for the provided path; resolve the ambiguity manually. "
+        "Candidates: {candidates}"
+    ).format(candidates=joined)
 
 
 def _cli_manual_resolver(
@@ -424,12 +424,14 @@ def _cli_manual_resolver(
     decision.candidates = candidates
     decision.strategy = "ambiguous"
     if reason == "fuzzy":
-        decision.message = (
-            "Più posizioni trovate sopra la soglia. La CLI non può scegliere automaticamente."
+        decision.message = _(
+            "Multiple candidate positions scored above the threshold. The CLI cannot "
+            "choose automatically."
         )
     else:
-        decision.message = (
-            "Solo il contesto coincide. Usa la GUI o regola la soglia per applicare questo hunk."
+        decision.message = _(
+            "Only the context matches. Use the GUI or adjust the threshold to apply this "
+            "hunk."
         )
     return None
 

--- a/patch_gui/diff_applier_gui.py
+++ b/patch_gui/diff_applier_gui.py
@@ -13,6 +13,7 @@ except ImportError:  # pragma: no cover - executed when PySide6 is not installed
 
 from . import cli
 from .i18n import install_translators
+from .localization import gettext as _
 from .utils import APP_NAME
 
 __all__ = ["main"]
@@ -24,9 +25,11 @@ CLI_PREFIXES = ("--threshold=", "--backup=")
 def _tr(text: str) -> str:
     """Translate ``text`` using the ``diff_applier_gui`` context."""
 
-    if QtCore is None:
-        return text
-    return QtCore.QCoreApplication.translate("diff_applier_gui", text)
+    if QtCore is not None:
+        translated = QtCore.QCoreApplication.translate("diff_applier_gui", text)
+        if translated != text:
+            return translated
+    return _(text)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -131,13 +134,13 @@ def _ensure_translator() -> None:
 
 
 def _print_missing_gui_dependency(exc: Optional[Exception] = None) -> None:
-    message = (
-        "PySide6 non è installato. Installa le dipendenze della GUI con "
-        "'pip install .[gui]' oppure includi l'extra 'gui' quando installi il pacchetto."
+    message = _(
+        "PySide6 is not installed. Install the GUI dependencies with 'pip install .[gui]' "
+        "or include the 'gui' extra when installing the package."
     )
     print(message, file=sys.stderr)
     if exc is not None:
-        print(f"Dettagli originali: {exc}", file=sys.stderr)
+        print(_("Original details: {error}").format(error=exc), file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/patch_gui/localization.py
+++ b/patch_gui/localization.py
@@ -1,0 +1,103 @@
+"""Helpers to manage gettext-based translations for CLI components."""
+
+from __future__ import annotations
+
+import gettext as _gettext
+import locale
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from .i18n import LANG_ENV_VAR
+
+DOMAIN = "patch_gui"
+LOCALE_DIR = Path(__file__).resolve().parent / "locale"
+
+_CACHE: Dict[Tuple[str, ...], _gettext.NullTranslations] = {}
+
+__all__ = ["get_translator", "gettext", "ngettext", "clear_translation_cache"]
+
+
+def _system_language() -> str | None:
+    """Return the system locale in ``LL`` or ``LL_CC`` form when available."""
+
+    for getter_name in ("getlocale", "getdefaultlocale"):
+        getter = getattr(locale, getter_name, None)
+        if getter is None:
+            continue
+        try:
+            value = getter()
+        except ValueError:
+            continue
+        if not value:
+            continue
+        lang = value[0] if isinstance(value, (tuple, list)) else value
+        if lang:
+            return str(lang)
+    return None
+
+
+def _append_candidate(value: str | None, seen: set[str], candidates: List[str]) -> None:
+    if not value:
+        return
+    normalized = value.replace("-", "_").strip()
+    if not normalized:
+        return
+    normalized = normalized.lower()
+    if normalized not in seen:
+        candidates.append(normalized)
+        seen.add(normalized)
+    if "_" in normalized:
+        base = normalized.split("_", 1)[0]
+        if base and base not in seen:
+            candidates.append(base)
+            seen.add(base)
+
+
+def _candidate_languages(preferred: str | None) -> List[str]:
+    candidates: List[str] = []
+    seen: set[str] = set()
+
+    _append_candidate(preferred, seen, candidates)
+    _append_candidate(os.getenv(LANG_ENV_VAR), seen, candidates)
+    _append_candidate(_system_language(), seen, candidates)
+
+    if "en" not in seen:
+        candidates.append("en")
+
+    return candidates
+
+
+def get_translator(locale_code: str | None = None) -> _gettext.NullTranslations:
+    """Return (and cache) the gettext translator for ``locale_code``."""
+
+    languages = tuple(_candidate_languages(locale_code))
+    translation = _CACHE.get(languages)
+    if translation is None:
+        translation = _gettext.translation(
+            DOMAIN,
+            localedir=str(LOCALE_DIR),
+            languages=list(languages),
+            fallback=True,
+        )
+        _CACHE[languages] = translation
+    return translation
+
+
+def gettext(message: str, locale_code: str | None = None) -> str:
+    """Translate ``message`` using the active translator."""
+
+    return get_translator(locale_code).gettext(message)
+
+
+def ngettext(singular: str, plural: str, n: int, locale_code: str | None = None) -> str:
+    """Return the singular or plural form based on ``n`` using the active translator."""
+
+    return get_translator(locale_code).ngettext(singular, plural, n)
+
+
+def clear_translation_cache() -> None:
+    """Remove cached gettext translators (useful in tests)."""
+
+    _CACHE.clear()
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -280,7 +280,7 @@ def test_load_patch_missing_file_raises_clierror(tmp_path: Path) -> None:
     with pytest.raises(cli.CLIError) as excinfo:
         cli.load_patch(str(missing))
 
-    assert str(excinfo.value) == f"File diff non trovato: {missing}"
+    assert str(excinfo.value) == f"Diff file not found: {missing}"
 
 
 def test_load_patch_invalid_diff_raises_clierror(tmp_path: Path) -> None:
@@ -298,7 +298,7 @@ def test_load_patch_invalid_diff_raises_clierror(tmp_path: Path) -> None:
         cli.load_patch(str(invalid))
 
     message = str(excinfo.value)
-    assert "Diff non valido" in message
+    assert "Invalid diff" in message
     assert "@@ -1,0 +1,0 @@" in message
 
 
@@ -423,10 +423,10 @@ def test_threshold_value_accepts_valid_inputs(raw: str, expected: float) -> None
 @pytest.mark.parametrize(
     "raw, expected_message",
     [
-        ("0", "La soglia deve essere compresa tra 0 (escluso) e 1 (incluso)."),
-        ("1.1", "La soglia deve essere compresa tra 0 (escluso) e 1 (incluso)."),
-        ("-0.2", "La soglia deve essere compresa tra 0 (escluso) e 1 (incluso)."),
-        ("abc", "La soglia deve essere un numero decimale."),
+        ("0", "Threshold must be between 0 (exclusive) and 1 (inclusive)."),
+        ("1.1", "Threshold must be between 0 (exclusive) and 1 (inclusive)."),
+        ("-0.2", "Threshold must be between 0 (exclusive) and 1 (inclusive)."),
+        ("abc", "Threshold must be a decimal number."),
     ],
 )
 def test_threshold_value_rejects_invalid_inputs(raw: str, expected_message: str) -> None:

--- a/tests/test_localization.py
+++ b/tests/test_localization.py
@@ -1,0 +1,29 @@
+import gettext
+
+import pytest
+
+from patch_gui import localization
+
+
+def test_get_translator_uses_english_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    localization.clear_translation_cache()
+
+    captured: dict[str, object] = {}
+
+    def fake_translation(domain: str, localedir: str, languages: list[str], fallback: bool):
+        captured["domain"] = domain
+        captured["localedir"] = localedir
+        captured["languages"] = list(languages)
+        captured["fallback"] = fallback
+        return gettext.NullTranslations()
+
+    monkeypatch.setattr(localization._gettext, "translation", fake_translation)
+
+    translator = localization.get_translator()
+    assert captured
+    assert captured["domain"] == localization.DOMAIN
+    assert captured["fallback"] is True
+    assert "en" in captured["languages"]
+    assert translator.gettext("Sample message") == "Sample message"
+
+    localization.clear_translation_cache()


### PR DESCRIPTION
## Summary
- add a gettext-based localization helper and use it in the CLI and dispatcher entry point with English defaults
- translate CLI messages to English and route user-facing text through the new translator
- document how to select the language and cover the default translation with automated tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9940b2fd483269011afe11756e819