### PR TITLE
Improve typing for Qt integration and normalize path display

### DIFF
--- a/patch_gui/diff_applier_gui.py
+++ b/patch_gui/diff_applier_gui.py
@@ -4,17 +4,22 @@ from __future__ import annotations
 
 import argparse
 import sys
-from typing import Optional, Sequence
-
-try:  # pragma: no cover - optional dependency may be missing in CLI-only installations
-    from PySide6 import QtCore
-except ImportError:  # pragma: no cover - executed when PySide6 is not installed
-    QtCore = None  # type: ignore[assignment]
-
 from . import cli
 from .i18n import install_translators
 from .localization import gettext as _
 from .utils import APP_NAME
+
+from types import ModuleType
+from typing import Optional, Sequence, cast
+
+QtCore: ModuleType | None
+
+try:  # pragma: no cover - optional dependency may be missing in CLI-only installations
+    from PySide6 import QtCore as _QtCore
+except ImportError:  # pragma: no cover - executed when PySide6 is not installed
+    QtCore = None
+else:
+    QtCore = cast(ModuleType, _QtCore)
 
 __all__ = ["main"]
 
@@ -26,9 +31,11 @@ def _tr(text: str) -> str:
     """Translate ``text`` using the ``diff_applier_gui`` context."""
 
     if QtCore is not None:
-        translated = QtCore.QCoreApplication.translate("diff_applier_gui", text)
-        if translated != text:
-            return translated
+        translated_text = cast(
+            str, QtCore.QCoreApplication.translate("diff_applier_gui", text)
+        )
+        if translated_text != text:
+            return translated_text
     return _(text)
 
 

--- a/patch_gui/executor.py
+++ b/patch_gui/executor.py
@@ -37,6 +37,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "CLIError",
+    "ApplySession",
     "apply_patchset",
     "load_patch",
     "session_completed",

--- a/patch_gui/filetypes.py
+++ b/patch_gui/filetypes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Protocol
+from typing import Iterable, Iterator, Protocol
 
 
 class _HunkLine(Protocol):
@@ -18,7 +18,7 @@ class _PatchLike(Protocol):
     target_file: str | None
     is_binary_file: bool | None
 
-    def __iter__(self) -> Iterable[_HunkLine]: ...
+    def __iter__(self) -> Iterator[Iterable[_HunkLine]]: ...
 
 
 @dataclass(frozen=True)

--- a/patch_gui/logo_widgets.py
+++ b/patch_gui/logo_widgets.py
@@ -7,7 +7,14 @@ produce stylised graphics so that the project can ship without raster images.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from PySide6 import QtCore, QtGui, QtWidgets
+
+if TYPE_CHECKING:
+    from PySide6.QtWidgets import QWidget
+else:  # pragma: no cover - provide runtime alias when type checking is disabled
+    QWidget = QtWidgets.QWidget
 
 __all__ = ["LogoWidget", "WordmarkWidget", "create_logo_pixmap"]
 
@@ -141,10 +148,10 @@ def create_logo_pixmap(size: int = 128) -> QtGui.QPixmap:
     return pixmap
 
 
-class LogoWidget(QtWidgets.QWidget):
+class LogoWidget(QWidget):
     """Widget that paints the square logo procedurally."""
 
-    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+    def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.setSizePolicy(
             QtWidgets.QSizePolicy.Policy.Fixed,
@@ -167,10 +174,10 @@ class LogoWidget(QtWidgets.QWidget):
         painter.end()
 
 
-class WordmarkWidget(QtWidgets.QWidget):
+class WordmarkWidget(QWidget):
     """Widget that draws a wordmark banner for the application."""
 
-    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+    def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.setSizePolicy(
             QtWidgets.QSizePolicy.Policy.Preferred,

--- a/patch_gui/utils.py
+++ b/patch_gui/utils.py
@@ -40,7 +40,10 @@ DEFAULT_REPORTS_DIR = _PACKAGE_ROOT / REPORTS_SUBDIR / REPORT_RESULTS_SUBDIR
 def display_path(path: Path) -> str:
     """Return ``path`` using forward slashes, regardless of the platform."""
 
-    return Path(path).as_posix()
+    path_text = str(Path(path))
+    if "\\" in path_text:
+        return path_text.replace("\\", "/")
+    return path_text
 
 
 def display_relative_path(path: Path, root: Path) -> str:
@@ -151,7 +154,9 @@ def _scan_hunk_body(lines: List[str], start: int) -> Tuple[int, int, int]:
     total = len(lines)
 
     while index < total:
-        continue_body, old_increment, new_increment = _hunk_body_line_effect(lines[index])
+        continue_body, old_increment, new_increment = _hunk_body_line_effect(
+            lines[index]
+        )
         if not continue_body:
             break
         old_count += old_increment

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+"""Test suite package for patch_gui."""
+

--- a/tests/test_diff_applier_gui.py
+++ b/tests/test_diff_applier_gui.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
-import pytest
 from typing import Any, cast
 
+import pytest
+
 from patch_gui import diff_applier_gui
+from tests.typing_helpers import parametrize
 
 
 GUI_RESULT = 42
 CLI_RESULT = 17
 
 
-@pytest.mark.parametrize(
+@parametrize(
     "argv, expected_calls, expected_result",
     [
         ([], [("gui", ())], GUI_RESULT),

--- a/tests/test_filetypes.py
+++ b/tests/test_filetypes.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+from typing import Iterable, Iterator
+
 from unidiff import PatchSet
+from unidiff.patch import PatchedFile
 
 from patch_gui.filetypes import FileTypeInfo, inspect_file_type
 
 
-def _first_file(diff: str):
+def _first_file(diff: str) -> PatchedFile:
     patch = PatchSet(diff)
     return patch[0]
 
@@ -29,14 +32,19 @@ def test_inspect_special_filename() -> None:
     assert info.name == "makefile"
 
 
+class _EmptyLine:
+    line_type: str = ""
+    value: str = ""
+
+
 def test_inspect_binary_stub() -> None:
     class DummyBinary:
-        path = "image.png"
-        source_file = "image.png"
-        target_file = "image.png"
-        is_binary_file = True
+        path: str | None = "image.png"
+        source_file: str | None = "image.png"
+        target_file: str | None = "image.png"
+        is_binary_file: bool | None = True
 
-        def __iter__(self):  # pragma: no cover - protocol requirement
+        def __iter__(self) -> Iterator[Iterable[_EmptyLine]]:  # pragma: no cover - protocol requirement
             return iter(())
 
     info = inspect_file_type(DummyBinary())

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -8,6 +8,7 @@ from typing import Any, Iterator, cast
 import pytest
 
 from patch_gui import i18n
+from tests.typing_helpers import fixture
 
 MODULE_I18N = cast(Any, i18n)
 
@@ -36,7 +37,7 @@ class DummyQLocale:
         return DummyQLocale.language_map[language]
 
 
-@pytest.fixture
+@fixture
 def dummy_qtcore(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     monkeypatch.setattr(MODULE_I18N, "QtCore", SimpleNamespace(QLocale=DummyQLocale))
     yield None

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -11,6 +11,8 @@ from typing import Iterator
 import pytest
 from logging.handlers import RotatingFileHandler
 
+from tests.typing_helpers import fixture
+
 
 class _DummyAttr:
     def __call__(self, *args: object, **kwargs: object) -> "_DummyAttr":
@@ -127,7 +129,7 @@ def _cleanup_file_handlers() -> None:
                 pass
 
 
-@pytest.fixture
+@fixture
 def clean_file_handlers() -> Iterator[None]:
     _cleanup_file_handlers()
     try:
@@ -151,8 +153,12 @@ def test_configure_logging_uses_rotating_handler(
     handler = handlers[0]
     assert isinstance(handler, RotatingFileHandler)
     assert handler.baseFilename == str(log_path)
-    assert handler.maxBytes == 1234
-    assert handler.backupCount == 3
+    max_bytes = handler.maxBytes
+    backup_count = handler.backupCount
+    assert isinstance(max_bytes, int)
+    assert isinstance(backup_count, int)
+    assert max_bytes == 1234
+    assert backup_count == 3
 
 
 def test_configure_logging_reads_environment(
@@ -170,8 +176,12 @@ def test_configure_logging_reads_environment(
         h for h in logging.getLogger().handlers if isinstance(h, RotatingFileHandler)
     )
     assert handler.baseFilename == str(log_path)
-    assert handler.maxBytes == 50
-    assert handler.backupCount == 2
+    max_bytes = handler.maxBytes
+    backup_count = handler.backupCount
+    assert isinstance(max_bytes, int)
+    assert isinstance(backup_count, int)
+    assert max_bytes == 50
+    assert backup_count == 2
 
 
 def test_configure_logging_rotates_files(

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -8,11 +8,12 @@ from typing import Any, cast
 import pytest
 
 from patch_gui import platform
+from tests.typing_helpers import parametrize
 
 MODULE_PLATFORM = cast(Any, platform)
 
 
-@pytest.mark.parametrize("env_value", ["Ubuntu", "Debian"])
+@parametrize("env_value", ["Ubuntu", "Debian"])
 def test_running_under_wsl_detects_env(
     monkeypatch: pytest.MonkeyPatch, env_value: str
 ) -> None:

--- a/tests/typing_helpers.py
+++ b/tests/typing_helpers.py
@@ -1,0 +1,26 @@
+"""Utilities that provide type-safe wrappers around common pytest decorators."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, TypeVar, cast
+
+import pytest
+
+F = TypeVar("F", bound=Callable[..., object])
+
+
+def fixture(func: F) -> F:
+    """Return ``func`` wrapped by :func:`pytest.fixture` with preserved typing."""
+
+    return cast(F, pytest.fixture(func))
+
+
+def parametrize(*args: Any, **kwargs: Any) -> Callable[[F], F]:
+    """Type-aware wrapper around :func:`pytest.mark.parametrize`."""
+
+    decorator = pytest.mark.parametrize(*args, **kwargs)
+
+    def _apply(func: F) -> F:
+        return cast(F, decorator(func))
+
+    return _apply


### PR DESCRIPTION
## Summary
- normalize `display_path` so Windows-style paths always use forward slashes
- introduce explicit Qt type aliases and guard rails to satisfy mypy in application modules
- add typed pytest decorator helpers and update tests to keep strict type checking happy

## Testing
- ruff check .
- mypy
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca6ffff9d88326ac9cd2759d721b89