### PR TITLE
Prevent closing while patch apply worker is running

### DIFF
--- a/patch_gui/app.py
+++ b/patch_gui/app.py
@@ -704,6 +704,15 @@ class MainWindow(QtWidgets.QMainWindow):
             self.statusBar().showMessage(lines[0][:100])
 
     def closeEvent(self, event: QtGui.QCloseEvent) -> None:
+        worker = self._current_worker
+        if worker is not None and worker.isRunning():
+            QtWidgets.QMessageBox.information(
+                self,
+                "Operazione in corso",
+                "Attendi il completamento dell'applicazione della patch prima di chiudere.",
+            )
+            event.ignore()
+            return
         if self._qt_log_handler is not None:
             logging.getLogger().removeHandler(self._qt_log_handler)
             self._qt_log_handler.close()


### PR DESCRIPTION
## Summary
- guard the main window close event while the patch application worker thread is running
- inform the user that they must wait for the active patch application to finish before closing the window

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca7371c5bc8326aa85632f7bfe974f