### PR TITLE
Ensure CLI defaults to English translations

### DIFF
--- a/tests/test_localization.py
+++ b/tests/test_localization.py
@@ -32,9 +32,9 @@ def test_get_translator_uses_english_by_default(
     translator = localization.get_translator()
     assert captured
     assert captured["domain"] == localization.DOMAIN
-    assert captured["fallback"] is True
+    assert captured["fallback"] is False
     languages = cast(list[str], captured["languages"])
-    assert "en" in languages
+    assert languages == ["en"]
     assert translator.gettext("Sample message") == "Sample message"
 
     localization.clear_translation_cache()


### PR DESCRIPTION
## Summary
- ensure the CLI localization loader does not fall back to non-English translations when no locale is specified
- adjust the localization unit test to reflect the updated translator loading logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caa38b9c6c8326b1059a7735cb4c76