### PR TITLE
Handle triple-asterisk diff headers

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,6 +44,25 @@ def test_preprocess_patch_text_normalizes_newlines_without_wrapper() -> None:
     assert preprocess_patch_text(raw) == expected
 
 
+def test_preprocess_patch_text_rewrites_triple_asterisk_headers() -> None:
+    raw = (
+        "*** a/js/eventReview.js\n"
+        "--- b/js/eventReview.js\n"
+        "@@ -1 +1 @@\n"
+        "-old\n"
+        "+new\n"
+    )
+
+    processed = preprocess_patch_text(raw)
+    lines = processed.splitlines()
+    assert lines[0] == "--- a/js/eventReview.js"
+    assert lines[1] == "+++ b/js/eventReview.js"
+
+    patch = PatchSet(processed)
+    assert len(patch) == 1
+    assert patch[0].path == "js/eventReview.js"
+
+
 def test_preprocess_patch_text_extracts_begin_patch_blocks() -> None:
     raw = (
         "*** Begin Patch\n"


### PR DESCRIPTION
## Summary
- normalize clipboard diffs that use `***`/`---` headers into standard unified diff headers
- run this normalization before parsing so files are detected correctly
- add regression test covering triple-asterisk header input

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca6d62be788326ba16b7e7fa4fdeeb