### PR TITLE
Set default backups outside project root

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ patch-gui apply --root . --non-interactive diff.patch
 
 - `--dry-run` simula l'applicazione lasciando i file invariati; i report vengono generati a meno di `--no-report`.
 - `--threshold` imposta la soglia fuzzy (default 0.85).
-- `--backup` permette di scegliere la cartella base (default `<root>/.diff_backups`).
+- `--backup` permette di scegliere la cartella base (default `~/.diff_backups`).
 - `--report-json` / `--report-txt` impostano i percorsi dei report generati (default `<app>/reports/results/<timestamp>/apply-report.json|.txt`).
 - `--no-report` disattiva entrambi i file di report.
 - `--non-interactive` mantiene il comportamento storico: se il percorso è ambiguo il file viene saltato senza prompt.
@@ -194,7 +194,7 @@ pre-commit run --all-files
 6. **Avanzamento**: la barra di stato mostra il progresso in tempo reale.
 7. **Ambiguità**: se sono trovate più posizioni plausibili, appare un dialog con tutte le opzioni e relativo contesto.
 8. **File mancanti**: se non trovati sotto la root, vengono saltati (come da preferenza).
-9. **Backup & report**: ogni run reale crea `./.diff_backups/<timestamp>/` con copie originali e genera `apply-report.json` e `apply-report.txt`. Anche in dry‑run, se i report non sono disattivati, vengono creati (senza backup) per documentare la simulazione.
+9. **Backup & report**: ogni run reale crea `~/.diff_backups/<timestamp>/` con copie originali (a meno di specificare `--backup`) e genera `apply-report.json` e `apply-report.txt`. Anche in dry‑run, se i report non sono disattivati, vengono creati (senza backup) per documentare la simulazione.
 10. **Ripristino**: usa **Ripristina da backup…**, scegli il timestamp e i file verranno ripristinati.
 
 Per una guida dettagliata con screenshot e flussi completi consulta [USAGE.md](USAGE.md).

--- a/USAGE.md
+++ b/USAGE.md
@@ -41,7 +41,7 @@ Questa guida passo‑passo descrive il workflow tipico per applicare una patch c
    - Se la patch può essere applicata in più punti plausibili, viene aperto un dialog che mostra tutte le opzioni con il relativo contesto.
    - Scegli manualmente il posizionamento corretto.
 7. **Consulta backup e report**
-   - Ogni esecuzione reale crea una cartella `./.diff_backups/<timestamp>/` con copie dei file originali.
+   - Ogni esecuzione reale crea una cartella `~/.diff_backups/<timestamp>/` con copie dei file originali (a meno di impostare un percorso diverso con `--backup`).
    - I report `apply-report.json` e `apply-report.txt` vengono salvati in `patch_gui/reports/results/<timestamp>/`
      accanto all'applicazione (anche in dry‑run, se non disattivati) per documentare l'esito della simulazione.
 8. **Ripristina da backup**

--- a/patch_gui/utils.py
+++ b/patch_gui/utils.py
@@ -41,7 +41,7 @@ DEFAULT_REPORTS_DIR = _PACKAGE_ROOT / REPORTS_SUBDIR / REPORT_RESULTS_SUBDIR
 def default_backup_base() -> Path:
     """Return the default directory where diff backups are stored."""
 
-    return _APP_ROOT / BACKUP_DIR
+    return Path.home() / BACKUP_DIR
 
 
 def display_path(path: Path) -> str:


### PR DESCRIPTION
## Summary
- store default backup sessions under the user home directory instead of the project root
- update README and usage guide to describe the new default backup location

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca8a19f7d08326af0acfd3d70435f1