### PR TITLE
Allow mypy subclassing of PySide6 base classes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,10 @@ module = [
 ]
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = [
+    "patch_gui.app",
+    "patch_gui.logo_widgets",
+]
+allow_subclassing_any = true
+


### PR DESCRIPTION
## Summary
- allow mypy to accept subclassing of PySide6 GUI base classes in strict mode

## Testing
- python -m mypy patch_gui
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca873afc8083269ad559359031b1d5