### PR TITLE
Refactor file patch workflow into shared helper

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ import pytest
 from unidiff import PatchSet
 
 from patch_gui import cli
+import patch_gui.patcher as patcher
 import patch_gui.utils as utils
 from patch_gui.utils import BACKUP_DIR, REPORT_JSON, REPORT_TXT
 
@@ -364,7 +365,7 @@ def test_apply_patchset_logs_warning_on_fallback(
         text, encoding, _ = real_decode(data)
         return text, encoding, True
 
-    monkeypatch.setattr(cli, "decode_bytes", fake_decode)
+    monkeypatch.setattr(patcher, "decode_bytes", fake_decode)
 
     with caplog.at_level(logging.WARNING):
         session = cli.apply_patchset(


### PR DESCRIPTION
## Summary
- add an apply_patch_to_file helper that centralises reading, backups and writes when applying hunks
- switch the CLI and GUI flows to rely on the shared helper and propagate PatchApplicationError skips
- extend CLI and patcher tests to exercise the new helper and ensure fallback logging continues to work

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c99411958483269b92babeeb68b8c7