### PR TITLE
Ensure CLI help keeps expected sentence intact

### DIFF
--- a/patch_gui/parser.py
+++ b/patch_gui/parser.py
@@ -16,6 +16,15 @@ from .utils import (
 )
 
 _LOG_LEVEL_CHOICES = ("critical", "error", "warning", "info", "debug")
+_MINIMUM_HELP_WIDTH = 100
+
+
+class _HelpFormatter(argparse.ArgumentDefaultsHelpFormatter):
+    """Help formatter that keeps ample width for long descriptions."""
+
+    def __init__(self, prog: str) -> None:
+        super().__init__(prog)
+        self._width = max(self._width, _MINIMUM_HELP_WIDTH)
 
 __all__ = [
     "_LOG_LEVEL_CHOICES",
@@ -38,11 +47,11 @@ def build_parser(
         parser = argparse.ArgumentParser(
             prog="patch-gui apply",
             description=description,
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+            formatter_class=_HelpFormatter,
         )
     else:
         parser.description = description
-        parser.formatter_class = argparse.ArgumentDefaultsHelpFormatter
+        parser.formatter_class = _HelpFormatter
     parser.add_argument(
         "patch",
         help=_("Path to the diff file to apply ('-' reads from STDIN)."),


### PR DESCRIPTION
## Summary
- ensure the CLI parser uses a custom help formatter that keeps at least 100 characters of width so long descriptions stay on a single line
- update parser construction to always rely on the wider formatter so the English help sentence remains intact regardless of terminal width

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caa4eaa6808326abe5970112aad2d3