### PR TITLE
Align minimum Python version to 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ Esegui la suite automatizzata con:
 pytest
 ```
 
+> La suite viene verificata con Python 3.10+, in linea con il requisito minimo del progetto.
+
 ## 🧹 Pre-commit
 
 Per avere formattazione automatica (**Black**), linting (**Ruff**), type checking (**mypy**) e test rapidi (**pytest --quiet**):
@@ -353,6 +355,12 @@ Versioni verificate:
 6. **Documenta il cambiamento** aggiornando questa sezione con versioni e test.
 
 7. Quando hai finito, `deactivate` e rimuovi la virtualenv temporanea.
+
+---
+
+## 🧾 Release notes
+
+- **0.1.0** – Allineati i requisiti minimi di Python alla versione 3.10 sia nella configurazione del progetto sia nella documentazione.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "patch-gui"
 version = "0.1.0"
 description = "PySide6 desktop application for applying unified diffs interactively."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "charset-normalizer>=3.3.2",
     "unidiff",
@@ -36,7 +36,7 @@ build_py = "build_translations.BuildPy"
 sdist = "build_translations.SDist"
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 strict = true
 files = ["patch_gui", "tests"]
 


### PR DESCRIPTION
## Summary
- raise the declared minimum Python requirement to 3.10 in the project metadata and mypy configuration
- document the Python 3.10 requirement in the README test instructions and add a release note entry for the change

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caaa5fc38483269e34aa1ff8ddc9b7