### PR TITLE
Handle added files when applying patches

### DIFF
--- a/patch_gui/executor.py
+++ b/patch_gui/executor.py
@@ -21,7 +21,6 @@ from .patcher import (
     DEFAULT_EXCLUDE_DIRS,
     apply_hunks,
     backup_file,
-    build_hunk_view,
     find_file_candidates,
     prepare_backup_dir,
 )
@@ -281,23 +280,12 @@ def _apply_file_patch(
     if not session.dry_run and not is_new_file:
         backup_file(project_root, path, session.backup_dir)
 
-    if is_new_file:
-        decisions: List[HunkDecision] = []
-        new_lines: List[str] = []
-        for hunk in pf:
-            hv = build_hunk_view(hunk)
-            new_lines.extend(hv.after_lines)
-            decision = HunkDecision(hunk_header=hv.header, strategy="new-file", selected_pos=0)
-            decisions.append(decision)
-        lines = new_lines
-        applied = len(decisions)
-    else:
-        lines, decisions, applied = apply_hunks(
-            lines,
-            pf,
-            threshold=session.threshold,
-            manual_resolver=_cli_manual_resolver,
-        )
+    lines, decisions, applied = apply_hunks(
+        lines,
+        pf,
+        threshold=session.threshold,
+        manual_resolver=_cli_manual_resolver,
+    )
 
     fr.hunks_applied = applied
     fr.decisions.extend(decisions)

--- a/patch_gui/patcher.py
+++ b/patch_gui/patcher.py
@@ -392,6 +392,21 @@ def apply_hunks(
         decision = HunkDecision(hunk_header=hv.header, strategy="")
         logger.debug("Processo hunk: %s", hv.header)
 
+        if not current_lines and not hv.before_lines:
+            logger.debug("File vuoto: applico l'hunk %s come nuova creazione", hv.header)
+            current_lines, success = _apply(
+                current_lines,
+                hv,
+                decision,
+                0,
+                None,
+                "new-file",
+            )
+            if success:
+                applied_count += 1
+            decisions.append(decision)
+            continue
+
         exact_candidates = find_candidates(
             current_lines, hv.before_lines, threshold=1.0
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -194,6 +194,36 @@ def test_apply_patchset_dry_run_adds_new_file(tmp_path: Path) -> None:
     assert file_result.file_path == target
     assert file_result.hunks_applied == file_result.hunks_total == 1
     assert file_result.file_type == "text"
+    assert len(file_result.decisions) == 1
+    assert file_result.decisions[0].strategy == "new-file"
+    assert file_result.decisions[0].selected_pos == 0
+
+
+def test_apply_patchset_real_run_adds_new_file(tmp_path: Path) -> None:
+    project = _create_project(tmp_path)
+
+    session = cli.apply_patchset(
+        PatchSet(ADDED_DIFF),
+        project,
+        dry_run=False,
+        threshold=0.85,
+    )
+
+    target = project / "docs" / "newfile.txt"
+    assert target.exists()
+    assert target.read_text(encoding="utf-8") == "first line\nsecond line\n"
+    assert session.backup_dir.exists()
+    assert not any(session.backup_dir.iterdir())
+    assert len(session.results) == 1
+
+    file_result = session.results[0]
+    assert file_result.skipped_reason is None
+    assert file_result.relative_to_root == "docs/newfile.txt"
+    assert file_result.file_path == target
+    assert file_result.hunks_applied == file_result.hunks_total == 1
+    assert file_result.file_type == "text"
+    assert len(file_result.decisions) == 1
+    assert file_result.decisions[0].strategy == "new-file"
 
 
 def test_apply_patchset_custom_report_paths(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- ensure added files reported in diffs are treated as valid targets even when no candidates are found
- reuse the standard hunk application pipeline for new files so their content is produced consistently
- cover the new-file scenario in CLI tests for both dry-run and real execution

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caa9a5953c8326b8a6347a43e58ac5