### PR TITLE
Ignore diff backup directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 *.pyc
 .fetch-client
 *.qm
+.diff_backups/


### PR DESCRIPTION
## Summary
- add the diff backup output directory to .gitignore to avoid committing generated backups

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca630d6acc8326abaf6a4251413ae2