### PR TITLE
Localize session report output to English with translations

### DIFF
--- a/patch_gui/locale/it/LC_MESSAGES/patch_gui.po
+++ b/patch_gui/locale/it/LC_MESSAGES/patch_gui.po
@@ -201,6 +201,123 @@ msgid ""
 "The --report-json/--report-txt options are incompatible with --no-report."
 msgstr ""
 
+#: patch_gui/patcher.py:156
+#, python-brace-format
+msgid "Report – {app_name}"
+msgstr "Report – {app_name}"
+
+#: patch_gui/patcher.py:159
+#, python-brace-format
+msgid "Started: {timestamp}"
+msgstr "Avviato: {timestamp}"
+
+#: patch_gui/patcher.py:163
+#, python-brace-format
+msgid "Project root: {project_root}"
+msgstr "Root progetto: {project_root}"
+
+#: patch_gui/patcher.py:165
+#, python-brace-format
+msgid "Backup directory: {backup_dir}"
+msgstr "Backup: {backup_dir}"
+
+#: patch_gui/patcher.py:167
+#, python-brace-format
+msgid "Dry-run: {dry_run}"
+msgstr "Dry-run: {dry_run}"
+
+#: patch_gui/patcher.py:169
+#, python-brace-format
+msgid "Fuzzy threshold: {threshold}"
+msgstr "Soglia fuzzy: {threshold}"
+
+#: patch_gui/patcher.py:171
+msgid "(none)"
+msgstr "(nessuna)"
+
+#: patch_gui/patcher.py:173
+#, python-brace-format
+msgid "Excluded directories: {directories}"
+msgstr "Directory escluse: {directories}"
+
+#: patch_gui/patcher.py:180
+msgid "Summary:"
+msgstr "Riepilogo:"
+
+#: patch_gui/patcher.py:182
+#, python-brace-format
+msgid "  Files processed: {count}"
+msgstr "  File analizzati: {count}"
+
+#: patch_gui/patcher.py:185
+#, python-brace-format
+msgid "  Files with changes: {count}"
+msgstr "  File con modifiche: {count}"
+
+#: patch_gui/patcher.py:189
+#, python-brace-format
+msgid "  Files skipped: {count}"
+msgstr "  File saltati: {count}"
+
+#: patch_gui/patcher.py:192
+#, python-brace-format
+msgid "  Hunks applied: {applied}/{total}"
+msgstr "  Hunks applicati: {applied}/{total}"
+
+#: patch_gui/patcher.py:197
+msgid "  No changes were applied to the files."
+msgstr "  Nessuna modifica è stata applicata ai file."
+
+#: patch_gui/patcher.py:200
+#, python-brace-format
+msgid "File: {path}"
+msgstr "File: {path}"
+
+#: patch_gui/patcher.py:203
+#, python-brace-format
+msgid "  SKIPPED: {reason}"
+msgstr "  SALTATO: {reason}"
+
+#: patch_gui/patcher.py:205
+#, python-brace-format
+msgid "  File type: {file_type}"
+msgstr "  Tipo file: {file_type}"
+
+#: patch_gui/patcher.py:207
+#, python-brace-format
+msgid "  Hunks: {applied}/{total}"
+msgstr "  Hunks: {applied}/{total}"
+
+#: patch_gui/patcher.py:213
+#, python-brace-format
+msgid "    Hunk {header} -> {strategy}"
+msgstr "    Hunk {header} -> {strategy}"
+
+#: patch_gui/patcher.py:219
+#, python-brace-format
+msgid "      Position: {position}"
+msgstr "      Posizione: {position}"
+
+#: patch_gui/patcher.py:225
+#, python-brace-format
+msgid "      Similarity: {similarity:.3f}"
+msgstr "      Similarità: {similarity:.3f}"
+
+#: patch_gui/patcher.py:232
+#, python-brace-format
+msgid "(position {position}, similarity {similarity:.3f})"
+msgstr "(posizione {position}, similarità {similarity:.3f})"
+
+#: patch_gui/patcher.py:239
+#, python-brace-format
+msgid "      Candidates: {candidates}"
+msgstr "      Candidati: {candidates}"
+
+#: patch_gui/patcher.py:245
+#, python-brace-format
+msgid "      Notes: {notes}"
+msgstr "      Note: {notes}"
+
 #: patch_gui/cli.py:69
 #, python-brace-format
 msgid "Error: {message}\n"

--- a/patch_gui/locale/patch_gui.pot
+++ b/patch_gui/locale/patch_gui.pot
@@ -199,6 +199,123 @@ msgid ""
 "The --report-json/--report-txt options are incompatible with --no-report."
 msgstr ""
 
+#: patch_gui/patcher.py:156
+#, python-brace-format
+msgid "Report – {app_name}"
+msgstr ""
+
+#: patch_gui/patcher.py:159
+#, python-brace-format
+msgid "Started: {timestamp}"
+msgstr ""
+
+#: patch_gui/patcher.py:163
+#, python-brace-format
+msgid "Project root: {project_root}"
+msgstr ""
+
+#: patch_gui/patcher.py:165
+#, python-brace-format
+msgid "Backup directory: {backup_dir}"
+msgstr ""
+
+#: patch_gui/patcher.py:167
+#, python-brace-format
+msgid "Dry-run: {dry_run}"
+msgstr ""
+
+#: patch_gui/patcher.py:169
+#, python-brace-format
+msgid "Fuzzy threshold: {threshold}"
+msgstr ""
+
+#: patch_gui/patcher.py:171
+msgid "(none)"
+msgstr ""
+
+#: patch_gui/patcher.py:173
+#, python-brace-format
+msgid "Excluded directories: {directories}"
+msgstr ""
+
+#: patch_gui/patcher.py:180
+msgid "Summary:"
+msgstr ""
+
+#: patch_gui/patcher.py:182
+#, python-brace-format
+msgid "  Files processed: {count}"
+msgstr ""
+
+#: patch_gui/patcher.py:185
+#, python-brace-format
+msgid "  Files with changes: {count}"
+msgstr ""
+
+#: patch_gui/patcher.py:189
+#, python-brace-format
+msgid "  Files skipped: {count}"
+msgstr ""
+
+#: patch_gui/patcher.py:192
+#, python-brace-format
+msgid "  Hunks applied: {applied}/{total}"
+msgstr ""
+
+#: patch_gui/patcher.py:197
+msgid "  No changes were applied to the files."
+msgstr ""
+
+#: patch_gui/patcher.py:200
+#, python-brace-format
+msgid "File: {path}"
+msgstr ""
+
+#: patch_gui/patcher.py:203
+#, python-brace-format
+msgid "  SKIPPED: {reason}"
+msgstr ""
+
+#: patch_gui/patcher.py:205
+#, python-brace-format
+msgid "  File type: {file_type}"
+msgstr ""
+
+#: patch_gui/patcher.py:207
+#, python-brace-format
+msgid "  Hunks: {applied}/{total}"
+msgstr ""
+
+#: patch_gui/patcher.py:213
+#, python-brace-format
+msgid "    Hunk {header} -> {strategy}"
+msgstr ""
+
+#: patch_gui/patcher.py:219
+#, python-brace-format
+msgid "      Position: {position}"
+msgstr ""
+
+#: patch_gui/patcher.py:225
+#, python-brace-format
+msgid "      Similarity: {similarity:.3f}"
+msgstr ""
+
+#: patch_gui/patcher.py:232
+#, python-brace-format
+msgid "(position {position}, similarity {similarity:.3f})"
+msgstr ""
+
+#: patch_gui/patcher.py:239
+#, python-brace-format
+msgid "      Candidates: {candidates}"
+msgstr ""
+
+#: patch_gui/patcher.py:245
+#, python-brace-format
+msgid "      Notes: {notes}"
+msgstr ""
+
 #: patch_gui/cli.py:69
 #, python-brace-format
 msgid "Error: {message}\n"

--- a/patch_gui/patcher.py
+++ b/patch_gui/patcher.py
@@ -20,6 +20,7 @@ from typing import (
     Tuple,
 )
 
+from .localization import gettext as _
 from .utils import (
     APP_NAME,
     REPORT_JSON,
@@ -153,47 +154,96 @@ class ApplySession:
 
     def to_txt(self) -> str:
         lines = []
-        lines.append(f"Report – {APP_NAME}")
-        lines.append(f"Avviato: {datetime.fromtimestamp(self.started_at)}")
-        lines.append(f"Root progetto: {self.project_root}")
-        lines.append(f"Backup: {self.backup_dir}")
-        lines.append(f"Dry-run: {self.dry_run}")
-        lines.append(f"Soglia fuzzy: {self.threshold}")
-        excludes = ", ".join(self.exclude_dirs) if self.exclude_dirs else "(nessuna)"
-        lines.append(f"Directory escluse: {excludes}")
+        lines.append(_("Report – {app_name}").format(app_name=APP_NAME))
+        lines.append(
+            _("Started: {timestamp}").format(
+                timestamp=datetime.fromtimestamp(self.started_at)
+            )
+        )
+        lines.append(_("Project root: {project_root}").format(project_root=self.project_root))
+        lines.append(
+            _("Backup directory: {backup_dir}").format(backup_dir=self.backup_dir)
+        )
+        lines.append(_("Dry-run: {dry_run}").format(dry_run=self.dry_run))
+        lines.append(
+            _("Fuzzy threshold: {threshold}").format(threshold=self.threshold)
+        )
+        excludes = ", ".join(self.exclude_dirs) if self.exclude_dirs else _("(none)")
+        lines.append(
+            _("Excluded directories: {directories}").format(directories=excludes)
+        )
         total_files = len(self.results)
         total_hunks = sum(fr.hunks_total for fr in self.results)
         applied_hunks = sum(fr.hunks_applied for fr in self.results)
         changed_files = sum(1 for fr in self.results if fr.hunks_applied > 0)
         skipped_files = sum(1 for fr in self.results if fr.skipped_reason)
-        lines.append("Riepilogo:")
-        lines.append(f"  File analizzati: {total_files}")
-        lines.append(f"  File con modifiche: {changed_files}")
+        lines.append(_("Summary:"))
+        lines.append(
+            _("  Files processed: {count}").format(count=total_files)
+        )
+        lines.append(
+            _("  Files with changes: {count}").format(count=changed_files)
+        )
         if skipped_files:
-            lines.append(f"  File saltati: {skipped_files}")
-        lines.append(f"  Hunks applicati: {applied_hunks}/{total_hunks}")
+            lines.append(
+                _("  Files skipped: {count}").format(count=skipped_files)
+            )
+        lines.append(
+            _("  Hunks applied: {applied}/{total}").format(
+                applied=applied_hunks, total=total_hunks
+            )
+        )
         if not total_hunks or not applied_hunks:
-            lines.append("  Nessuna modifica è stata applicata ai file.")
+            lines.append(_("  No changes were applied to the files."))
         lines.append("")
         for fr in self.results:
-            lines.append(f"File: {fr.relative_to_root}")
+            lines.append(_("File: {path}").format(path=fr.relative_to_root))
             if fr.skipped_reason:
-                lines.append(f"  SKIPPED: {fr.skipped_reason}")
-            lines.append(f"  Tipo file: {fr.file_type}")
-            lines.append(f"  Hunks: {fr.hunks_applied}/{fr.hunks_total}")
+                lines.append(
+                    _("  SKIPPED: {reason}").format(reason=fr.skipped_reason)
+                )
+            lines.append(_("  File type: {file_type}").format(file_type=fr.file_type))
+            lines.append(
+                _("  Hunks: {applied}/{total}").format(
+                    applied=fr.hunks_applied, total=fr.hunks_total
+                )
+            )
             for d in fr.decisions:
-                lines.append(f"    Hunk {d.hunk_header} -> {d.strategy}")
+                lines.append(
+                    _("    Hunk {header} -> {strategy}").format(
+                        header=d.hunk_header, strategy=d.strategy
+                    )
+                )
                 if d.selected_pos is not None:
-                    lines.append(f"      Pos: {d.selected_pos}")
+                    lines.append(
+                        _("      Position: {position}").format(
+                            position=d.selected_pos
+                        )
+                    )
                 if d.similarity is not None:
-                    lines.append(f"      Similarità: {d.similarity:.3f}")
+                    lines.append(
+                        _("      Similarity: {similarity:.3f}").format(
+                            similarity=d.similarity
+                        )
+                    )
                 if d.candidates:
                     cand_str = ", ".join(
-                        [f"(pos {p}, sim {s:.3f})" for p, s in d.candidates]
+                        [
+                            _("(position {position}, similarity {similarity:.3f})").format(
+                                position=p, similarity=s
+                            )
+                            for p, s in d.candidates
+                        ]
                     )
-                    lines.append(f"      Candidati: {cand_str}")
+                    lines.append(
+                        _("      Candidates: {candidates}").format(
+                            candidates=cand_str
+                        )
+                    )
                 if d.message:
-                    lines.append(f"      Note: {d.message}")
+                    lines.append(
+                        _("      Notes: {notes}").format(notes=d.message)
+                    )
             lines.append("")
         return "\n".join(lines)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -105,8 +105,8 @@ def test_session_report_highlights_missing_changes(tmp_path: Path) -> None:
 
     report = session.to_txt()
 
-    assert "Riepilogo:" in report
-    assert "Nessuna modifica è stata applicata ai file." in report
+    assert "Summary:" in report
+    assert "No changes were applied to the files." in report
 
 
 def test_apply_patchset_real_run_creates_backup(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- switch the session text report to English strings wrapped with gettext
- update the CLI test expectations for the new report wording
- refresh the gettext catalog and Italian translations for the new messages

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca95d893588326bb038ff3da25da7d