### PR TITLE
Fix setuptools cmdclass identifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,8 @@ include = ["patch_gui*"]
 "patch_gui" = ["translations/*.ts", "translations/*.qm"]
 
 [tool.setuptools.cmdclass]
-build_py = "build_translations:BuildPy"
-sdist = "build_translations:SDist"
+build_py = "build_translations.BuildPy"
+sdist = "build_translations.SDist"
 
 [tool.mypy]
 python_version = "3.9"


### PR DESCRIPTION
## Summary
- update the setuptools cmdclass entries in `pyproject.toml` to use python qualified identifiers

## Testing
- `.venv/bin/pip install -e ".[gui]"` *(fails: cannot download setuptools because outbound network access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68ca6c9f26888326ace7a2133f7d6dae