### PR TITLE
Fix mypy Qt subclassing errors

### DIFF
--- a/patch_gui/app.py
+++ b/patch_gui/app.py
@@ -53,6 +53,21 @@ if TYPE_CHECKING:
 
 _F = TypeVar("_F", bound=Callable[..., object])
 
+class _QObjectBase(QObject):
+    """Concrete ``QObject`` subclass with a stable static type for mypy."""
+
+
+class _QDialogBase(QDialog):
+    """Concrete ``QDialog`` subclass with a stable static type for mypy."""
+
+
+class _QThreadBase(QThread):
+    """Concrete ``QThread`` subclass with a stable static type for mypy."""
+
+
+class _QMainWindowBase(QMainWindow):
+    """Concrete ``QMainWindow`` subclass with a stable static type for mypy."""
+
 
 def _qt_slot(
     *types: type[object], name: str | None = None, result: type[object] | None = None
@@ -182,7 +197,7 @@ def configure_logging(
     return file_path
 
 
-class _QtLogEmitter(QObject):
+class _QtLogEmitter(_QObjectBase):
     """Helper ``QObject`` used to forward log messages to the GUI thread."""
 
     message = QtCore.Signal(str, int)
@@ -239,7 +254,7 @@ def _apply_platform_workarounds() -> None:
             )
 
 
-class CandidateDialog(QDialog):
+class CandidateDialog(_QDialogBase):
     def __init__(
         self,
         parent: QtWidgets.QWidget | None,
@@ -326,7 +341,7 @@ class CandidateDialog(QDialog):
         super().accept()
 
 
-class FileChoiceDialog(QDialog):
+class FileChoiceDialog(_QDialogBase):
     def __init__(
         self,
         parent: QtWidgets.QWidget | None,
@@ -378,7 +393,7 @@ class FileChoiceDialog(QDialog):
         super().accept()
 
 
-class PatchApplyWorker(QThread):
+class PatchApplyWorker(_QThreadBase):
     progress = QtCore.Signal(str, int)
     finished = QtCore.Signal(object)
     error = QtCore.Signal(str)
@@ -561,7 +576,7 @@ class PatchApplyWorker(QThread):
         return pos
 
 
-class MainWindow(QMainWindow):
+class MainWindow(_QMainWindowBase):
     def __init__(self) -> None:
         super().__init__()
         self.setWindowTitle(APP_NAME)

--- a/patch_gui/logo_widgets.py
+++ b/patch_gui/logo_widgets.py
@@ -8,9 +8,13 @@ produce stylised graphics so that the project can ship without raster images.
 from __future__ import annotations
 
 from PySide6 import QtCore, QtGui, QtWidgets
-from PySide6.QtWidgets import QWidget
 
 __all__ = ["LogoWidget", "WordmarkWidget", "create_logo_pixmap"]
+
+
+class _QWidgetBase(QtWidgets.QWidget):
+    """Concrete ``QWidget`` subclass with a stable static type for mypy."""
+
 
 
 def _draw_logo(painter: QtGui.QPainter, target: QtCore.QRectF) -> None:
@@ -142,7 +146,7 @@ def create_logo_pixmap(size: int = 128) -> QtGui.QPixmap:
     return pixmap
 
 
-class LogoWidget(QWidget):
+class LogoWidget(_QWidgetBase):
     """Widget that paints the square logo procedurally."""
 
     def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
@@ -168,7 +172,7 @@ class LogoWidget(QWidget):
         painter.end()
 
 
-class WordmarkWidget(QWidget):
+class WordmarkWidget(_QWidgetBase):
     """Widget that draws a wordmark banner for the application."""
 
     def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:


### PR DESCRIPTION
## Summary
- add concrete Qt base helper classes so subclasses have stable types for mypy
- update widget, dialog, and window classes to inherit from the typed bases

## Testing
- python -m mypy patch_gui
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ca843f82808326b45795b097fd1d8b