### PR TITLE
Avoid passing null Qt slot metadata

### DIFF
--- a/patch_gui/app.py
+++ b/patch_gui/app.py
@@ -69,7 +69,13 @@ def _qt_slot(
 ) -> Callable[[_F], _F]:
     """Typed wrapper around :func:`QtCore.Slot` to appease the type checker."""
 
-    return cast("Callable[[_F], _F]", QtCore.Slot(*types, name=name, result=result))
+    kwargs: dict[str, object] = {}
+    if name is not None:
+        kwargs["name"] = name
+    if result is not None:
+        kwargs["result"] = result
+
+    return cast("Callable[[_F], _F]", QtCore.Slot(*types, **kwargs))
 
 
 LOG_FILE_ENV_VAR: str = "PATCH_GUI_LOG_FILE"


### PR DESCRIPTION
## Summary
- ensure the Qt slot helper only forwards name and result metadata when provided

## Testing
- python -m patch_gui *(fails: PySide6 optional GUI dependencies are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7f6312888326b53ec78b76333f9e