### PR TITLE
Fix typing utilities for Qt and build commands

### DIFF
--- a/patch_gui/diff_applier_gui.py
+++ b/patch_gui/diff_applier_gui.py
@@ -26,7 +26,8 @@ def _tr(text: str) -> str:
     """Translate ``text`` using the ``diff_applier_gui`` context."""
 
     if QtCore is not None:
-        translated = QtCore.QCoreApplication.translate("diff_applier_gui", text)
+        translated_obj = QtCore.QCoreApplication.translate("diff_applier_gui", text)
+        translated = str(translated_obj)
         if translated != text:
             return translated
     return _(text)

--- a/patch_gui/filetypes.py
+++ b/patch_gui/filetypes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Iterator, Protocol
+from typing import Iterator, Protocol
 
 
 class _HunkLine(Protocol):

--- a/patch_gui/logo_widgets.py
+++ b/patch_gui/logo_widgets.py
@@ -7,16 +7,7 @@ produce stylised graphics so that the project can ship without raster images.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from PySide6 import QtCore, QtGui, QtWidgets
-
-if TYPE_CHECKING:
-    from PySide6 import QtWidgets as _QtWidgetsModule
-
-    _BaseWidget = _QtWidgetsModule.QWidget
-else:
-    _BaseWidget = QtWidgets.QWidget
 
 __all__ = ["LogoWidget", "WordmarkWidget", "create_logo_pixmap"]
 
@@ -150,7 +141,7 @@ def create_logo_pixmap(size: int = 128) -> QtGui.QPixmap:
     return pixmap
 
 
-class LogoWidget(_BaseWidget):
+class LogoWidget(QtWidgets.QWidget):
     """Widget that paints the square logo procedurally."""
 
     def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
@@ -176,7 +167,7 @@ class LogoWidget(_BaseWidget):
         painter.end()
 
 
-class WordmarkWidget(_BaseWidget):
+class WordmarkWidget(QtWidgets.QWidget):
     """Widget that draws a wordmark banner for the application."""
 
     def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ module = [
     "charset_normalizer.*",
     "unidiff",
     "unidiff.*",
+    "setuptools",
+    "setuptools.*",
 ]
 ignore_missing_imports = true
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -63,7 +63,9 @@ def test_preprocess_patch_text_rewrites_triple_asterisk_headers() -> None:
     assert patch[0].path == "js/eventReview.js"
 
 
-def test_preprocess_patch_text_rewrites_triple_asterisk_headers_without_prefixes() -> None:
+def test_preprocess_patch_text_rewrites_triple_asterisk_headers_without_prefixes() -> (
+    None
+):
     raw = (
         "*** js/eventReview.js\n"
         "--- js/eventReview.js\n"


### PR DESCRIPTION
## Summary
- update the Qt slot helper and widget bases so QtCore.Slot no longer receives None arguments and classes inherit concrete PySide types
- tighten typing around the build translation commands by introducing protocols, TYPE_CHECKING stubs, and ignoring missing setuptools stubs in mypy config
- ensure GUI translation helper always returns text and remove an unused typing import

## Testing
- black --check .
- ruff check
- mypy patch_gui build_translations.py tests
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca7e3f9d58832690350aae58d6b50e