### PR TITLE
Adjust default report output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 *.pyc
 .fetch-client
 *.qm
+patch_gui/reports/

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ patch-gui apply --root . --non-interactive diff.patch
   essere generati (a meno di `--no-report`) per consultare l'esito della simulazione.
 * `--threshold` imposta la soglia fuzzy (default 0.85).
 * `--backup` permette di scegliere la cartella base dei backup (di default `<root>/.diff_backups`).
-* `--report-json` / `--report-txt` impostano il percorso dei report generati (default `<backup>/apply-report.json` e `<backup>/apply-report.txt`).
+* `--report-json` / `--report-txt` impostano il percorso dei report generati (default `<app>/reports/<timestamp>/apply-report.json` e `<app>/reports/<timestamp>/apply-report.txt`, con `<app>` pari alla cartella dell'applicazione).
 * `--no-report` disattiva entrambi i file di report.
 * `--non-interactive` mantiene il comportamento storico: se il percorso è ambiguo il file viene saltato senza richiesta su STDIN.
 * `--log-level` imposta la verbosità del logger su stdout (`debug`, `info`, `warning`, `error`, `critical`; default `warning`).
@@ -301,6 +301,8 @@ Aggiungi l’italiano e alcune parole tecniche:
 .diff_backups/
   2025YYYYMMDD-HHMMSS/
     path/del/file/originale.ext
+patch_gui/reports/
+  2025YYYYMMDD-HHMMSS-fff/
     apply-report.json
     apply-report.txt
 ```

--- a/USAGE.md
+++ b/USAGE.md
@@ -42,9 +42,8 @@ Questa guida passo‑passo descrive il workflow tipico per applicare una patch c
    - Scegli manualmente il posizionamento corretto.
 7. **Consulta backup e report**
    - Ogni esecuzione reale crea una cartella `./.diff_backups/<timestamp>/` con copie dei file originali.
-   - I report `apply-report.json` e `apply-report.txt` vengono generati nella stessa
-     cartella anche in dry‑run (se non disattivati) per documentare l'esito della
-     simulazione.
+   - I report `apply-report.json` e `apply-report.txt` vengono salvati in `patch_gui/reports/<timestamp>/`
+     accanto all'applicazione (anche in dry‑run, se non disattivati) per documentare l'esito della simulazione.
 8. **Ripristina da backup**
    - Usa il pulsante **Ripristina da backup…** e seleziona il timestamp desiderato per ripristinare i file originali.
 

--- a/patch_gui/patcher.py
+++ b/patch_gui/patcher.py
@@ -10,7 +10,13 @@ from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Callable, Iterable, Iterator, List, Optional, Protocol, Sequence, Tuple
 
-from .utils import APP_NAME, BACKUP_DIR, REPORT_JSON, REPORT_TXT
+from .utils import (
+    APP_NAME,
+    BACKUP_DIR,
+    REPORT_JSON,
+    REPORT_TXT,
+    default_session_report_dir,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -492,6 +498,7 @@ def write_reports(
         return None, None
 
     session.backup_dir.mkdir(parents=True, exist_ok=True)
+    default_report_dir = default_session_report_dir(session.started_at)
 
     def _resolve_path(raw: Path | str | None, default: Path) -> Path:
         if raw is None:
@@ -507,7 +514,7 @@ def write_reports(
     txt_target: Optional[Path] = None
 
     if write_json:
-        json_target = _resolve_path(json_path, session.backup_dir / REPORT_JSON)
+        json_target = _resolve_path(json_path, default_report_dir / REPORT_JSON)
         json_target.parent.mkdir(parents=True, exist_ok=True)
         json_target.write_text(
             json.dumps(session.to_json(), ensure_ascii=False, indent=2),
@@ -515,7 +522,7 @@ def write_reports(
         )
 
     if write_txt:
-        txt_target = _resolve_path(txt_path, session.backup_dir / REPORT_TXT)
+        txt_target = _resolve_path(txt_path, default_report_dir / REPORT_TXT)
         txt_target.parent.mkdir(parents=True, exist_ok=True)
         txt_target.write_text(session.to_txt(), encoding="utf-8")
 

--- a/patch_gui/utils.py
+++ b/patch_gui/utils.py
@@ -1,6 +1,7 @@
 """Utility helpers for patch processing and shared configuration."""
 from __future__ import annotations
 
+from datetime import datetime
 import re
 from pathlib import Path
 from typing import Callable, List, Optional, Protocol, Tuple, cast
@@ -27,6 +28,10 @@ APP_NAME = "Patch GUI – Diff Applier"
 BACKUP_DIR = ".diff_backups"
 REPORT_JSON = "apply-report.json"
 REPORT_TXT = "apply-report.txt"
+
+_PACKAGE_ROOT = Path(__file__).resolve().parent
+REPORTS_SUBDIR = "reports"
+DEFAULT_REPORTS_DIR = _PACKAGE_ROOT / REPORTS_SUBDIR
 
 
 def display_path(path: Path) -> str:
@@ -252,11 +257,29 @@ def preprocess_patch_text(raw_text: str) -> str:
     return _normalize_hunk_line_counts("".join(parts))
 
 
+def format_session_timestamp(started_at: float) -> str:
+    """Return a filesystem-friendly timestamp label for ``started_at``."""
+
+    dt = datetime.fromtimestamp(started_at)
+    fractional = int((started_at - int(started_at)) * 1000)
+    return f"{dt.strftime('%Y%m%d-%H%M%S')}-{fractional:03d}"
+
+
+def default_session_report_dir(started_at: float) -> Path:
+    """Return the default directory where reports for ``started_at`` should be saved."""
+
+    return DEFAULT_REPORTS_DIR / format_session_timestamp(started_at)
+
+
 __all__ = [
     "APP_NAME",
     "BACKUP_DIR",
     "REPORT_JSON",
     "REPORT_TXT",
+    "DEFAULT_REPORTS_DIR",
+    "REPORTS_SUBDIR",
+    "default_session_report_dir",
+    "format_session_timestamp",
     "decode_bytes",
     "detect_encoding",
     "display_path",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -64,8 +64,10 @@ def test_apply_patchset_dry_run(tmp_path: Path) -> None:
     assert session.report_txt_path is not None
     assert session.report_json_path.exists()
     assert session.report_txt_path.exists()
-    assert session.report_json_path.parent == session.backup_dir
-    assert session.report_txt_path.parent == session.backup_dir
+    expected_dir = utils.default_session_report_dir(session.started_at)
+    assert expected_dir.parent == utils.DEFAULT_REPORTS_DIR
+    assert session.report_json_path.parent == expected_dir
+    assert session.report_txt_path.parent == expected_dir
     assert not (session.backup_dir / "sample.txt").exists()
     assert len(session.results) == 1
 
@@ -94,8 +96,10 @@ def test_apply_patchset_real_run_creates_backup(tmp_path: Path) -> None:
     assert backup_copy.exists()
     assert backup_copy.read_text(encoding="utf-8") == original
 
-    json_report = session.backup_dir / REPORT_JSON
-    text_report = session.backup_dir / REPORT_TXT
+    report_dir = utils.default_session_report_dir(session.started_at)
+    assert report_dir.parent == utils.DEFAULT_REPORTS_DIR
+    json_report = report_dir / REPORT_JSON
+    text_report = report_dir / REPORT_TXT
     assert json_report.exists()
     assert text_report.exists()
     assert session.report_json_path == json_report
@@ -127,8 +131,9 @@ def test_apply_patchset_custom_report_paths(tmp_path: Path) -> None:
     assert session.report_txt_path == txt_dest
     assert json_dest.exists()
     assert txt_dest.exists()
-    assert not (session.backup_dir / REPORT_JSON).exists()
-    assert not (session.backup_dir / REPORT_TXT).exists()
+    default_dir = utils.default_session_report_dir(session.started_at)
+    assert not (default_dir / REPORT_JSON).exists()
+    assert not (default_dir / REPORT_TXT).exists()
 
     data = json.loads(json_dest.read_text(encoding="utf-8"))
     assert data["files"][0]["hunks_applied"] == 1
@@ -147,8 +152,9 @@ def test_apply_patchset_no_report(tmp_path: Path) -> None:
 
     assert session.report_json_path is None
     assert session.report_txt_path is None
-    assert not (session.backup_dir / REPORT_JSON).exists()
-    assert not (session.backup_dir / REPORT_TXT).exists()
+    default_dir = utils.default_session_report_dir(session.started_at)
+    assert not (default_dir / REPORT_JSON).exists()
+    assert not (default_dir / REPORT_TXT).exists()
 
 
 def test_apply_patchset_reports_ambiguous_candidates(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- write CLI reports to a timestamped subdirectory under the application's `reports` folder by default
- expose helpers for computing the default report path and update tests/docs accordingly
- ignore generated report directories in version control

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca6359e8588326aebf7c74f3d16ade