### PR TITLE
Fix load_patch path handling and clean up tests

### DIFF
--- a/patch_gui/__init__.py
+++ b/patch_gui/__init__.py
@@ -11,7 +11,7 @@ __all__ = ["main", "__version__"]
 __version__ = _version.__version__
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> str:
     if name == "__version__":
         return _version.__version__
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary
- add a return type annotation for `__getattr__` in the package init to satisfy mypy
- update `load_patch` to rely on `os.path.expanduser` and export `sys` so tests can patch stdin
- collapse the duplicate real-run test while keeping its assertions about backups

## Testing
- python -m black patch_gui/executor.py tests/test_cli.py
- python -m ruff check patch_gui/__init__.py patch_gui/executor.py tests/test_cli.py
- python -m mypy patch_gui/__init__.py patch_gui/executor.py tests/test_cli.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cab66b09f48326bfdd8af6caeb55cb