### PR TITLE
Improve backup timestamp resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ patch-gui apply --root . --non-interactive diff.patch
 - `--dry-run` simula l'applicazione lasciando i file invariati; i report vengono generati a meno di `--no-report`.
 - `--threshold` imposta la soglia fuzzy (default 0.85).
 - `--backup` permette di scegliere la cartella base (default `~/.diff_backups`).
-- `--report-json` / `--report-txt` impostano i percorsi dei report generati (default `~/.diff_backups/reports/results/<timestamp>/apply-report.json|.txt`).
+- `--report-json` / `--report-txt` impostano i percorsi dei report generati (default `~/.diff_backups/reports/results/<timestamp-ms>/apply-report.json|.txt`, dove `<timestamp-ms>` segue il formato `YYYYMMDD-HHMMSS-fff`).
 - `--no-report` disattiva entrambi i file di report.
 - `--non-interactive` mantiene il comportamento storico: se il percorso è ambiguo il file viene saltato senza prompt.
 - `--log-level` imposta la verbosità del logger (`debug`, `info`, `warning`, `error`, `critical`; default `warning`). La variabile `PATCH_GUI_LOG_LEVEL` fornisce lo stesso controllo.
@@ -194,7 +194,7 @@ pre-commit run --all-files
 6. **Avanzamento**: la barra di stato mostra il progresso in tempo reale.
 7. **Ambiguità**: se sono trovate più posizioni plausibili, appare un dialog con tutte le opzioni e relativo contesto.
 8. **File mancanti**: se non trovati sotto la root, vengono saltati (come da preferenza).
-9. **Backup & report**: ogni run reale crea `~/.diff_backups/<timestamp>/` con copie originali (a meno di specificare `--backup`) e genera `apply-report.json` e `apply-report.txt`. Anche in dry‑run, se i report non sono disattivati, vengono creati (senza backup) per documentare la simulazione.
+9. **Backup & report**: ogni run reale crea `~/.diff_backups/<timestamp-ms>/` con copie originali (a meno di specificare `--backup`) e genera `apply-report.json` e `apply-report.txt`. Il suffisso `<timestamp-ms>` include millisecondi (`YYYYMMDD-HHMMSS-fff`) per rendere univoca ogni esecuzione. Anche in dry‑run, se i report non sono disattivati, vengono creati (senza backup) per documentare la simulazione.
 10. **Ripristino**: usa **Ripristina da backup…**, scegli il timestamp e i file verranno ripristinati.
 
 Per una guida dettagliata con screenshot e flussi completi consulta [USAGE.md](USAGE.md).
@@ -303,7 +303,7 @@ Aggiungi l'italiano e alcune parole tecniche:
 
 ```text
 ~/.diff_backups/
-  2025YYYYMMDD-HHMMSS/
+  2025YYYYMMDD-HHMMSS-fff/
     path/del/file/originale.ext
   reports/
     results/

--- a/USAGE.md
+++ b/USAGE.md
@@ -41,8 +41,8 @@ Questa guida passo‑passo descrive il workflow tipico per applicare una patch c
    - Se la patch può essere applicata in più punti plausibili, viene aperto un dialog che mostra tutte le opzioni con il relativo contesto.
    - Scegli manualmente il posizionamento corretto.
 7. **Consulta backup e report**
-   - Ogni esecuzione reale crea una cartella `~/.diff_backups/<timestamp>/` con copie dei file originali (a meno di impostare un percorso diverso con `--backup`).
-   - I report `apply-report.json` e `apply-report.txt` vengono salvati in `~/.diff_backups/reports/results/<timestamp>/`
+   - Ogni esecuzione reale crea una cartella `~/.diff_backups/<timestamp-ms>/` con copie dei file originali (a meno di impostare un percorso diverso con `--backup`). Il suffisso `<timestamp-ms>` usa il formato `YYYYMMDD-HHMMSS-fff`, includendo i millisecondi per evitare collisioni.
+   - I report `apply-report.json` e `apply-report.txt` vengono salvati in `~/.diff_backups/reports/results/<timestamp-ms>/`
      (anche in dry‑run, se non disattivati) per documentare l'esito della simulazione.
 8. **Ripristina da backup**
    - Usa il pulsante **Ripristina da backup…** e seleziona il timestamp desiderato per ripristinare i file originali.

--- a/patch_gui/app.py
+++ b/patch_gui/app.py
@@ -934,14 +934,19 @@ class MainWindow(_QMainWindowBase):
         thr = float(self.spin_thresh.value())
         excludes = self._current_exclude_dirs()
         self.exclude_dirs = excludes
-        backup_dir = prepare_backup_dir(self.project_root, dry_run=dry)
+        started_at = time.time()
+        backup_dir = prepare_backup_dir(
+            self.project_root,
+            dry_run=dry,
+            started_at=started_at,
+        )
         session = ApplySession(
             project_root=self.project_root,
             backup_dir=backup_dir,
             dry_run=dry,
             threshold=thr,
             exclude_dirs=excludes,
-            started_at=time.time(),
+            started_at=started_at,
         )
         worker = PatchApplyWorker(self.patch, session)
         worker.progress.connect(self._on_worker_progress)

--- a/patch_gui/executor.py
+++ b/patch_gui/executor.py
@@ -138,7 +138,13 @@ def apply_patchset(
     if not root.exists() or not root.is_dir():
         raise CLIError(_("Invalid project root: {path}").format(path=project_root))
 
-    backup_dir = prepare_backup_dir(root, dry_run=dry_run, backup_base=backup_base)
+    started_at = time.time()
+    backup_dir = prepare_backup_dir(
+        root,
+        dry_run=dry_run,
+        backup_base=backup_base,
+        started_at=started_at,
+    )
     resolved_excludes = (
         tuple(exclude_dirs) if exclude_dirs is not None else DEFAULT_EXCLUDE_DIRS
     )
@@ -149,7 +155,7 @@ def apply_patchset(
         dry_run=dry_run,
         threshold=threshold,
         exclude_dirs=resolved_excludes,
-        started_at=time.time(),
+        started_at=started_at,
     )
 
     for pf in patch:

--- a/patch_gui/patcher.py
+++ b/patch_gui/patcher.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import shutil
+import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from difflib import SequenceMatcher
@@ -27,6 +28,7 @@ from .utils import (
     REPORT_TXT,
     default_backup_base,
     default_session_report_dir,
+    format_session_timestamp,
 )
 
 
@@ -587,13 +589,21 @@ def prepare_backup_dir(
     *,
     dry_run: bool,
     backup_base: Optional[Path] = None,
+    started_at: Optional[float] = None,
 ) -> Path:
-    """Return a timestamped backup directory for the session."""
+    """Return a timestamped backup directory for the session.
+
+    When ``started_at`` is provided the directory will match the session timestamp.
+    Otherwise the current time is used with millisecond precision to avoid
+    collisions between multiple runs that start within the same second.
+    """
 
     base = (
         backup_base.expanduser() if backup_base is not None else default_backup_base()
     )
-    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    timestamp = format_session_timestamp(
+        started_at if started_at is not None else time.time()
+    )
     backup_dir = base / timestamp
     if not dry_run:
         backup_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,12 @@ from patch_gui import cli, localization
 import patch_gui.executor as executor
 import patch_gui.utils as utils
 import patch_gui.parser as parser
-from patch_gui.utils import BACKUP_DIR, REPORT_JSON, REPORT_TXT
+from patch_gui.utils import (
+    BACKUP_DIR,
+    REPORT_JSON,
+    REPORT_TXT,
+    format_session_timestamp,
+)
 
 SAMPLE_DIFF = """--- a/sample.txt
 +++ b/sample.txt
@@ -85,6 +90,7 @@ def test_apply_patchset_dry_run(tmp_path: Path) -> None:
     assert target.read_text(encoding="utf-8") == "old line\nline2\n"
     assert session.dry_run is True
     assert session.backup_dir.parent == utils.default_backup_base()
+    assert session.backup_dir.name == format_session_timestamp(session.started_at)
     assert not session.backup_dir.exists()
     assert session.report_json_path is not None
     assert session.report_txt_path is not None
@@ -134,6 +140,7 @@ def test_apply_patchset_real_run_creates_backup(tmp_path: Path) -> None:
     assert target.read_text(encoding="utf-8") == "new line\nline2\n"
     assert session.backup_dir.parent.name == BACKUP_DIR
     assert session.backup_dir.parent == utils.default_backup_base()
+    assert session.backup_dir.name == format_session_timestamp(session.started_at)
     assert session.backup_dir.exists()
 
     backup_copy = session.backup_dir / "sample.txt"


### PR DESCRIPTION
## Summary
- ensure backup directories use millisecond-resolution timestamps derived from the session start time
- update session creation to share the computed timestamp with backup preparation
- refresh tests and documentation to reflect the new timestamp format

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caa5bbc2108326ae19eba540ca8f1e