### PR TITLE
Ensure setuptools cmdclass identifiers are dotted

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ include = ["patch_gui*"]
 "patch_gui" = ["translations/*.ts", "translations/*.qm"]
 
 [tool.setuptools.cmdclass]
+# NOTE: setuptools>=75 validates that cmdclass targets are python-qualified
+# identifiers (``module.Class``). Keep these dotted to avoid install-time
+# failures when ``validate-pyproject`` checks the configuration.
 build_py = "build_translations.BuildPy"
 sdist = "build_translations.SDist"
 

--- a/tests/test_pyproject_configuration.py
+++ b/tests/test_pyproject_configuration.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_cmdclass_uses_python_qualified_identifiers() -> None:
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    text = pyproject.read_text(encoding="utf-8")
+
+    assert "build_translations:BuildPy" not in text
+    assert "build_translations:SDist" not in text


### PR DESCRIPTION
## Summary
- document in `pyproject.toml` that the custom setuptools commands must be referenced with dotted names to satisfy validate-pyproject
- add a regression test that ensures the cmdclass configuration never reintroduces the old colon-separated identifiers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca6f68354c832686f5997733dd0705