### PR TITLE
Add CLI config subcommand support

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -67,3 +67,13 @@ Esempio:
 ```bash
 patch-gui apply --root . --no-default-exclude fix.diff
 ```
+
+## Gestione della configurazione via CLI
+
+Oltre a usare la GUI, puoi ispezionare e modificare le impostazioni persistenti tramite il sottocomando `patch-gui config`:
+
+- `patch-gui config show` stampa la configurazione corrente in formato JSON;
+- `patch-gui config set <chiave> <valori…>` aggiorna un parametro (ad esempio `threshold`, `exclude_dirs`, `backup_base`, `log_level`);
+- `patch-gui config reset [chiave]` ripristina un singolo valore o l'intera configurazione ai default.
+
+Se vuoi operare su un file alternativo (per test o ambienti portabili) aggiungi `--config-path /percorso/custom/settings.toml` dopo il nome del sottocomando.

--- a/patch_gui/diff_applier_gui.py
+++ b/patch_gui/diff_applier_gui.py
@@ -58,6 +58,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args[0] == "apply":
         return cli.run_cli(args[1:])
 
+    if args[0] == "config":
+        return cli.run_config(args[1:])
+
     if any(opt in {"-h", "--help"} for opt in args):
         _print_help()
         return 0
@@ -120,12 +123,14 @@ def _print_help() -> None:
     parser.add_argument(
         "command",
         nargs="?",
-        choices=["gui", "apply"],
+        choices=["gui", "apply", "config"],
         help=_tr("Command to execute (default: gui)."),
     )
     parser.print_help()
     print(_tr("\nCLI options:"), file=sys.stdout)
     cli.build_parser().print_help()
+    print(_tr("\nConfiguration commands:"), file=sys.stdout)
+    cli.build_config_parser().print_help()
 
 
 def _ensure_translator() -> None:

--- a/tests/test_diff_applier_gui.py
+++ b/tests/test_diff_applier_gui.py
@@ -10,6 +10,7 @@ from tests._pytest_typing import typed_parametrize
 
 GUI_RESULT = 42
 CLI_RESULT = 17
+CONFIG_RESULT = 7
 
 
 @typed_parametrize(
@@ -17,6 +18,7 @@ CLI_RESULT = 17
     [
         ([], [("gui", ())], GUI_RESULT),
         (["apply", "patch.diff"], [("cli", ["patch.diff"])], CLI_RESULT),
+        (["config", "show"], [("config", ["show"])], CONFIG_RESULT),
         (
             ["--root", ".", "patch.diff"],
             [("cli", ["--root", ".", "patch.diff"])],
@@ -87,12 +89,17 @@ def test_main_dispatches_between_gui_and_cli(
         calls.append(("cli", args))
         return CLI_RESULT
 
+    def fake_run_config(args: list[str]) -> int:
+        calls.append(("config", args))
+        return CONFIG_RESULT
+
     def fake_launch_gui() -> int:
         calls.append(("gui", ()))
         return GUI_RESULT
 
     module_cli = cast(Any, diff_applier_gui).cli
     monkeypatch.setattr(module_cli, "run_cli", fake_run_cli)
+    monkeypatch.setattr(module_cli, "run_config", fake_run_config)
     monkeypatch.setattr(diff_applier_gui, "_launch_gui", fake_launch_gui)
 
     result = diff_applier_gui.main(argv)


### PR DESCRIPTION
## Summary
- add a `patch-gui config` subcommand with helpers to show, set, and reset saved options
- update the launcher help output and usage docs to describe the new configuration commands
- cover the new functionality with unit tests for the dispatcher and CLI helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cac041e630832689d22db2b4771f25