### PR TITLE
Improve CLI detection heuristics

### DIFF
--- a/tests/test_diff_applier_gui.py
+++ b/tests/test_diff_applier_gui.py
@@ -22,6 +22,57 @@ CLI_RESULT = 17
             [("cli", ["--root", ".", "patch.diff"])],
             CLI_RESULT,
         ),
+        (
+            ["--non-interactive", "--root", ".", "patch.diff"],
+            [("cli", ["--non-interactive", "--root", ".", "patch.diff"])],
+            CLI_RESULT,
+        ),
+        (
+            ["--no-report", "--root", ".", "patch.diff"],
+            [("cli", ["--no-report", "--root", ".", "patch.diff"])],
+            CLI_RESULT,
+        ),
+        (
+            ["--report-json", "report.json", "--root", ".", "patch.diff"],
+            [
+                (
+                    "cli",
+                    ["--report-json", "report.json", "--root", ".", "patch.diff"],
+                )
+            ],
+            CLI_RESULT,
+        ),
+        (
+            ["--report-txt=report.txt", "--root", ".", "patch.diff"],
+            [
+                (
+                    "cli",
+                    ["--report-txt=report.txt", "--root", ".", "patch.diff"],
+                )
+            ],
+            CLI_RESULT,
+        ),
+        (
+            ["--encoding=utf-8", "--root", ".", "patch.diff"],
+            [
+                ("cli", ["--encoding=utf-8", "--root", ".", "patch.diff"]),
+            ],
+            CLI_RESULT,
+        ),
+        (
+            ["--log-level", "debug", "--root", ".", "patch.diff"],
+            [
+                ("cli", ["--log-level", "debug", "--root", ".", "patch.diff"]),
+            ],
+            CLI_RESULT,
+        ),
+        (
+            ["--exclude-dir=build", "--root", ".", "patch.diff"],
+            [
+                ("cli", ["--exclude-dir=build", "--root", ".", "patch.diff"]),
+            ],
+            CLI_RESULT,
+        ),
     ],
 )
 def test_main_dispatches_between_gui_and_cli(


### PR DESCRIPTION
## Summary
- update diff_applier_gui to derive CLI detection flags from the parser so every supported option triggers CLI execution
- extend diff_applier_gui tests with the newer CLI options to ensure the dispatcher routes them to the CLI

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca94148a748326952d4073d25e448e