### PR TITLE
Fix mypy errors for Qt subclasses

### DIFF
--- a/patch_gui/app.py
+++ b/patch_gui/app.py
@@ -15,6 +15,8 @@ from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, TypeVar, cast
 from logging.handlers import RotatingFileHandler
 
 from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6.QtCore import QObject, QThread
+from PySide6.QtWidgets import QDialog, QMainWindow
 from unidiff import PatchSet
 
 from .filetypes import inspect_file_type
@@ -180,7 +182,7 @@ def configure_logging(
     return file_path
 
 
-class _QtLogEmitter(QtCore.QObject):
+class _QtLogEmitter(QObject):
     """Helper ``QObject`` used to forward log messages to the GUI thread."""
 
     message = QtCore.Signal(str, int)
@@ -237,7 +239,7 @@ def _apply_platform_workarounds() -> None:
             )
 
 
-class CandidateDialog(QtWidgets.QDialog):
+class CandidateDialog(QDialog):
     def __init__(
         self,
         parent: QtWidgets.QWidget | None,
@@ -324,7 +326,7 @@ class CandidateDialog(QtWidgets.QDialog):
         super().accept()
 
 
-class FileChoiceDialog(QtWidgets.QDialog):
+class FileChoiceDialog(QDialog):
     def __init__(
         self,
         parent: QtWidgets.QWidget | None,
@@ -376,7 +378,7 @@ class FileChoiceDialog(QtWidgets.QDialog):
         super().accept()
 
 
-class PatchApplyWorker(QtCore.QThread):
+class PatchApplyWorker(QThread):
     progress = QtCore.Signal(str, int)
     finished = QtCore.Signal(object)
     error = QtCore.Signal(str)
@@ -559,7 +561,7 @@ class PatchApplyWorker(QtCore.QThread):
         return pos
 
 
-class MainWindow(QtWidgets.QMainWindow):
+class MainWindow(QMainWindow):
     def __init__(self) -> None:
         super().__init__()
         self.setWindowTitle(APP_NAME)

--- a/patch_gui/logo_widgets.py
+++ b/patch_gui/logo_widgets.py
@@ -8,6 +8,7 @@ produce stylised graphics so that the project can ship without raster images.
 from __future__ import annotations
 
 from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6.QtWidgets import QWidget
 
 __all__ = ["LogoWidget", "WordmarkWidget", "create_logo_pixmap"]
 
@@ -141,7 +142,7 @@ def create_logo_pixmap(size: int = 128) -> QtGui.QPixmap:
     return pixmap
 
 
-class LogoWidget(QtWidgets.QWidget):
+class LogoWidget(QWidget):
     """Widget that paints the square logo procedurally."""
 
     def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
@@ -167,7 +168,7 @@ class LogoWidget(QtWidgets.QWidget):
         painter.end()
 
 
-class WordmarkWidget(QtWidgets.QWidget):
+class WordmarkWidget(QWidget):
     """Widget that draws a wordmark banner for the application."""
 
     def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:

--- a/patch_gui/parser.py
+++ b/patch_gui/parser.py
@@ -9,7 +9,6 @@ from .localization import gettext as _
 from .patcher import DEFAULT_EXCLUDE_DIRS
 from .utils import (
     APP_NAME,
-    BACKUP_DIR,
     REPORT_JSON,
     REPORT_TXT,
     default_backup_base,

--- a/patch_gui/patcher.py
+++ b/patch_gui/patcher.py
@@ -22,7 +22,6 @@ from typing import (
 
 from .utils import (
     APP_NAME,
-    BACKUP_DIR,
     REPORT_JSON,
     REPORT_TXT,
     default_backup_base,
@@ -534,9 +533,7 @@ def prepare_backup_dir(
     """Return a timestamped backup directory for the session."""
 
     base = (
-        backup_base.expanduser()
-        if backup_base is not None
-        else default_backup_base()
+        backup_base.expanduser() if backup_base is not None else default_backup_base()
     )
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
     backup_dir = base / timestamp


### PR DESCRIPTION
## Summary
- import Qt base classes with type information so our widget, dialog, thread, and main window subclasses type-check cleanly
- drop unused BACKUP_DIR imports flagged by ruff

## Testing
- ruff check
- mypy
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca80ec4360832690705a2d6db7c8ee