### PR TITLE
Add CLI encoding option for patch loading

### DIFF
--- a/patch_gui/cli.py
+++ b/patch_gui/cli.py
@@ -43,7 +43,7 @@ def run_cli(argv: Sequence[str] | None = None) -> int:
     )
 
     try:
-        patch = load_patch(args.patch)
+        patch = load_patch(args.patch, encoding=args.encoding)
         raw_backup = args.backup
         backup_base = (
             Path(raw_backup).expanduser() if isinstance(raw_backup, str) and raw_backup else None

--- a/patch_gui/parser.py
+++ b/patch_gui/parser.py
@@ -71,6 +71,13 @@ def build_parser(parser: Optional[argparse.ArgumentParser] = None) -> argparse.A
         % REPORT_TXT,
     )
     parser.add_argument(
+        "--encoding",
+        default=None,
+        help=_(
+            "Explicit encoding to decode the diff file; defaults to automatic detection."
+        ),
+    )
+    parser.add_argument(
         "--no-report",
         action="store_true",
         help=_("Do not create JSON/TXT report files."),


### PR DESCRIPTION
## Summary
- add a --encoding CLI option to let users choose how diffs are decoded
- update patch loading to honor the explicit encoding while retaining the automatic fallback warnings
- expand CLI tests to exercise the new option and the fallback decoding path

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca68047f30832698b40215eca96576