### PR TITLE
Migliora il report del dry run

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,6 +74,9 @@ def test_apply_patchset_dry_run(tmp_path: Path) -> None:
     file_result = session.results[0]
     assert file_result.skipped_reason is None
     assert file_result.hunks_applied == file_result.hunks_total == 1
+    report_txt = session.to_txt()
+    assert "Hunk che verrebbero applicati: 1/1" in report_txt
+    assert "Modalità dry-run" in report_txt
 
 
 def test_apply_patchset_real_run_creates_backup(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- arricchisci il report testuale della sessione con un riepilogo che esplicita i conteggi simulati in dry-run
- evidenzia all'interno delle sezioni per file quando i numeri si riferiscono a una simulazione
- aggiorna i test CLI per coprire il nuovo contenuto del report

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca6c507bd08326aa51ceef504f328d