### PR TITLE
Adjust default report storage directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ patch-gui apply --root . --non-interactive diff.patch
   essere generati (a meno di `--no-report`) per consultare l'esito della simulazione.
 * `--threshold` imposta la soglia fuzzy (default 0.85).
 * `--backup` permette di scegliere la cartella base dei backup (di default `<root>/.diff_backups`).
-* `--report-json` / `--report-txt` impostano il percorso dei report generati (default `<app>/reports/<timestamp>/apply-report.json` e `<app>/reports/<timestamp>/apply-report.txt`, con `<app>` pari alla cartella dell'applicazione).
+* `--report-json` / `--report-txt` impostano il percorso dei report generati (default `<app>/reports/results/<timestamp>/apply-report.json` e `<app>/reports/results/<timestamp>/apply-report.txt`, con `<app>` pari alla cartella dell'applicazione).
 * `--no-report` disattiva entrambi i file di report.
 * `--non-interactive` mantiene il comportamento storico: se il percorso è ambiguo il file viene saltato senza richiesta su STDIN.
 * `--log-level` imposta la verbosità del logger su stdout (`debug`, `info`, `warning`, `error`, `critical`; default `warning`).
@@ -302,9 +302,10 @@ Aggiungi l’italiano e alcune parole tecniche:
   2025YYYYMMDD-HHMMSS/
     path/del/file/originale.ext
 patch_gui/reports/
-  2025YYYYMMDD-HHMMSS-fff/
-    apply-report.json
-    apply-report.txt
+  results/
+    2025YYYYMMDD-HHMMSS-fff/
+      apply-report.json
+      apply-report.txt
 ```
 
 ---

--- a/USAGE.md
+++ b/USAGE.md
@@ -42,7 +42,7 @@ Questa guida passo‑passo descrive il workflow tipico per applicare una patch c
    - Scegli manualmente il posizionamento corretto.
 7. **Consulta backup e report**
    - Ogni esecuzione reale crea una cartella `./.diff_backups/<timestamp>/` con copie dei file originali.
-   - I report `apply-report.json` e `apply-report.txt` vengono salvati in `patch_gui/reports/<timestamp>/`
+   - I report `apply-report.json` e `apply-report.txt` vengono salvati in `patch_gui/reports/results/<timestamp>/`
      accanto all'applicazione (anche in dry‑run, se non disattivati) per documentare l'esito della simulazione.
 8. **Ripristina da backup**
    - Usa il pulsante **Ripristina da backup…** e seleziona il timestamp desiderato per ripristinare i file originali.

--- a/patch_gui/utils.py
+++ b/patch_gui/utils.py
@@ -31,7 +31,8 @@ REPORT_TXT = "apply-report.txt"
 
 _PACKAGE_ROOT = Path(__file__).resolve().parent
 REPORTS_SUBDIR = "reports"
-DEFAULT_REPORTS_DIR = _PACKAGE_ROOT / REPORTS_SUBDIR
+REPORT_RESULTS_SUBDIR = "results"
+DEFAULT_REPORTS_DIR = _PACKAGE_ROOT / REPORTS_SUBDIR / REPORT_RESULTS_SUBDIR
 
 
 def display_path(path: Path) -> str:
@@ -277,6 +278,7 @@ __all__ = [
     "REPORT_JSON",
     "REPORT_TXT",
     "DEFAULT_REPORTS_DIR",
+    "REPORT_RESULTS_SUBDIR",
     "REPORTS_SUBDIR",
     "default_session_report_dir",
     "format_session_timestamp",


### PR DESCRIPTION
## Summary
- route the default report path to the `reports/results` subfolder next to the Python package
- update the README and usage guide to document the new default location

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca67f1a4e48326bf84bc2ac3eec377