### PR TITLE
Normalize triple-asterisk headers without diff prefixes

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -63,6 +63,25 @@ def test_preprocess_patch_text_rewrites_triple_asterisk_headers() -> None:
     assert patch[0].path == "js/eventReview.js"
 
 
+def test_preprocess_patch_text_rewrites_triple_asterisk_headers_without_prefixes() -> None:
+    raw = (
+        "*** js/eventReview.js\n"
+        "--- js/eventReview.js\n"
+        "@@ -1 +1 @@\n"
+        "-old\n"
+        "+new\n"
+    )
+
+    processed = preprocess_patch_text(raw)
+    lines = processed.splitlines()
+    assert lines[0] == "--- a/js/eventReview.js"
+    assert lines[1] == "+++ b/js/eventReview.js"
+
+    patch = PatchSet(processed)
+    assert len(patch) == 1
+    assert patch[0].path == "js/eventReview.js"
+
+
 def test_preprocess_patch_text_extracts_begin_patch_blocks() -> None:
     raw = (
         "*** Begin Patch\n"


### PR DESCRIPTION
## Summary
- normalize clipboard patches whose headers use the legacy `***`/`---` pair without `a/` and `b/` prefixes
- keep `/dev/null` paths untouched while synthesizing standard prefixes for other files
- cover the regression with a new `preprocess_patch_text` unit test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca7b52f56083268d059ebde9f8035b