### PR TITLE
Add type hints to GUI modules

### DIFF
--- a/patch_gui/diff_applier_gui.py
+++ b/patch_gui/diff_applier_gui.py
@@ -4,21 +4,26 @@ from __future__ import annotations
 
 import argparse
 import sys
-from typing import Optional, Sequence
+from typing import Any, Sequence, TYPE_CHECKING, cast
 
 try:  # pragma: no cover - optional dependency may be missing in CLI-only installations
-    from PySide6 import QtCore
+    from PySide6 import QtCore as _QtCore
 except ImportError:  # pragma: no cover - executed when PySide6 is not installed
-    QtCore = None  # type: ignore[assignment]
+    _QtCore = cast(Any, None)
+
+if TYPE_CHECKING:
+    from PySide6.QtCore import QCoreApplication
+
+QtCore: Any = cast(Any, _QtCore)
 
 from . import cli
 from .i18n import install_translators
 from .utils import APP_NAME
 
-__all__ = ["main"]
+__all__: list[str] = ["main"]
 
-CLI_FLAGS = {"--dry-run", "--threshold", "--backup", "--root"}
-CLI_PREFIXES = ("--threshold=", "--backup=")
+CLI_FLAGS: set[str] = {"--dry-run", "--threshold", "--backup", "--root"}
+CLI_PREFIXES: tuple[str, ...] = ("--threshold=", "--backup=")
 
 
 def _tr(text: str) -> str:
@@ -26,7 +31,7 @@ def _tr(text: str) -> str:
 
     if QtCore is None:
         return text
-    return QtCore.QCoreApplication.translate("diff_applier_gui", text)
+    return cast(str, QtCore.QCoreApplication.translate("diff_applier_gui", text))
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -116,7 +121,7 @@ def _ensure_translator() -> None:
     if QtCore is None:
         return
 
-    app = QtCore.QCoreApplication.instance()
+    app: QCoreApplication | None = QtCore.QCoreApplication.instance()
     if app is None:
         # ``[]`` so the temporary instance does not inherit CLI arguments that belong to
         # ``argparse``; this avoids warnings from Qt about unknown options.
@@ -130,7 +135,7 @@ def _ensure_translator() -> None:
     setattr(app, "_installed_translators", translators)
 
 
-def _print_missing_gui_dependency(exc: Optional[Exception] = None) -> None:
+def _print_missing_gui_dependency(exc: Exception | None = None) -> None:
     message = (
         "PySide6 non è installato. Installa le dipendenze della GUI con "
         "'pip install .[gui]' oppure includi l'extra 'gui' quando installi il pacchetto."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,10 +48,3 @@ module = [
 ]
 ignore_missing_imports = true
 
-[[tool.mypy.overrides]]
-module = [
-    "patch_gui.app",
-    "patch_gui.diff_applier_gui",
-]
-allow_untyped_defs = true
-allow_untyped_calls = true

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -19,20 +19,20 @@ def test_running_under_wsl_detects_env(monkeypatch: pytest.MonkeyPatch, env_valu
 def test_running_under_wsl_detects_kernel_release(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("WSL_DISTRO_NAME", raising=False)
 
-    def fake_read_text(self: Path, *args, **kwargs) -> str:
+    def fake_read_text(self: Path, *args: object, **kwargs: object) -> str:
         if str(self) == "/proc/sys/kernel/osrelease":
             return "5.15.133.1-microsoft-standard-WSL2"
         raise OSError
 
-    monkeypatch.setattr(platform.Path, "read_text", fake_read_text)
+    monkeypatch.setattr(Path, "read_text", fake_read_text)
     assert platform.running_under_wsl()
 
 
 def test_running_under_wsl_returns_false_when_no_markers(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("WSL_DISTRO_NAME", raising=False)
 
-    def fake_read_text(self: Path, *args, **kwargs) -> str:
+    def fake_read_text(self: Path, *args: object, **kwargs: object) -> str:
         raise OSError
 
-    monkeypatch.setattr(platform.Path, "read_text", fake_read_text)
+    monkeypatch.setattr(Path, "read_text", fake_read_text)
     assert not platform.running_under_wsl()


### PR DESCRIPTION
## Summary
- remove the mypy override and add explicit typing across the GUI application module
- update the GUI/CLI dispatcher to load Qt bindings safely when absent and return typed translations
- adjust the platform tests to use typed helpers that satisfy strict mypy checks

## Testing
- mypy
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c994548c3083269c2b562a81573ace