### PR TITLE
Support home shortcuts when loading patches

### DIFF
--- a/patch_gui/executor.py
+++ b/patch_gui/executor.py
@@ -69,7 +69,7 @@ def load_patch(source: str, encoding: str | None = None) -> PatchSet:
         else:
             text = sys.stdin.read()
     else:
-        path = Path(source)
+        path = Path(source).expanduser()
         if not path.exists():
             raise CLIError(_("Diff file not found: {path}").format(path=path))
         if encoding:


### PR DESCRIPTION
## Summary
- expand diff path resolution in `load_patch` to honor home directory shortcuts
- add a CLI test that monkeypatches home expansion and verifies `~` patch loading

## Testing
- pytest tests/test_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68caa5c82064832691a09d3666925451