### PR TITLE
Handle empty-context hunks using metadata

### DIFF
--- a/patch_gui/patcher.py
+++ b/patch_gui/patcher.py
@@ -499,6 +499,32 @@ def apply_hunks(
             decisions.append(decision)
             continue
 
+        if not hv.before_lines and not context_candidates:
+            fallback_pos: Optional[int] = None
+            target_start = getattr(hunk, "target_start", None)
+            source_start = getattr(hunk, "source_start", None)
+            if isinstance(target_start, int):
+                fallback_pos = max(0, min(len(current_lines), target_start - 1))
+            elif isinstance(source_start, int):
+                fallback_pos = max(0, min(len(current_lines), source_start - 1))
+            if fallback_pos is not None:
+                logger.debug(
+                    "Uso metadati del hunk per determinare la posizione di inserimento: %d",
+                    fallback_pos,
+                )
+                current_lines, success = _apply(
+                    current_lines,
+                    hv,
+                    decision,
+                    fallback_pos,
+                    None,
+                    "metadata",
+                )
+                if success:
+                    applied_count += 1
+                decisions.append(decision)
+                continue
+
         decision.strategy = "failed"
         if not decision.message:
             decision.message = (

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -138,6 +138,27 @@ def test_apply_hunks_context_fallback_uses_context_lines() -> None:
     assert decisions[0].message == "context review"
 
 
+def test_apply_hunks_metadata_fallback_for_insertions_without_context() -> None:
+    diff = """--- a/sample.txt
++++ b/sample.txt
+@@ -0,0 +1,2 @@
++first line
++second line
+"""
+    patch = PatchSet(diff)
+    pf = patch[0]
+    file_lines = ["original\n"]
+
+    new_lines, decisions, applied = apply_hunks(
+        file_lines, pf, threshold=0.5, manual_resolver=None
+    )
+
+    assert applied == 1
+    assert new_lines == ["first line\n", "second line\n", "original\n"]
+    assert decisions[0].strategy == "metadata"
+    assert decisions[0].selected_pos == 0
+
+
 def test_find_file_candidates_handles_prefix_and_suffix(tmp_path: Path) -> None:
     project_root = tmp_path
     target = project_root / "src" / "pkg"


### PR DESCRIPTION
## Summary
- fall back to hunk metadata when no context candidates are available for insert-only hunks
- add regression coverage for metadata fallback in patch application logic
- ensure CLI dry-run and real runs can patch existing empty files with @@ -0,0 +1,n @@ diffs

## Testing
- pytest tests/test_patcher.py tests/test_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68caaf202b508326b0411e65e0e0018e