### PR TITLE
Add dry-run summary to text reports

### DIFF
--- a/patch_gui/patcher.py
+++ b/patch_gui/patcher.py
@@ -156,6 +156,19 @@ class ApplySession:
         lines.append(f"Soglia fuzzy: {self.threshold}")
         excludes = ", ".join(self.exclude_dirs) if self.exclude_dirs else "(nessuna)"
         lines.append(f"Directory escluse: {excludes}")
+        total_files = len(self.results)
+        total_hunks = sum(fr.hunks_total for fr in self.results)
+        applied_hunks = sum(fr.hunks_applied for fr in self.results)
+        changed_files = sum(1 for fr in self.results if fr.hunks_applied > 0)
+        skipped_files = sum(1 for fr in self.results if fr.skipped_reason)
+        lines.append("Riepilogo:")
+        lines.append(f"  File analizzati: {total_files}")
+        lines.append(f"  File con modifiche: {changed_files}")
+        if skipped_files:
+            lines.append(f"  File saltati: {skipped_files}")
+        lines.append(f"  Hunks applicati: {applied_hunks}/{total_hunks}")
+        if not total_hunks or not applied_hunks:
+            lines.append("  Nessuna modifica è stata applicata ai file.")
         lines.append("")
         for fr in self.results:
             lines.append(f"File: {fr.relative_to_root}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import logging
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -75,6 +76,21 @@ def test_apply_patchset_dry_run(tmp_path: Path) -> None:
     assert file_result.skipped_reason is None
     assert file_result.hunks_applied == file_result.hunks_total == 1
     assert file_result.file_type == "text"
+
+
+def test_session_report_highlights_missing_changes(tmp_path: Path) -> None:
+    session = executor.ApplySession(
+        project_root=tmp_path,
+        backup_dir=tmp_path / "backup",
+        dry_run=True,
+        threshold=0.85,
+        started_at=time.time(),
+    )
+
+    report = session.to_txt()
+
+    assert "Riepilogo:" in report
+    assert "Nessuna modifica è stata applicata ai file." in report
 
 
 def test_apply_patchset_real_run_creates_backup(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a summary block to CLI text reports with the number of processed files and hunks
- highlight when no changes were applied so dry-run sessions are easier to interpret
- cover the new behaviour with a regression test for empty sessions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca6d822c2c83269bd388067e4b05ca