### PR TITLE
Ensure CLI defaults to English help text

### DIFF
--- a/patch_gui/localization.py
+++ b/patch_gui/localization.py
@@ -15,7 +15,13 @@ LOCALE_DIR = Path(__file__).resolve().parent / "locale"
 
 _CACHE: Dict[Tuple[str, ...], _gettext.NullTranslations] = {}
 
-__all__ = ["get_translator", "gettext", "ngettext", "clear_translation_cache"]
+__all__ = [
+    "get_translator",
+    "gettext",
+    "ngettext",
+    "clear_translation_cache",
+    "LANG_ENV_VAR",
+]
 
 
 def _system_language() -> str | None:
@@ -59,11 +65,15 @@ def _candidate_languages(preferred: str | None) -> List[str]:
     seen: set[str] = set()
 
     _append_candidate(preferred, seen, candidates)
-    _append_candidate(os.getenv(LANG_ENV_VAR), seen, candidates)
-    _append_candidate(_system_language(), seen, candidates)
 
-    if "en" not in seen:
-        candidates.append("en")
+    env_language = os.getenv(LANG_ENV_VAR)
+    _append_candidate(env_language, seen, candidates)
+
+    # English is the default language for the CLI; prefer it when no explicit
+    # locale was requested via ``locale_code`` or the environment variable.
+    _append_candidate("en", seen, candidates)
+
+    _append_candidate(_system_language(), seen, candidates)
 
     return candidates
 


### PR DESCRIPTION
## Summary
- ensure the localization module always prefers English when no locale is provided
- export the LANG_ENV_VAR constant from patch_gui.localization

## Testing
- mypy patch_gui tests
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca9db516e883269b920c0338f325f7