### PR TITLE
Add pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        args: ["--target-version=py39"]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.7
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
+        additional_dependencies: []
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest --maxfail=1 --quiet
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/README.md
+++ b/README.md
@@ -129,6 +129,17 @@ Per eseguire la suite automatizzata del progetto:
 pytest
 ```
 
+### Pre-commit hooks
+
+Per allineare automaticamente formattazione, linting e test rapidi prima dei commit:
+
+```bash
+pip install pre-commit
+pre-commit install
+# (facoltativo) esegui subito tutti gli hook sul repository
+pre-commit run --all-files
+```
+
 ### Verifica manuale barra di avanzamento
 
 1. Avvia la GUI (`patch-gui`) e analizza un diff contenente più file/hunk.


### PR DESCRIPTION
## Summary
- add a pre-commit configuration bundling black, ruff, mypy, and a quick pytest run
- document how to install and execute the pre-commit hooks in the README

## Testing
- pytest --maxfail=1 --quiet
- mypy

------
https://chatgpt.com/codex/tasks/task_e_68ca61934da883269953c05930273cca