### PR TITLE
Change default backup location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 *.pyc
 .fetch-client
 *.qm
+patch_gui/.diff_backups/

--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ patch-gui apply --root . --non-interactive diff.patch
 * `--dry-run` esegue solo l'analisi lasciando i file invariati; i report possono comunque
   essere generati (a meno di `--no-report`) per consultare l'esito della simulazione.
 * `--threshold` imposta la soglia fuzzy (default 0.85).
-* `--backup` permette di scegliere la cartella base dei backup (di default `<root>/.diff_backups`).
+* `--backup` permette di scegliere la cartella base dei backup (di default `patch_gui/.diff_backups`
+  nella stessa directory dove risiede lo script Python).
 * `--report-json` / `--report-txt` impostano il percorso dei report generati (default `<backup>/apply-report.json` e `<backup>/apply-report.txt`).
 * `--no-report` disattiva entrambi i file di report.
 * `--non-interactive` mantiene il comportamento storico: se il percorso è ambiguo il file viene saltato senza richiesta su STDIN.
@@ -280,6 +281,9 @@ Aggiungi l’italiano e alcune parole tecniche:
 ---
 
 ## Struttura backup/report
+
+Per impostazione predefinita i backup (e quindi i report) vengono creati nella cartella
+`patch_gui/.diff_backups/` accanto allo script Python del tool.
 
 ```
 .diff_backups/

--- a/patch_gui/app.py
+++ b/patch_gui/app.py
@@ -33,8 +33,8 @@ from .patcher import (
 )
 from .utils import (
     APP_NAME,
-    BACKUP_DIR,
     decode_bytes,
+    default_backup_base,
     display_path,
     display_relative_path,
     normalize_newlines,
@@ -978,7 +978,7 @@ class MainWindow(QtWidgets.QMainWindow):
         if not self.project_root:
             QtWidgets.QMessageBox.warning(self, "Root mancante", "Seleziona la root del progetto.")
             return
-        base = self.project_root / BACKUP_DIR
+        base = default_backup_base()
         if not base.exists():
             QtWidgets.QMessageBox.information(self, "Nessun backup", "Cartella backup non trovata.")
             return

--- a/patch_gui/cli.py
+++ b/patch_gui/cli.py
@@ -27,10 +27,11 @@ from .patcher import (
 )
 from .utils import (
     APP_NAME,
-    BACKUP_DIR,
     REPORT_JSON,
     REPORT_TXT,
     decode_bytes,
+    default_backup_base,
+    display_path,
     display_relative_path,
     normalize_newlines,
     preprocess_patch_text,
@@ -91,10 +92,12 @@ def build_parser(parser: Optional[argparse.ArgumentParser] = None) -> argparse.A
         default=0.85,
         help=_("Matching threshold (0-1) for fuzzy context alignment."),
     )
+    default_backup = display_path(default_backup_base())
     parser.add_argument(
         "--backup",
-        help=_("Base directory for backups and reports; defaults to '<root>/%s'.")
-        % BACKUP_DIR,
+        help=_("Base directory for backups and reports; defaults to '{path}'.").format(
+            path=default_backup
+        ),
     )
     parser.add_argument(
         "--report-json",

--- a/patch_gui/patcher.py
+++ b/patch_gui/patcher.py
@@ -9,7 +9,7 @@ from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Callable, Iterable, Iterator, List, Optional, Protocol, Sequence, Tuple
 
-from .utils import APP_NAME, BACKUP_DIR, REPORT_JSON, REPORT_TXT
+from .utils import APP_NAME, REPORT_JSON, REPORT_TXT, default_backup_base
 
 
 DEFAULT_EXCLUDE_DIRS: tuple[str, ...] = (".git", ".venv", "node_modules")
@@ -417,9 +417,12 @@ def prepare_backup_dir(
 ) -> Path:
     """Return a timestamped backup directory for the session."""
 
-    base = backup_base.expanduser() if backup_base is not None else project_root / BACKUP_DIR
-    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    base = backup_base.expanduser() if backup_base is not None else default_backup_base()
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
     backup_dir = base / timestamp
+    while backup_dir.exists():
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
+        backup_dir = base / timestamp
     if not dry_run:
         backup_dir.mkdir(parents=True, exist_ok=True)
     return backup_dir

--- a/patch_gui/utils.py
+++ b/patch_gui/utils.py
@@ -29,6 +29,12 @@ REPORT_JSON = "apply-report.json"
 REPORT_TXT = "apply-report.txt"
 
 
+def default_backup_base() -> Path:
+    """Return the default directory where backups and reports are stored."""
+
+    return Path(__file__).resolve().parent / BACKUP_DIR
+
+
 def display_path(path: Path) -> str:
     """Return ``path`` using forward slashes, regardless of the platform."""
 
@@ -257,6 +263,7 @@ __all__ = [
     "BACKUP_DIR",
     "REPORT_JSON",
     "REPORT_TXT",
+    "default_backup_base",
     "decode_bytes",
     "detect_encoding",
     "display_path",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,6 +86,7 @@ def test_apply_patchset_real_run_creates_backup(tmp_path: Path) -> None:
 
     assert target.read_text(encoding="utf-8") == "new line\nline2\n"
     assert session.backup_dir.parent.name == BACKUP_DIR
+    assert session.backup_dir.parent == utils.default_backup_base()
     assert session.backup_dir.exists()
 
     backup_copy = session.backup_dir / "sample.txt"


### PR DESCRIPTION
## Summary
- store backups and reports under the tool's installation directory by default and expose a `default_backup_base()` helper
- update CLI/UI messaging, documentation, and tests to reflect the new default directory and ignore generated folders
- ensure new backup directories are unique by including microseconds in the timestamp to avoid collisions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ca5ed98f4c83268f84afaf7a1d6a0c