### PR TITLE
Fix mypy subclassing errors for Qt base classes

### DIFF
--- a/patch_gui/app.py
+++ b/patch_gui/app.py
@@ -53,20 +53,29 @@ if TYPE_CHECKING:
 
 _F = TypeVar("_F", bound=Callable[..., object])
 
-class _QObjectBase(QObject):
-    """Concrete ``QObject`` subclass with a stable static type for mypy."""
+if TYPE_CHECKING:
+    # ``PySide6`` exposes these Qt base classes as ``Any`` which prevents mypy
+    # from allowing subclassing. Providing explicit subclasses in the
+    # ``TYPE_CHECKING`` branch gives the type checker concrete types while the
+    # assignments below preserve the runtime behaviour.
 
+    class _QObjectBase(QObject):
+        """Concrete ``QObject`` subclass with a stable static type for mypy."""
 
-class _QDialogBase(QDialog):
-    """Concrete ``QDialog`` subclass with a stable static type for mypy."""
+    class _QDialogBase(QDialog):
+        """Concrete ``QDialog`` subclass with a stable static type for mypy."""
 
+    class _QThreadBase(QThread):
+        """Concrete ``QThread`` subclass with a stable static type for mypy."""
 
-class _QThreadBase(QThread):
-    """Concrete ``QThread`` subclass with a stable static type for mypy."""
+    class _QMainWindowBase(QMainWindow):
+        """Concrete ``QMainWindow`` subclass with a stable static type for mypy."""
 
-
-class _QMainWindowBase(QMainWindow):
-    """Concrete ``QMainWindow`` subclass with a stable static type for mypy."""
+else:
+    _QObjectBase = QObject
+    _QDialogBase = QDialog
+    _QThreadBase = QThread
+    _QMainWindowBase = QMainWindow
 
 
 def _qt_slot(

--- a/patch_gui/logo_widgets.py
+++ b/patch_gui/logo_widgets.py
@@ -7,14 +7,24 @@ produce stylised graphics so that the project can ship without raster images.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from PySide6 import QtCore, QtGui, QtWidgets
 
 __all__ = ["LogoWidget", "WordmarkWidget", "create_logo_pixmap"]
 
 
-class _QWidgetBase(QtWidgets.QWidget):
-    """Concrete ``QWidget`` subclass with a stable static type for mypy."""
+if TYPE_CHECKING:
+    # ``PySide6`` does not ship typing-friendly base classes, so mypy sees them
+    # as ``Any``. Defining the class in the ``TYPE_CHECKING`` branch gives the
+    # type checker something concrete to work with, while the assignment keeps
+    # the runtime behaviour identical.
 
+    class _QWidgetBase(QtWidgets.QWidget):
+        """Concrete ``QWidget`` subclass with a stable static type for mypy."""
+
+else:
+    _QWidgetBase = QtWidgets.QWidget
 
 
 def _draw_logo(painter: QtGui.QPainter, target: QtCore.QRectF) -> None:


### PR DESCRIPTION
## Summary
- provide type-checking-only subclasses for the Qt base classes so mypy no longer treats them as Any while keeping runtime behaviour unchanged

## Testing
- black patch_gui/logo_widgets.py patch_gui/app.py
- ruff check patch_gui/logo_widgets.py patch_gui/app.py
- mypy patch_gui/logo_widgets.py patch_gui/app.py
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ca85fb7d108326a62dc98e1d27bcbc