### PR TITLE
Add pre-commit configuration and documentation updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.7
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+      - id: ruff-format
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.9.0
+    hooks:
+      - id: mypy
+        additional_dependencies:
+          - types-requests
+  - repo: https://github.com/pre-commit/mirrors-pytest
+    rev: v8.1.1
+    hooks:
+      - id: pytest
+        args: ["-q"]

--- a/README.md
+++ b/README.md
@@ -129,6 +129,21 @@ Per eseguire la suite automatizzata del progetto:
 pytest
 ```
 
+## Pre-commit
+
+Per abilitare i controlli automatici (formattazione, lint, type checking e test rapidi):
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Puoi eseguire manualmente tutti gli hook con:
+
+```bash
+pre-commit run --all-files
+```
+
 ### Verifica manuale barra di avanzamento
 
 1. Avvia la GUI (`patch-gui`) e analizza un diff contenente più file/hunk.


### PR DESCRIPTION
## Summary
- add a pre-commit configuration with Black, Ruff, MyPy, and pytest hooks
- document how to install and run the pre-commit hooks in the README

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ca616593b48326ab73e0d985c2b4e1