### PR TITLE
Move reports into user backup directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ patch-gui apply --root . --non-interactive diff.patch
 - `--dry-run` simula l'applicazione lasciando i file invariati; i report vengono generati a meno di `--no-report`.
 - `--threshold` imposta la soglia fuzzy (default 0.85).
 - `--backup` permette di scegliere la cartella base (default `~/.diff_backups`).
-- `--report-json` / `--report-txt` impostano i percorsi dei report generati (default `<app>/reports/results/<timestamp>/apply-report.json|.txt`).
+- `--report-json` / `--report-txt` impostano i percorsi dei report generati (default `~/.diff_backups/reports/results/<timestamp>/apply-report.json|.txt`).
 - `--no-report` disattiva entrambi i file di report.
 - `--non-interactive` mantiene il comportamento storico: se il percorso è ambiguo il file viene saltato senza prompt.
 - `--log-level` imposta la verbosità del logger (`debug`, `info`, `warning`, `error`, `critical`; default `warning`). La variabile `PATCH_GUI_LOG_LEVEL` fornisce lo stesso controllo.
@@ -302,14 +302,14 @@ Aggiungi l'italiano e alcune parole tecniche:
 ## 🗂️ Struttura backup/report
 
 ```text
-.diff_backups/
+~/.diff_backups/
   2025YYYYMMDD-HHMMSS/
     path/del/file/originale.ext
-patch_gui/reports/
-  results/
-    2025YYYYMMDD-HHMMSS-fff/
-      apply-report.json
-      apply-report.txt
+  reports/
+    results/
+      2025YYYYMMDD-HHMMSS-fff/
+        apply-report.json
+        apply-report.txt
 ```
 
 ---

--- a/USAGE.md
+++ b/USAGE.md
@@ -42,8 +42,8 @@ Questa guida passo‑passo descrive il workflow tipico per applicare una patch c
    - Scegli manualmente il posizionamento corretto.
 7. **Consulta backup e report**
    - Ogni esecuzione reale crea una cartella `~/.diff_backups/<timestamp>/` con copie dei file originali (a meno di impostare un percorso diverso con `--backup`).
-   - I report `apply-report.json` e `apply-report.txt` vengono salvati in `patch_gui/reports/results/<timestamp>/`
-     accanto all'applicazione (anche in dry‑run, se non disattivati) per documentare l'esito della simulazione.
+   - I report `apply-report.json` e `apply-report.txt` vengono salvati in `~/.diff_backups/reports/results/<timestamp>/`
+     (anche in dry‑run, se non disattivati) per documentare l'esito della simulazione.
 8. **Ripristina da backup**
    - Usa il pulsante **Ripristina da backup…** e seleziona il timestamp desiderato per ripristinare i file originali.
 

--- a/patch_gui/utils.py
+++ b/patch_gui/utils.py
@@ -35,13 +35,15 @@ _PACKAGE_ROOT = Path(__file__).resolve().parent
 _APP_ROOT = _PACKAGE_ROOT.parent
 REPORTS_SUBDIR = "reports"
 REPORT_RESULTS_SUBDIR = "results"
-DEFAULT_REPORTS_DIR = _PACKAGE_ROOT / REPORTS_SUBDIR / REPORT_RESULTS_SUBDIR
-
-
 def default_backup_base() -> Path:
     """Return the default directory where diff backups are stored."""
 
     return Path.home() / BACKUP_DIR
+
+
+DEFAULT_REPORTS_DIR = (
+    default_backup_base() / REPORTS_SUBDIR / REPORT_RESULTS_SUBDIR
+)
 
 
 def display_path(path: Path) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,6 +49,15 @@ def _create_project(tmp_path: Path) -> Path:
     return project
 
 
+def test_default_reports_dir_points_to_user_space() -> None:
+    started_at = time.time()
+
+    default_dir = utils.default_session_report_dir(started_at)
+
+    assert utils.default_backup_base() in default_dir.parents
+    assert default_dir.parent == utils.DEFAULT_REPORTS_DIR
+
+
 def test_parser_help_uses_english_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
     localization.clear_translation_cache()
     monkeypatch.delenv(localization.LANG_ENV_VAR, raising=False)
@@ -82,6 +91,7 @@ def test_apply_patchset_dry_run(tmp_path: Path) -> None:
     assert session.report_json_path.exists()
     assert session.report_txt_path.exists()
     expected_dir = utils.default_session_report_dir(session.started_at)
+    assert utils.default_backup_base() in expected_dir.parents
     assert expected_dir.parent == utils.DEFAULT_REPORTS_DIR
     assert session.report_json_path.parent == expected_dir
     assert session.report_txt_path.parent == expected_dir
@@ -131,6 +141,7 @@ def test_apply_patchset_real_run_creates_backup(tmp_path: Path) -> None:
     assert backup_copy.read_text(encoding="utf-8") == original
 
     report_dir = utils.default_session_report_dir(session.started_at)
+    assert utils.default_backup_base() in report_dir.parents
     assert report_dir.parent == utils.DEFAULT_REPORTS_DIR
     json_report = report_dir / REPORT_JSON
     text_report = report_dir / REPORT_TXT
@@ -168,6 +179,7 @@ def test_apply_patchset_custom_report_paths(tmp_path: Path) -> None:
     assert json_dest.exists()
     assert txt_dest.exists()
     default_dir = utils.default_session_report_dir(session.started_at)
+    assert utils.default_backup_base() in default_dir.parents
     assert not (default_dir / REPORT_JSON).exists()
     assert not (default_dir / REPORT_TXT).exists()
 
@@ -190,6 +202,7 @@ def test_apply_patchset_no_report(tmp_path: Path) -> None:
     assert session.report_json_path is None
     assert session.report_txt_path is None
     default_dir = utils.default_session_report_dir(session.started_at)
+    assert utils.default_backup_base() in default_dir.parents
     assert not (default_dir / REPORT_JSON).exists()
     assert not (default_dir / REPORT_TXT).exists()
 


### PR DESCRIPTION
## Summary
- point the default reports directory to the user backup location under `~/.diff_backups`
- ensure write reports tests expect the new location and document the updated default paths

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca9e5436fc832683820f13dc7af7fb