### PR TITLE
Store diff backups in Patch GUI workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ __pycache__/
 .fetch-client
 *.qm
 patch_gui/reports/
+.diff_backups/
 .venv-upgrade

--- a/patch_gui/parser.py
+++ b/patch_gui/parser.py
@@ -7,7 +7,14 @@ from typing import List, Optional, Sequence
 
 from .localization import gettext as _
 from .patcher import DEFAULT_EXCLUDE_DIRS
-from .utils import APP_NAME, BACKUP_DIR, REPORT_JSON, REPORT_TXT
+from .utils import (
+    APP_NAME,
+    BACKUP_DIR,
+    REPORT_JSON,
+    REPORT_TXT,
+    default_backup_base,
+    display_path,
+)
 
 _LOG_LEVEL_CHOICES = ("critical", "error", "warning", "info", "debug")
 
@@ -59,8 +66,9 @@ def build_parser(
     )
     parser.add_argument(
         "--backup",
-        help=_("Base directory for backups and reports; defaults to '<root>/%s'.")
-        % BACKUP_DIR,
+        help=_('Base directory for backups and reports; defaults to "{path}".').format(
+            path=display_path(default_backup_base())
+        ),
     )
     parser.add_argument(
         "--report-json",

--- a/patch_gui/patcher.py
+++ b/patch_gui/patcher.py
@@ -25,6 +25,7 @@ from .utils import (
     BACKUP_DIR,
     REPORT_JSON,
     REPORT_TXT,
+    default_backup_base,
     default_session_report_dir,
 )
 
@@ -535,7 +536,7 @@ def prepare_backup_dir(
     base = (
         backup_base.expanduser()
         if backup_base is not None
-        else project_root / BACKUP_DIR
+        else default_backup_base()
     )
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
     backup_dir = base / timestamp

--- a/patch_gui/utils.py
+++ b/patch_gui/utils.py
@@ -32,9 +32,16 @@ REPORT_JSON = "apply-report.json"
 REPORT_TXT = "apply-report.txt"
 
 _PACKAGE_ROOT = Path(__file__).resolve().parent
+_APP_ROOT = _PACKAGE_ROOT.parent
 REPORTS_SUBDIR = "reports"
 REPORT_RESULTS_SUBDIR = "results"
 DEFAULT_REPORTS_DIR = _PACKAGE_ROOT / REPORTS_SUBDIR / REPORT_RESULTS_SUBDIR
+
+
+def default_backup_base() -> Path:
+    """Return the default directory where diff backups are stored."""
+
+    return _APP_ROOT / BACKUP_DIR
 
 
 def display_path(path: Path) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,6 +60,7 @@ def test_apply_patchset_dry_run(tmp_path: Path) -> None:
     target = project / "sample.txt"
     assert target.read_text(encoding="utf-8") == "old line\nline2\n"
     assert session.dry_run is True
+    assert session.backup_dir.parent == utils.default_backup_base()
     assert session.backup_dir.exists()
     assert session.report_json_path is not None
     assert session.report_txt_path is not None
@@ -107,6 +108,7 @@ def test_apply_patchset_real_run_creates_backup(tmp_path: Path) -> None:
 
     assert target.read_text(encoding="utf-8") == "new line\nline2\n"
     assert session.backup_dir.parent.name == BACKUP_DIR
+    assert session.backup_dir.parent == utils.default_backup_base()
     assert session.backup_dir.exists()
 
     backup_copy = session.backup_dir / "sample.txt"

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -154,10 +154,12 @@ def test_find_file_candidates_allows_overriding_excludes(tmp_path: Path) -> None
 
 def test_prepare_backup_dir_respects_dry_run(tmp_path: Path) -> None:
     project_root = tmp_path
-    dry_dir = prepare_backup_dir(project_root, dry_run=True)
+    base_dir = tmp_path / "backups"
+
+    dry_dir = prepare_backup_dir(project_root, dry_run=True, backup_base=base_dir)
     assert not dry_dir.exists()
 
-    real_dir = prepare_backup_dir(project_root, dry_run=False)
+    real_dir = prepare_backup_dir(project_root, dry_run=False, backup_base=base_dir)
     assert real_dir.exists()
 
 


### PR DESCRIPTION
## Summary
- default diff backup location now resolves to the Patch GUI workspace instead of the project root
- ensure CLI help text reports the new backup directory path
- refresh tests to cover the relocated backup directory behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca7c4186708326897118ce54c67364