### PR TITLE
Use user home for default reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ patch-gui apply --root . --non-interactive diff.patch
 - `--dry-run` simula l'applicazione lasciando i file invariati; i report vengono generati a meno di `--no-report`.
 - `--threshold` imposta la soglia fuzzy (default 0.85).
 - `--backup` permette di scegliere la cartella base (default `~/.diff_backups`).
-- `--report-json` / `--report-txt` impostano i percorsi dei report generati (default `<app>/reports/results/<timestamp>/apply-report.json|.txt`).
+- `--report-json` / `--report-txt` impostano i percorsi dei report generati (default `~/.diff_backups/reports/results/<timestamp>/apply-report.json|.txt`).
 - `--no-report` disattiva entrambi i file di report.
 - `--non-interactive` mantiene il comportamento storico: se il percorso è ambiguo il file viene saltato senza prompt.
 - `--log-level` imposta la verbosità del logger (`debug`, `info`, `warning`, `error`, `critical`; default `warning`). La variabile `PATCH_GUI_LOG_LEVEL` fornisce lo stesso controllo.
@@ -305,11 +305,11 @@ Aggiungi l'italiano e alcune parole tecniche:
 .diff_backups/
   2025YYYYMMDD-HHMMSS/
     path/del/file/originale.ext
-patch_gui/reports/
-  results/
-    2025YYYYMMDD-HHMMSS-fff/
-      apply-report.json
-      apply-report.txt
+  reports/
+    results/
+      2025YYYYMMDD-HHMMSS-fff/
+        apply-report.json
+        apply-report.txt
 ```
 
 ---

--- a/USAGE.md
+++ b/USAGE.md
@@ -42,8 +42,8 @@ Questa guida passo‑passo descrive il workflow tipico per applicare una patch c
    - Scegli manualmente il posizionamento corretto.
 7. **Consulta backup e report**
    - Ogni esecuzione reale crea una cartella `~/.diff_backups/<timestamp>/` con copie dei file originali (a meno di impostare un percorso diverso con `--backup`).
-   - I report `apply-report.json` e `apply-report.txt` vengono salvati in `patch_gui/reports/results/<timestamp>/`
-     accanto all'applicazione (anche in dry‑run, se non disattivati) per documentare l'esito della simulazione.
+   - I report `apply-report.json` e `apply-report.txt` vengono salvati in `~/.diff_backups/reports/results/<timestamp>/`
+     (anche in dry‑run, se non disattivati) per documentare l'esito della simulazione.
 8. **Ripristina da backup**
    - Usa il pulsante **Ripristina da backup…** e seleziona il timestamp desiderato per ripristinare i file originali.
 

--- a/patch_gui/patcher.py
+++ b/patch_gui/patcher.py
@@ -622,7 +622,7 @@ def write_reports(
     if not write_json and not write_txt:
         return None, None
 
-    default_report_dir = default_session_report_dir(session.started_at)
+    default_report_dir = default_session_report_dir(session.started_at).expanduser()
 
     def _resolve_path(raw: Path | str | None, default: Path) -> Path:
         if raw is None:

--- a/patch_gui/utils.py
+++ b/patch_gui/utils.py
@@ -31,17 +31,20 @@ BACKUP_DIR = ".diff_backups"
 REPORT_JSON = "apply-report.json"
 REPORT_TXT = "apply-report.txt"
 
-_PACKAGE_ROOT = Path(__file__).resolve().parent
-_APP_ROOT = _PACKAGE_ROOT.parent
-REPORTS_SUBDIR = "reports"
-REPORT_RESULTS_SUBDIR = "results"
-DEFAULT_REPORTS_DIR = _PACKAGE_ROOT / REPORTS_SUBDIR / REPORT_RESULTS_SUBDIR
-
-
+ 
 def default_backup_base() -> Path:
     """Return the default directory where diff backups are stored."""
 
     return Path.home() / BACKUP_DIR
+
+
+_PACKAGE_ROOT = Path(__file__).resolve().parent
+_APP_ROOT = _PACKAGE_ROOT.parent
+REPORTS_SUBDIR = "reports"
+REPORT_RESULTS_SUBDIR = "results"
+DEFAULT_REPORTS_DIR = (
+    default_backup_base() / REPORTS_SUBDIR / REPORT_RESULTS_SUBDIR
+)
 
 
 def display_path(path: Path) -> str:


### PR DESCRIPTION
## Summary
- store generated reports under the user backup base instead of the package tree
- ensure CLI reporting keeps working with the new directory and guard against the legacy location
- document the updated default paths for reports in the README and usage guide

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca9e78f46483269edebfa7f38dfded