### PR TITLE
Add CLI encoding option and support in load_patch

### DIFF
--- a/patch_gui/cli.py
+++ b/patch_gui/cli.py
@@ -45,7 +45,7 @@ def run_cli(argv: Sequence[str] | None = None) -> int:
     )
 
     try:
-        patch = load_patch(args.patch)
+        patch = load_patch(args.patch, encoding=args.encoding)
         raw_backup = args.backup
         backup_base = (
             Path(raw_backup).expanduser()

--- a/patch_gui/parser.py
+++ b/patch_gui/parser.py
@@ -88,6 +88,11 @@ def build_parser(
         ),
     )
     parser.add_argument(
+        "--encoding",
+        default=None,
+        help=_("Explicit encoding to use when reading the diff (default: auto-detect)."),
+    )
+    parser.add_argument(
         "--log-level",
         default="warning",
         choices=_LOG_LEVEL_CHOICES,


### PR DESCRIPTION
## Summary
- add a --encoding option to the CLI parser and pass it through run_cli
- extend load_patch to honor an explicit encoding or fall back to auto detection
- cover explicit encoding handling and default behaviour with new CLI tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca6a56ce6c8326bf477f26aab29b51