### PR TITLE
Fix display_path double slash output

### DIFF
--- a/patch_gui/utils.py
+++ b/patch_gui/utils.py
@@ -42,7 +42,10 @@ def display_path(path: Path) -> str:
 
     path_str = str(Path(path))
     if "\\" in path_str:
-        return path_str.replace("\\", "/")
+        normalized = path_str.replace("\\", "/")
+        while len(normalized) > 3 and normalized[1:3] == ":/" and normalized[3] == "/":
+            normalized = normalized[:3] + normalized[4:]
+        return normalized
     return path_str
 
 


### PR DESCRIPTION
## Summary
- prevent `display_path` from emitting a duplicated slash after Windows drive letters when normalizing

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ca787c5ba88326ac91d33de2395418