### PR TITLE
Add GUI progress bar with worker percentage tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ Per eseguire la suite automatizzata del progetto:
 pytest
 ```
 
+### Verifica manuale barra di avanzamento
+
+1. Avvia la GUI (`patch-gui`) e analizza un diff contenente più file/hunk.
+2. Premi **Applica patch** (anche in modalità Dry‑run): la barra di stato mostrerà la **QProgressBar** con la percentuale di avanzamento.
+3. Attendi il completamento per verificare che la barra raggiunga il 100 % e scompaia automaticamente.
+
 ---
 
 ## Guida all'uso
@@ -150,6 +156,7 @@ pytest
 5. **Applica realmente**: disabilita Dry‑run → **Applica patch**.
 
    * Matching: **esatto** → **fuzzy**.
+   * Durante l'esecuzione la barra di stato mostra una barra di avanzamento con la percentuale di file/hunk elaborati.
    * **Ambiguità**: se esistono più posizioni plausibili, si apre un dialog con **tutte** le opzioni e contesto; scegli manualmente.
    * File mancanti: se non trovati sotto la root, **vengono saltati** (come da preferenza).
 6. **Backup & Report**: ogni run reale crea `./.diff_backups/<timestamp>/` con copie originali e genera:

--- a/USAGE.md
+++ b/USAGE.md
@@ -36,6 +36,7 @@ Questa guida passo‑passo descrive il workflow tipico per applicare una patch c
 5. **Applica la patch**
    - Con Dry‑run attivo clicca **Applica patch** per vedere l'anteprima dei risultati.
    - Quando sei soddisfatto, disattiva Dry‑run e premi nuovamente **Applica patch** per modificare realmente i file.
+   - Durante l'esecuzione la barra di stato mostra una barra di avanzamento numerica con la percentuale di file/hunk già elaborati.
 6. **Gestisci eventuali ambiguità**
    - Se la patch può essere applicata in più punti plausibili, viene aperto un dialog che mostra tutte le opzioni con il relativo contesto.
    - Scegli manualmente il posizionamento corretto.

--- a/patch_gui/app.py
+++ b/patch_gui/app.py
@@ -259,7 +259,7 @@ class FileChoiceDialog(QtWidgets.QDialog):
 
 
 class PatchApplyWorker(QtCore.QThread):
-    progress = QtCore.Signal(str)
+    progress = QtCore.Signal(str, int)
     finished = QtCore.Signal(object)
     error = QtCore.Signal(str)
     request_file_choice = QtCore.Signal(str, object)
@@ -273,6 +273,27 @@ class PatchApplyWorker(QtCore.QThread):
         self._file_choice_result: Optional[Path] = None
         self._hunk_choice_event = threading.Event()
         self._hunk_choice_result: Optional[int] = None
+        self._total_files = len(self.patch)
+        self._total_hunks = sum(len(pf) for pf in self.patch)
+        self._total_units = sum(max(len(pf), 1) for pf in self.patch)
+        self._processed_files = 0
+        self._processed_hunks = 0
+        self._processed_units = 0
+
+    def _calculate_percent(self) -> int:
+        if self._total_units:
+            ratio = self._processed_units / self._total_units
+        elif self._processed_files:
+            ratio = 1.0
+        else:
+            ratio = 0.0
+        percent = int(round(ratio * 100))
+        return max(0, min(percent, 100))
+
+    def _emit_progress(self, message: str, *, percent: Optional[int] = None) -> None:
+        resolved_percent = self._calculate_percent() if percent is None else percent
+        resolved_percent = max(0, min(int(resolved_percent), 100))
+        self.progress.emit(message, resolved_percent)
 
     def provide_file_choice(self, choice: Optional[Path]) -> None:
         self._file_choice_result = choice
@@ -284,12 +305,28 @@ class PatchApplyWorker(QtCore.QThread):
 
     def run(self) -> None:  # pragma: no cover - thread orchestration
         try:
+            if not self._total_units:
+                self._emit_progress("Nessun file o hunk da applicare.", percent=100)
             for pf in self.patch:
                 rel = pf.path or pf.target_file or pf.source_file or ""
-                self.progress.emit(f"Applicazione file: {rel}")
                 file_result = self.apply_file_patch(pf, rel)
                 self.session.results.append(file_result)
-            self.progress.emit("Applicazione diff completata.")
+                self._processed_files += 1
+                hunks_in_file = len(pf)
+                self._processed_hunks += hunks_in_file
+                self._processed_units += max(hunks_in_file, 1)
+                hunks_total = self._total_hunks
+                if hunks_total:
+                    hunks_msg = f"hunk {self._processed_hunks}/{hunks_total}"
+                else:
+                    hunks_msg = "hunk 0/0"
+                files_total = self._total_files or 0
+                message = (
+                    f"Applicazione file: {rel} "
+                    f"(file {self._processed_files}/{files_total}, {hunks_msg})"
+                )
+                self._emit_progress(message)
+            self._emit_progress("Applicazione diff completata.", percent=100)
             self.finished.emit(self.session)
         except Exception as exc:  # pragma: no cover - defensive guard
             logger.exception("Errore durante l'applicazione della patch: %s", exc)
@@ -502,7 +539,15 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self._setup_gui_logging()
 
-        self.statusBar().showMessage("Pronto")
+        status_bar = self.statusBar()
+        status_bar.showMessage("Pronto")
+        self.progress_bar = QtWidgets.QProgressBar()
+        self.progress_bar.setRange(0, 100)
+        self.progress_bar.setValue(0)
+        self.progress_bar.setFormat("%p%")
+        self.progress_bar.setTextVisible(True)
+        self.progress_bar.setVisible(False)
+        status_bar.addPermanentWidget(self.progress_bar)
 
         self.restore_last_project_root()
 
@@ -671,15 +716,22 @@ class MainWindow(QtWidgets.QMainWindow):
         worker.error.connect(worker.deleteLater)
         self._current_worker = worker
         self._set_busy(True)
+        self.progress_bar.setValue(0)
+        self.progress_bar.setVisible(True)
+        self.progress_bar.setToolTip("")
         self.statusBar().showMessage("Applicazione diff in corso…")
         worker.start()
 
-    @QtCore.Slot(str)
-    def _on_worker_progress(self, message: str) -> None:  # pragma: no cover - UI feedback
+    @QtCore.Slot(str, int)
+    def _on_worker_progress(self, message: str, percent: int) -> None:  # pragma: no cover - UI feedback
         if not message:
             return
         self.log.appendPlainText(message)
         self.statusBar().showMessage(message[:100])
+        clamped = max(0, min(int(percent), 100))
+        self.progress_bar.setVisible(True)
+        self.progress_bar.setValue(clamped)
+        self.progress_bar.setToolTip(message)
 
     @QtCore.Slot(object)
     def _on_worker_finished(self, session: ApplySession) -> None:  # pragma: no cover - UI feedback
@@ -687,6 +739,9 @@ class MainWindow(QtWidgets.QMainWindow):
         write_reports(session)
         logger.info("\n=== RISULTATO ===\n%s", session.to_txt())
         self._set_busy(False)
+        self.progress_bar.setValue(100)
+        self.progress_bar.setVisible(False)
+        self.progress_bar.setToolTip("")
         QtWidgets.QMessageBox.information(
             self,
             "Completato",
@@ -699,6 +754,8 @@ class MainWindow(QtWidgets.QMainWindow):
         logger.error("Errore durante l'applicazione della patch: %s", message)
         self._set_busy(False)
         self._current_worker = None
+        self.progress_bar.setVisible(False)
+        self.progress_bar.setToolTip("")
         QtWidgets.QMessageBox.critical(self, "Errore", message)
         self.statusBar().showMessage("Errore durante l'applicazione della patch")
 


### PR DESCRIPTION
## Summary
- compute processed file/hunk percentage in PatchApplyWorker and emit it with progress updates
- expose the new progress values in the main window via a status-bar QProgressBar
- document manual verification steps for the progress bar in the README/USAGE guides

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c99432d0f08326b7f008f36208b307