### PR TITLE
Save reports in dedicated subfolder

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ patch-gui apply --root . --non-interactive diff.patch
 * `--dry-run` esegue solo l'analisi lasciando i file invariati.
 * `--threshold` imposta la soglia fuzzy (default 0.85).
 * `--backup` permette di scegliere la cartella base dei backup (di default `<root>/.diff_backups`).
-* `--report-json` / `--report-txt` impostano il percorso dei report generati (default `<backup>/apply-report.json` e `<backup>/apply-report.txt`).
+* `--report-json` / `--report-txt` impostano il percorso dei report generati (default `<backup>/reports/apply-report.json` e `<backup>/reports/apply-report.txt`).
 * `--no-report` disattiva entrambi i file di report.
 * `--non-interactive` mantiene il comportamento storico: se il percorso è ambiguo il file viene saltato senza richiesta su STDIN.
 * `--log-level` imposta la verbosità del logger su stdout (`debug`, `info`, `warning`, `error`, `critical`; default `warning`).
@@ -271,8 +271,9 @@ Aggiungi l’italiano e alcune parole tecniche:
 .diff_backups/
   2025YYYYMMDD-HHMMSS/
     path/del/file/originale.ext
-    apply-report.json
-    apply-report.txt
+    reports/
+      apply-report.json
+      apply-report.txt
 ```
 
 ---

--- a/USAGE.md
+++ b/USAGE.md
@@ -41,7 +41,7 @@ Questa guida passo‑passo descrive il workflow tipico per applicare una patch c
    - Scegli manualmente il posizionamento corretto.
 7. **Consulta backup e report**
    - Ogni esecuzione reale crea una cartella `./.diff_backups/<timestamp>/` con copie dei file originali.
-   - Nella stessa cartella vengono generati anche `apply-report.json` e `apply-report.txt` con i dettagli dell'operazione.
+   - Nella sottocartella `reports/` vengono generati anche `apply-report.json` e `apply-report.txt` con i dettagli dell'operazione.
 8. **Ripristina da backup**
    - Usa il pulsante **Ripristina da backup…** e seleziona il timestamp desiderato per ripristinare i file originali.
 

--- a/patch_gui/cli.py
+++ b/patch_gui/cli.py
@@ -27,6 +27,7 @@ from .utils import (
     APP_NAME,
     BACKUP_DIR,
     REPORT_JSON,
+    REPORT_SUBDIR,
     REPORT_TXT,
     decode_bytes,
     normalize_newlines,
@@ -100,15 +101,15 @@ def build_parser(parser: Optional[argparse.ArgumentParser] = None) -> argparse.A
     parser.add_argument(
         "--report-json",
         help=(
-            "Percorso del report JSON generato; di default '<backup>/%s'."
-            % REPORT_JSON
+            "Percorso del report JSON generato; di default '<backup>/%s/%s'."
+            % (REPORT_SUBDIR, REPORT_JSON)
         ),
     )
     parser.add_argument(
         "--report-txt",
         help=(
-            "Percorso del report testuale generato; di default '<backup>/%s'."
-            % REPORT_TXT
+            "Percorso del report testuale generato; di default '<backup>/%s/%s'."
+            % (REPORT_SUBDIR, REPORT_TXT)
         ),
     )
     parser.add_argument(

--- a/patch_gui/patcher.py
+++ b/patch_gui/patcher.py
@@ -9,7 +9,7 @@ from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Callable, Iterable, Iterator, List, Optional, Protocol, Sequence, Tuple
 
-from .utils import APP_NAME, BACKUP_DIR, REPORT_JSON, REPORT_TXT
+from .utils import APP_NAME, BACKUP_DIR, REPORT_JSON, REPORT_SUBDIR, REPORT_TXT
 
 
 class _HunkLine(Protocol):
@@ -387,7 +387,9 @@ def write_reports(
     txt_target: Optional[Path] = None
 
     if write_json:
-        json_target = _resolve_path(json_path, session.backup_dir / REPORT_JSON)
+        json_target = _resolve_path(
+            json_path, session.backup_dir / REPORT_SUBDIR / REPORT_JSON
+        )
         json_target.parent.mkdir(parents=True, exist_ok=True)
         json_target.write_text(
             json.dumps(session.to_json(), ensure_ascii=False, indent=2),
@@ -395,7 +397,9 @@ def write_reports(
         )
 
     if write_txt:
-        txt_target = _resolve_path(txt_path, session.backup_dir / REPORT_TXT)
+        txt_target = _resolve_path(
+            txt_path, session.backup_dir / REPORT_SUBDIR / REPORT_TXT
+        )
         txt_target.parent.mkdir(parents=True, exist_ok=True)
         txt_target.write_text(session.to_txt(), encoding="utf-8")
 

--- a/patch_gui/utils.py
+++ b/patch_gui/utils.py
@@ -25,6 +25,7 @@ else:
 
 APP_NAME = "Patch GUI – Diff Applier"
 BACKUP_DIR = ".diff_backups"
+REPORT_SUBDIR = "reports"
 REPORT_JSON = "apply-report.json"
 REPORT_TXT = "apply-report.txt"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,7 @@ from unidiff import PatchSet
 
 from patch_gui import cli
 import patch_gui.utils as utils
-from patch_gui.utils import BACKUP_DIR, REPORT_JSON, REPORT_TXT
+from patch_gui.utils import BACKUP_DIR, REPORT_JSON, REPORT_SUBDIR, REPORT_TXT
 
 SAMPLE_DIFF = """--- a/sample.txt
 +++ b/sample.txt
@@ -85,8 +85,9 @@ def test_apply_patchset_real_run_creates_backup(tmp_path: Path) -> None:
     assert backup_copy.exists()
     assert backup_copy.read_text(encoding="utf-8") == original
 
-    json_report = session.backup_dir / REPORT_JSON
-    text_report = session.backup_dir / REPORT_TXT
+    report_dir = session.backup_dir / REPORT_SUBDIR
+    json_report = report_dir / REPORT_JSON
+    text_report = report_dir / REPORT_TXT
     assert json_report.exists()
     assert text_report.exists()
     assert session.report_json_path == json_report
@@ -118,8 +119,9 @@ def test_apply_patchset_custom_report_paths(tmp_path: Path) -> None:
     assert session.report_txt_path == txt_dest
     assert json_dest.exists()
     assert txt_dest.exists()
-    assert not (session.backup_dir / REPORT_JSON).exists()
-    assert not (session.backup_dir / REPORT_TXT).exists()
+    report_dir = session.backup_dir / REPORT_SUBDIR
+    assert not (report_dir / REPORT_JSON).exists()
+    assert not (report_dir / REPORT_TXT).exists()
 
     data = json.loads(json_dest.read_text(encoding="utf-8"))
     assert data["files"][0]["hunks_applied"] == 1
@@ -138,8 +140,9 @@ def test_apply_patchset_no_report(tmp_path: Path) -> None:
 
     assert session.report_json_path is None
     assert session.report_txt_path is None
-    assert not (session.backup_dir / REPORT_JSON).exists()
-    assert not (session.backup_dir / REPORT_TXT).exists()
+    report_dir = session.backup_dir / REPORT_SUBDIR
+    assert not (report_dir / REPORT_JSON).exists()
+    assert not (report_dir / REPORT_TXT).exists()
 
 
 def test_apply_patchset_reports_ambiguous_candidates(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- default report generation now targets the `<backup>/reports/` subdirectory via the new `REPORT_SUBDIR` constant
- adjust CLI messaging, documentation, and tests to reflect the new default location for JSON/TXT reports

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c994c57fcc832693782ba5d4c05069