### PR TITLE
Add parametrized tests for diff applier GUI entry point

### DIFF
--- a/tests/test_diff_applier_gui.py
+++ b/tests/test_diff_applier_gui.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pytest
+
+from patch_gui import diff_applier_gui
+
+
+GUI_RESULT = 42
+CLI_RESULT = 17
+
+
+@pytest.mark.parametrize(
+    "argv, expected_calls, expected_result",
+    [
+        ([], [("gui", ())], GUI_RESULT),
+        (["apply", "patch.diff"], [("cli", ["patch.diff"])], CLI_RESULT),
+        (["--root", ".", "patch.diff"], [("cli", ["--root", ".", "patch.diff"])], CLI_RESULT),
+    ],
+)
+def test_main_dispatches_between_gui_and_cli(
+    argv: list[str], expected_calls: list[tuple[str, object]], expected_result: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[tuple[str, object]] = []
+
+    def fake_run_cli(args: list[str]) -> int:
+        calls.append(("cli", args))
+        return CLI_RESULT
+
+    def fake_launch_gui() -> int:
+        calls.append(("gui", ()))
+        return GUI_RESULT
+
+    monkeypatch.setattr(diff_applier_gui.cli, "run_cli", fake_run_cli)
+    monkeypatch.setattr(diff_applier_gui, "_launch_gui", fake_launch_gui)
+
+    result = diff_applier_gui.main(argv)
+
+    assert result == expected_result
+    assert calls == expected_calls


### PR DESCRIPTION
## Summary
- add parametrized tests covering how `diff_applier_gui.main` dispatches between the CLI and GUI paths

## Testing
- pytest tests/test_diff_applier_gui.py

------
https://chatgpt.com/codex/tasks/task_e_68c9946c1aa083269f8d3d257b82bb90