### PR TITLE
Add CLI flag to disable default exclude directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ patch-gui apply --root . --non-interactive diff.patch
 - `--backup` permette di scegliere la cartella base (default `~/.diff_backups`).
 - `--report-json` / `--report-txt` impostano i percorsi dei report generati (default `~/.diff_backups/reports/results/<timestamp>/apply-report.json|.txt`).
 - `--no-report` disattiva entrambi i file di report.
+- `--exclude-dir NAME` permette di aggiungere directory personalizzate all'elenco di esclusione (puoi passare l'opzione più volte o separare i valori con virgole).
+- `--no-default-exclude` disabilita la lista predefinita di esclusioni (es. `.git`, `.venv`, `node_modules`, `.diff_backups`) così da poter patchare anche file normalmente ignorati.
 - `--non-interactive` mantiene il comportamento storico: se il percorso è ambiguo il file viene saltato senza prompt.
 - `--log-level` imposta la verbosità del logger (`debug`, `info`, `warning`, `error`, `critical`; default `warning`). La variabile `PATCH_GUI_LOG_LEVEL` fornisce lo stesso controllo.
 - L'uscita termina con codice `0` solo se tutti gli hunk vengono applicati.

--- a/USAGE.md
+++ b/USAGE.md
@@ -54,3 +54,16 @@ Questa guida passo‑passo descrive il workflow tipico per applicare una patch c
 - Per diff molto grandi l'analisi può richiedere tempo; attendi il completamento prima di chiudere la finestra.
 
 Per una panoramica delle opzioni tecniche e delle dipendenze consulta il [README](README.md).
+
+## Suggerimento CLI: includere directory normalmente escluse
+
+Quando usi la modalità `patch-gui apply`, per impostazione predefinita vengono ignorate directory come `.git`, `.venv`, `node_modules` e `.diff_backups`. Se devi patchare file posizionati lì dentro:
+
+- aggiungi `--no-default-exclude` per disabilitare la lista automatica di esclusioni;
+- opzionalmente specifica `--exclude-dir` più volte (o con valori separati da virgole) per costruire un elenco personalizzato di directory da ignorare.
+
+Esempio:
+
+```bash
+patch-gui apply --root . --no-default-exclude fix.diff
+```

--- a/patch_gui/cli.py
+++ b/patch_gui/cli.py
@@ -52,7 +52,9 @@ def run_cli(argv: Sequence[str] | None = None) -> int:
             if isinstance(raw_backup, str) and raw_backup
             else None
         )
-        exclude_dirs = parse_exclude_dirs(args.exclude_dirs)
+        exclude_dirs = parse_exclude_dirs(
+            args.exclude_dirs, ignore_default=args.no_default_exclude
+        )
         session = apply_patchset(
             patch,
             Path(args.root),

--- a/patch_gui/parser.py
+++ b/patch_gui/parser.py
@@ -120,6 +120,15 @@ def build_parser(
         )
         % ", ".join(DEFAULT_EXCLUDE_DIRS),
     )
+    parser.add_argument(
+        "--no-default-exclude",
+        action="store_true",
+        help=_(
+            "Do not ignore the default directories (e.g. %s). Use together with "
+            "--exclude-dir to specify an explicit allowlist."
+        )
+        % ", ".join(DEFAULT_EXCLUDE_DIRS),
+    )
     return parser
 
 
@@ -139,9 +148,13 @@ def threshold_value(value: str) -> float:
     return parsed
 
 
-def parse_exclude_dirs(values: Sequence[str] | None) -> tuple[str, ...]:
+def parse_exclude_dirs(
+    values: Sequence[str] | None,
+    *,
+    ignore_default: bool = False,
+) -> tuple[str, ...]:
     if not values:
-        return DEFAULT_EXCLUDE_DIRS
+        return tuple() if ignore_default else DEFAULT_EXCLUDE_DIRS
     parsed: List[str] = []
     for raw in values:
         for item in raw.split(","):
@@ -149,6 +162,6 @@ def parse_exclude_dirs(values: Sequence[str] | None) -> tuple[str, ...]:
             if normalized:
                 parsed.append(normalized)
     if not parsed:
-        return DEFAULT_EXCLUDE_DIRS
+        return tuple() if ignore_default else DEFAULT_EXCLUDE_DIRS
     # Remove duplicates preserving order
     return tuple(dict.fromkeys(parsed))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -429,6 +429,39 @@ def test_run_cli_rejects_report_conflicts(
     assert "--no-report" in message or "no-report" in message
 
 
+def test_run_cli_can_include_default_excludes(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    venv_dir = project / ".venv"
+    venv_dir.mkdir()
+    target = venv_dir / "module.py"
+    target.write_text("old_value = 1\n", encoding="utf-8")
+
+    patch_text = """--- a/.venv/module.py
++++ b/.venv/module.py
+@@ -1 +1 @@
+-old_value = 1
++old_value = 2
+"""
+    patch_path = tmp_path / "inside-venv.diff"
+    patch_path.write_text(patch_text, encoding="utf-8")
+
+    exit_code = cli.run_cli(
+        [
+            "--root",
+            str(project),
+            "--backup",
+            str(tmp_path / "backups"),
+            "--no-report",
+            "--no-default-exclude",
+            str(patch_path),
+        ]
+    )
+
+    assert exit_code == 0
+    assert target.read_text(encoding="utf-8") == "old_value = 2\n"
+
+
 def test_apply_patchset_logs_warning_on_fallback(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:


### PR DESCRIPTION
## Summary
- add the --no-default-exclude option to the CLI parser and plumb it to the patch executor
- document how to customise the exclude list in the README and USAGE guides
- extend the CLI test suite with coverage for patching files below .venv when defaults are disabled

## Testing
- pytest tests/test_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68caa5ddf81c8326bf799382d49972cb