### PR TITLE
Refine hunk body scanning and add edge case coverage

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -94,6 +94,53 @@ def test_preprocess_patch_text_repairs_incorrect_hunk_lengths() -> None:
     assert hunk.target_length == 2
 
 
+def test_preprocess_patch_text_handles_no_newline_marker() -> None:
+    raw = (
+        "--- a/sample.txt\n"
+        "+++ b/sample.txt\n"
+        "@@ -1 +1 @@\n"
+        "-old\n"
+        "\\ No newline at end of file\n"
+        "+new\n"
+        "\\ No newline at end of file\n"
+    )
+
+    processed = preprocess_patch_text(raw)
+    patch = PatchSet(processed)
+
+    header_line = processed.splitlines()[2]
+    assert header_line == "@@ -1 +1 @@"
+    hunk = patch[0][0]
+    assert hunk.source_length == 1
+    assert hunk.target_length == 1
+
+
+def test_preprocess_patch_text_allows_empty_hunks() -> None:
+    raw = (
+        "--- a/empty.txt\n"
+        "+++ b/empty.txt\n"
+        "@@ -0,0 +0,0 @@\n"
+    )
+
+    processed = preprocess_patch_text(raw)
+    assert processed == raw
+
+
+def test_preprocess_patch_text_infers_missing_counts() -> None:
+    raw = (
+        "--- a/config.ini\n"
+        "+++ b/config.ini\n"
+        "@@ -1 +1 @@\n"
+        "-foo=1\n"
+        "-bar=2\n"
+        "+foo=10\n"
+        "+bar=20\n"
+    )
+
+    processed = preprocess_patch_text(raw)
+    header_line = processed.splitlines()[2]
+    assert header_line == "@@ -1,2 +1,2 @@"
+
 def test_display_path_normalizes_windows_separators() -> None:
     win_path = Path(PureWindowsPath(r"C:\\projects\\demo\\file.txt"))
     assert display_path(win_path) == "C:/projects/demo/file.txt"


### PR DESCRIPTION
## Summary
- extract the hunk body scanning logic into dedicated helpers for better readability
- document the preprocessing behaviours handled by `preprocess_patch_text`
- add regression tests covering newline markers, empty hunks, and missing count headers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca67fc35408326bb1458c71209fed1