### PR TITLE
docs: inline apt install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,7 @@ Pacchetti utili in ambiente Ubuntu/WSL:
 
 ```bash
 sudo apt update
-sudo apt install -y python3 python3-venv python3-pip git \
-                    libgl1 libegl1 libxkbcommon-x11-0 libxcb-xinerama0
+sudo apt install -y python3 python3-venv python3-pip git libgl1 libegl1 libxkbcommon-x11-0 libxcb-xinerama0
 ```
 
 > ℹ️ I pacchetti `libgl1`/`libegl1`/`libxkbcommon-x11-0`/`libxcb-xinerama0` risolvono i tipici errori Qt (`plugin xcb`) in WSL.


### PR DESCRIPTION
## Summary
- inline the Ubuntu dependency installation command to avoid shell misinterpretation when pasted

## Testing
- not run; documentation-only change

------
https://chatgpt.com/codex/tasks/task_e_68ca6f90eba08326b9732de5590befc5