### PR TITLE
Add diff-based file type inspection

### DIFF
--- a/patch_gui/app.py
+++ b/patch_gui/app.py
@@ -17,6 +17,7 @@ from logging.handlers import RotatingFileHandler
 from PySide6 import QtCore, QtGui, QtWidgets
 from unidiff import PatchSet
 
+from .filetypes import inspect_file_type
 from .i18n import install_translators
 from .logo_widgets import LogoWidget, WordmarkWidget, create_logo_pixmap
 from .platform import running_under_wsl
@@ -433,6 +434,12 @@ class PatchApplyWorker(QtCore.QThread):
 
     def apply_file_patch(self, pf: "PatchedFile", rel_path: str) -> FileResult:
         fr = FileResult(file_path=Path(), relative_to_root=rel_path)
+        file_type_info = inspect_file_type(pf)
+        fr.file_type = file_type_info.name
+
+        if file_type_info.name == "binary":
+            fr.skipped_reason = "Patch binaria non supportata nella GUI"
+            return fr
 
         candidates = find_file_candidates(
             self.session.project_root,

--- a/patch_gui/executor.py
+++ b/patch_gui/executor.py
@@ -11,6 +11,7 @@ from typing import Any, List, Optional, Sequence, Tuple
 from unidiff import PatchSet
 from unidiff.errors import UnidiffParseError
 
+from .filetypes import inspect_file_type
 from .localization import gettext as _
 from .patcher import (
     ApplySession,
@@ -157,7 +158,10 @@ def _apply_file_patch(
     fr = FileResult(file_path=Path(), relative_to_root=rel_path)
     fr.hunks_total = len(pf)
 
-    if getattr(pf, "is_binary_file", False):
+    file_type_info = inspect_file_type(pf)
+    fr.file_type = file_type_info.name
+
+    if file_type_info.name == "binary":
         fr.skipped_reason = _("Binary patches are not supported in CLI mode")
         return fr
 

--- a/patch_gui/filetypes.py
+++ b/patch_gui/filetypes.py
@@ -1,0 +1,192 @@
+"""Utilities to inspect file types from unified diff metadata."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Protocol
+
+
+class _HunkLine(Protocol):
+    line_type: str
+    value: str
+
+
+class _PatchLike(Protocol):
+    path: str | None
+    source_file: str | None
+    target_file: str | None
+    is_binary_file: bool | None
+
+    def __iter__(self) -> Iterable[_HunkLine]: ...
+
+
+@dataclass(frozen=True)
+class FileTypeInfo:
+    """Describe the detected file type and preservation requirements."""
+
+    name: str
+    preserve_trailing_whitespace: bool = True
+    preserve_final_newline: bool = True
+
+
+_EXTENSION_MAP = {
+    ".py": "python",
+    ".pyi": "python",
+    ".pyw": "python",
+    ".json": "json",
+    ".yaml": "yaml",
+    ".yml": "yaml",
+    ".toml": "toml",
+    ".ini": "ini",
+    ".cfg": "ini",
+    ".conf": "ini",
+    ".md": "markdown",
+    ".rst": "rst",
+    ".html": "html",
+    ".htm": "html",
+    ".xml": "xml",
+    ".xaml": "xml",
+    ".xhtml": "xml",
+    ".css": "css",
+    ".scss": "scss",
+    ".less": "less",
+    ".js": "javascript",
+    ".ts": "typescript",
+    ".tsx": "tsx",
+    ".jsx": "jsx",
+    ".java": "java",
+    ".kt": "kotlin",
+    ".swift": "swift",
+    ".c": "c",
+    ".h": "c",
+    ".cpp": "cpp",
+    ".cc": "cpp",
+    ".cxx": "cpp",
+    ".hpp": "cpp",
+    ".hh": "cpp",
+    ".m": "objective-c",
+    ".mm": "objective-c++",
+    ".cs": "csharp",
+    ".go": "go",
+    ".rs": "rust",
+    ".php": "php",
+    ".rb": "ruby",
+    ".sh": "shell",
+    ".bash": "shell",
+    ".zsh": "shell",
+    ".fish": "shell",
+    ".ps1": "powershell",
+    ".bat": "batch",
+    ".cmd": "batch",
+    ".scala": "scala",
+    ".sql": "sql",
+    ".po": "po",
+    ".csv": "csv",
+    ".tex": "tex",
+    ".txt": "text",
+}
+
+_SPECIAL_FILENAMES = {
+    "makefile": "makefile",
+    "dockerfile": "dockerfile",
+    "cmakelists.txt": "cmake",
+    "gemfile": "ruby",
+    "rakefile": "ruby",
+    "podfile": "ruby",
+    "package.json": "json",
+    "composer.json": "json",
+    "poetry.lock": "toml",
+    "pyproject.toml": "toml",
+    "requirements.txt": "text",
+    "license": "text",
+    "readme": "markdown",
+}
+
+
+def inspect_file_type(patched_file: _PatchLike) -> FileTypeInfo:
+    """Return a :class:`FileTypeInfo` describing ``patched_file``."""
+
+    if getattr(patched_file, "is_binary_file", False):
+        return FileTypeInfo(name="binary", preserve_trailing_whitespace=False)
+
+    path = (
+        (patched_file.path or patched_file.target_file or patched_file.source_file)
+        or ""
+    ).strip()
+    lowered = path.lower()
+
+    if lowered:
+        suffix = Path(lowered).suffix
+        if suffix in _EXTENSION_MAP:
+            return FileTypeInfo(name=_EXTENSION_MAP[suffix])
+
+        name = Path(lowered).name
+        if name in _SPECIAL_FILENAMES:
+            return FileTypeInfo(name=_SPECIAL_FILENAMES[name])
+
+        stem = Path(lowered).stem
+        if stem in _SPECIAL_FILENAMES:
+            return FileTypeInfo(name=_SPECIAL_FILENAMES[stem])
+
+    sample = _sample_content(patched_file)
+    inferred = _infer_from_sample(sample)
+    return FileTypeInfo(name=inferred)
+
+
+def _sample_content(patched_file: _PatchLike, limit: int = 20) -> list[str]:
+    lines: list[str] = []
+    try:
+        iterator = iter(patched_file)
+    except TypeError:
+        return lines
+
+    for hunk in iterator:
+        try:
+            hunk_iter = iter(hunk)
+        except TypeError:
+            continue
+        for line in hunk_iter:
+            if getattr(line, "line_type", "") not in {" ", "+", "-"}:
+                continue
+            value = getattr(line, "value", "")
+            stripped = value.strip()
+            if stripped:
+                lines.append(stripped)
+            if len(lines) >= limit:
+                return lines
+    return lines
+
+
+def _infer_from_sample(sample: list[str]) -> str:
+    if not sample:
+        return "text"
+
+    joined = "\n".join(sample)
+    first = sample[0]
+
+    if first.startswith("{") or first.startswith("["):
+        return "json"
+    if first.startswith("<?xml") or first.startswith("<"):
+        return "xml"
+    if any(line.startswith("---") and ":" in line for line in sample):
+        return "yaml"
+    if any(line.startswith("#include") for line in sample):
+        return "c"
+    if any(line.startswith("def ") or line.startswith("class ") for line in sample):
+        return "python"
+    if any(line.startswith("function ") or line.startswith("const ") for line in sample):
+        return "javascript"
+    if any(line.startswith("SELECT ") or line.startswith("CREATE TABLE") for line in sample):
+        return "sql"
+
+    if joined.count("=") >= 2 and all("=" in line for line in sample[:5]):
+        return "ini"
+    if any(line.startswith("#!/") for line in sample):
+        return "shell"
+
+    return "text"
+
+
+__all__ = ["FileTypeInfo", "inspect_file_type"]
+

--- a/patch_gui/patcher.py
+++ b/patch_gui/patcher.py
@@ -82,6 +82,7 @@ class FileResult:
 
     file_path: Path
     relative_to_root: str
+    file_type: str = "text"
     hunks_applied: int = 0
     hunks_total: int = 0
     decisions: List[HunkDecision] = field(default_factory=list)
@@ -125,6 +126,7 @@ class ApplySession:
                 {
                     "file": fr.relative_to_root,
                     "abs_path": str(fr.file_path),
+                    "file_type": fr.file_type,
                     "hunks_applied": fr.hunks_applied,
                     "hunks_total": fr.hunks_total,
                     "skipped_reason": fr.skipped_reason,
@@ -159,6 +161,7 @@ class ApplySession:
             lines.append(f"File: {fr.relative_to_root}")
             if fr.skipped_reason:
                 lines.append(f"  SKIPPED: {fr.skipped_reason}")
+            lines.append(f"  Tipo file: {fr.file_type}")
             lines.append(f"  Hunks: {fr.hunks_applied}/{fr.hunks_total}")
             for d in fr.decisions:
                 lines.append(f"    Hunk {d.hunk_header} -> {d.strategy}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,6 +74,7 @@ def test_apply_patchset_dry_run(tmp_path: Path) -> None:
     file_result = session.results[0]
     assert file_result.skipped_reason is None
     assert file_result.hunks_applied == file_result.hunks_total == 1
+    assert file_result.file_type == "text"
 
 
 def test_apply_patchset_real_run_creates_backup(tmp_path: Path) -> None:
@@ -107,9 +108,11 @@ def test_apply_patchset_real_run_creates_backup(tmp_path: Path) -> None:
 
     data = json.loads(json_report.read_text(encoding="utf-8"))
     assert data["files"][0]["hunks_applied"] == 1
+    assert data["files"][0]["file_type"] == "text"
 
     file_result = session.results[0]
     assert file_result.hunks_applied == file_result.hunks_total == 1
+    assert file_result.file_type == "text"
 
 
 def test_apply_patchset_custom_report_paths(tmp_path: Path) -> None:
@@ -137,6 +140,7 @@ def test_apply_patchset_custom_report_paths(tmp_path: Path) -> None:
 
     data = json.loads(json_dest.read_text(encoding="utf-8"))
     assert data["files"][0]["hunks_applied"] == 1
+    assert data["files"][0]["file_type"] == "text"
 
 
 def test_apply_patchset_no_report(tmp_path: Path) -> None:
@@ -182,6 +186,7 @@ def test_apply_patchset_reports_ambiguous_candidates(tmp_path: Path) -> None:
     assert file_result.skipped_reason is not None
     assert "src/app/sample.txt" in file_result.skipped_reason
     assert "tests/app/sample.txt" in file_result.skipped_reason
+    assert file_result.file_type == "text"
 
     report = session.to_txt()
     assert "src/app/sample.txt" in report
@@ -216,6 +221,7 @@ def test_apply_patchset_interactive_candidate_selection(
     assert file_result.skipped_reason is None
     assert file_result.relative_to_root == "tests/app/sample.txt"
     assert file_result.hunks_applied == file_result.hunks_total == 1
+    assert file_result.file_type == "text"
 
 
 def test_apply_patchset_skipped_reason_lists_candidates(tmp_path: Path) -> None:

--- a/tests/test_filetypes.py
+++ b/tests/test_filetypes.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from unidiff import PatchSet
+
+from patch_gui.filetypes import FileTypeInfo, inspect_file_type
+
+
+def _first_file(diff: str):
+    patch = PatchSet(diff)
+    return patch[0]
+
+
+def test_inspect_python_file() -> None:
+    diff = """--- a/app.py\n+++ b/app.py\n@@ -1 +1 @@\n-print('hi')\n+print('hello')\n"""
+    info = inspect_file_type(_first_file(diff))
+    assert info == FileTypeInfo(name="python")
+
+
+def test_inspect_json_file() -> None:
+    diff = """--- a/config.json\n+++ b/config.json\n@@ -1 +1 @@\n-{"a": 1}\n+{"a": 2}\n"""
+    info = inspect_file_type(_first_file(diff))
+    assert info.name == "json"
+    assert info.preserve_final_newline is True
+
+
+def test_inspect_special_filename() -> None:
+    diff = """--- a/Makefile\n+++ b/Makefile\n@@ -1 +1 @@\n-old:\n+new:\n"""
+    info = inspect_file_type(_first_file(diff))
+    assert info.name == "makefile"
+
+
+def test_inspect_binary_stub() -> None:
+    class DummyBinary:
+        path = "image.png"
+        source_file = "image.png"
+        target_file = "image.png"
+        is_binary_file = True
+
+        def __iter__(self):  # pragma: no cover - protocol requirement
+            return iter(())
+
+    info = inspect_file_type(DummyBinary())
+    assert info.name == "binary"
+    assert info.preserve_trailing_whitespace is False
+
+
+def test_inspect_unknown_defaults_to_text() -> None:
+    diff = """--- a/notes\n+++ b/notes\n@@ -1 +1 @@\n-old\n+new\n"""
+    info = inspect_file_type(_first_file(diff))
+    assert info.name == "text"


### PR DESCRIPTION
## Summary
- add a diff-driven file type inspector with extension and content heuristics
- capture the inferred file type in CLI/GUI workflows and expose it in reports
- cover the new behaviour with dedicated tests and updated CLI expectations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca6ac82378832694c836041f22faf9