### PR TITLE
Add CLI version flag and expose package version

### DIFF
--- a/patch_gui/__init__.py
+++ b/patch_gui/__init__.py
@@ -4,9 +4,17 @@ from __future__ import annotations
 
 from typing import Sequence
 
+from . import _version
+
 __all__ = ["main", "__version__"]
 
-__version__ = "0.1.0"
+__version__ = _version.__version__
+
+
+def __getattr__(name: str):
+    if name == "__version__":
+        return _version.__version__
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/patch_gui/_version.py
+++ b/patch_gui/_version.py
@@ -1,0 +1,14 @@
+"""Central place to store the package version."""
+
+from __future__ import annotations
+
+import sys
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"
+
+_PACKAGE_NAME = __name__.rsplit(".", 1)[0]
+_parent = sys.modules.get(_PACKAGE_NAME)
+if _parent is not None:
+    setattr(_parent, "__version__", __version__)

--- a/patch_gui/parser.py
+++ b/patch_gui/parser.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 from typing import List, Optional, Sequence
 
+from ._version import __version__
 from .localization import gettext as _
 from .patcher import DEFAULT_EXCLUDE_DIRS
 from .utils import (
@@ -53,6 +54,12 @@ def build_parser(
     else:
         parser.description = description
         parser.formatter_class = _HelpFormatter
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=__version__,
+        help=_("Show the version number and exit."),
+    )
     parser.add_argument(
         "patch",
         help=_("Path to the diff file to apply ('-' reads from STDIN)."),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,7 @@ from unidiff import PatchSet
 
 from tests._pytest_typing import typed_parametrize
 
+import patch_gui
 from patch_gui import cli, localization
 import patch_gui.executor as executor
 import patch_gui.utils as utils
@@ -84,6 +85,18 @@ def test_parser_help_uses_english_by_default(monkeypatch: pytest.MonkeyPatch) ->
         "Directory (relative to the root) to ignore while searching for files."
         in help_text
     )
+
+
+def test_parser_version_reports_package_version(capsys: pytest.CaptureFixture[str]) -> None:
+    parser_obj = parser.build_parser()
+
+    with pytest.raises(SystemExit) as excinfo:
+        parser_obj.parse_args(["--version"])
+
+    assert excinfo.value.code == 0
+    captured = capsys.readouterr()
+    assert captured.out.strip() == patch_gui.__version__
+    assert captured.err == ""
 
 
 def test_apply_patchset_dry_run(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a --version flag to the CLI parser that reports the package version
- centralize the __version__ constant in a dedicated module and re-export it from the package
- ensure CLI tests cover the new version flag output

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caaa5ccccc8326949601da6cd8cfd9