### PR TITLE
Add configurable settings dialog and persistence

### DIFF
--- a/patch_gui/locale/it/LC_MESSAGES/patch_gui.po
+++ b/patch_gui/locale/it/LC_MESSAGES/patch_gui.po
@@ -24,6 +24,80 @@ msgid ""
 "but from the command line."
 msgstr ""
 
+#: patch_gui/app.py:437 patch_gui/app.py:755
+msgid "Impostazioni"
+msgstr "Impostazioni"
+
+#: patch_gui/app.py:756
+msgid "Preferenze…"
+msgstr "Preferenze…"
+
+#: patch_gui/app.py:452
+msgid "Soglia fuzzy"
+msgstr "Soglia fuzzy"
+
+#: patch_gui/app.py:458
+msgid "Directory escluse (separate da virgola)"
+msgstr "Directory escluse (separate da virgola)"
+
+#: patch_gui/app.py:460
+msgid "Directory escluse"
+msgstr "Directory escluse"
+
+#: patch_gui/app.py:466
+msgid "Percorso base per i backup"
+msgstr "Percorso base per i backup"
+
+#: patch_gui/app.py:471
+msgid "Sfoglia…"
+msgstr "Sfoglia…"
+
+#: patch_gui/app.py:476
+msgid "Directory backup"
+msgstr "Directory backup"
+
+#: patch_gui/app.py:484
+msgid "Livello log"
+msgstr "Livello log"
+
+#: patch_gui/app.py:487
+msgid "Esegui sempre in dry-run inizialmente"
+msgstr "Esegui sempre in dry-run inizialmente"
+
+#: patch_gui/app.py:493
+msgid "Genera report al termine (JSON + testo)"
+msgstr "Genera report al termine (JSON + testo)"
+
+#: patch_gui/app.py:509
+msgid "Seleziona directory di backup"
+msgstr "Seleziona directory di backup"
+
+#: patch_gui/app.py:947
+msgid "Impostazioni salvate"
+msgstr "Impostazioni salvate"
+
+#: patch_gui/app.py:1173
+msgid "Operazione terminata. Vedi log e report nella cartella di backup."
+msgstr "Operazione terminata. Vedi log e report nella cartella di backup."
+
+#: patch_gui/app.py:1177
+msgid "Operazione terminata. Report disabilitati nelle impostazioni."
+msgstr "Operazione terminata. Report disabilitati nelle impostazioni."
+
+#: patch_gui/app.py:1184
+msgid "Operazione completata"
+msgstr "Operazione completata"
+
+#: patch_gui/cli.py:327
+#, python-brace-format
+msgid "The {key} key expects exactly one value."
+msgstr "La chiave {key} richiede esattamente un valore."
+
+#: patch_gui/cli.py:346
+#, python-brace-format
+msgid "Unsupported boolean value: {value}."
+msgstr "Valore booleano non supportato: {value}."
+
 #: patch_gui/parser.py:48
 msgid "Path to the diff file to apply ('-' reads from STDIN)."
 msgstr ""

--- a/patch_gui/locale/patch_gui.pot
+++ b/patch_gui/locale/patch_gui.pot
@@ -24,6 +24,80 @@ msgid ""
 "but from the command line."
 msgstr ""
 
+#: patch_gui/app.py:437 patch_gui/app.py:755
+msgid "Impostazioni"
+msgstr ""
+
+#: patch_gui/app.py:756
+msgid "Preferenze…"
+msgstr ""
+
+#: patch_gui/app.py:452
+msgid "Soglia fuzzy"
+msgstr ""
+
+#: patch_gui/app.py:458
+msgid "Directory escluse (separate da virgola)"
+msgstr ""
+
+#: patch_gui/app.py:460
+msgid "Directory escluse"
+msgstr ""
+
+#: patch_gui/app.py:466
+msgid "Percorso base per i backup"
+msgstr ""
+
+#: patch_gui/app.py:471
+msgid "Sfoglia…"
+msgstr ""
+
+#: patch_gui/app.py:476
+msgid "Directory backup"
+msgstr ""
+
+#: patch_gui/app.py:484
+msgid "Livello log"
+msgstr ""
+
+#: patch_gui/app.py:487
+msgid "Esegui sempre in dry-run inizialmente"
+msgstr ""
+
+#: patch_gui/app.py:493
+msgid "Genera report al termine (JSON + testo)"
+msgstr ""
+
+#: patch_gui/app.py:509
+msgid "Seleziona directory di backup"
+msgstr ""
+
+#: patch_gui/app.py:947
+msgid "Impostazioni salvate"
+msgstr ""
+
+#: patch_gui/app.py:1173
+msgid "Operazione terminata. Vedi log e report nella cartella di backup."
+msgstr ""
+
+#: patch_gui/app.py:1177
+msgid "Operazione terminata. Report disabilitati nelle impostazioni."
+msgstr ""
+
+#: patch_gui/app.py:1184
+msgid "Operazione completata"
+msgstr ""
+
+#: patch_gui/cli.py:327
+#, python-brace-format
+msgid "The {key} key expects exactly one value."
+msgstr ""
+
+#: patch_gui/cli.py:346
+#, python-brace-format
+msgid "Unsupported boolean value: {value}."
+msgstr ""
+
 #: patch_gui/parser.py:48
 msgid "Path to the diff file to apply ('-' reads from STDIN)."
 msgstr ""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -980,6 +980,22 @@ def test_config_set_updates_values(tmp_path: Path) -> None:
     )
     assert load_config(config_path).backup_base == (tmp_path / "custom").expanduser()
 
+    cli.config_set(
+        "dry_run_default",
+        ["false"],
+        path=config_path,
+        stream=io.StringIO(),
+    )
+    assert load_config(config_path).dry_run_default is False
+
+    cli.config_set(
+        "write_reports",
+        ["no"],
+        path=config_path,
+        stream=io.StringIO(),
+    )
+    assert load_config(config_path).write_reports is False
+
 
 def test_config_reset_values(tmp_path: Path) -> None:
     config_path = tmp_path / "settings.toml"
@@ -1001,6 +1017,8 @@ def test_config_reset_values(tmp_path: Path) -> None:
     assert reset.log_level == defaults.log_level
     assert reset.exclude_dirs == defaults.exclude_dirs
     assert reset.backup_base == defaults.backup_base
+    assert reset.dry_run_default == defaults.dry_run_default
+    assert reset.write_reports == defaults.write_reports
 
 
 def test_run_config_reports_invalid_log_level(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,6 +15,8 @@ def test_load_config_returns_defaults_when_missing(tmp_path: Path) -> None:
     assert loaded.exclude_dirs == defaults.exclude_dirs
     assert loaded.backup_base == defaults.backup_base
     assert loaded.log_level == defaults.log_level
+    assert loaded.dry_run_default == defaults.dry_run_default
+    assert loaded.write_reports == defaults.write_reports
 
 
 def test_save_and_load_roundtrip(tmp_path: Path) -> None:
@@ -26,6 +28,8 @@ def test_save_and_load_roundtrip(tmp_path: Path) -> None:
         exclude_dirs=("one", "two"),
         backup_base=custom_backup,
         log_level="debug",
+        dry_run_default=False,
+        write_reports=False,
     )
 
     save_config(original, path=config_path)
@@ -44,6 +48,8 @@ def test_load_config_invalid_values_fallback(tmp_path: Path) -> None:
                 "exclude_dirs = \"\"",
                 "backup_base = \"   \"",
                 "log_level = 123",
+                "dry_run_default = \"maybe\"",
+                "write_reports = \"sometimes\"",
                 "",
             ]
         ),
@@ -57,6 +63,8 @@ def test_load_config_invalid_values_fallback(tmp_path: Path) -> None:
     assert loaded.exclude_dirs == defaults.exclude_dirs
     assert loaded.backup_base == defaults.backup_base
     assert loaded.log_level == defaults.log_level
+    assert loaded.dry_run_default == defaults.dry_run_default
+    assert loaded.write_reports == defaults.write_reports
 
 
 def test_load_config_accepts_empty_exclude_list(tmp_path: Path) -> None:
@@ -69,6 +77,8 @@ def test_load_config_accepts_empty_exclude_list(tmp_path: Path) -> None:
                 "exclude_dirs = []",
                 "backup_base = \"" + str(tmp_path / "backups") + "\"",
                 "log_level = \"warning\"",
+                "dry_run_default = false",
+                "write_reports = true",
                 "",
             ]
         ),
@@ -81,3 +91,5 @@ def test_load_config_accepts_empty_exclude_list(tmp_path: Path) -> None:
     assert loaded.threshold == pytest.approx(0.85)
     assert loaded.log_level == "warning"
     assert loaded.backup_base == (tmp_path / "backups")
+    assert loaded.dry_run_default is False
+    assert loaded.write_reports is True

--- a/tests/test_diff_applier_gui.py
+++ b/tests/test_diff_applier_gui.py
@@ -1,16 +1,36 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, cast
 
 import pytest
 
 from patch_gui import diff_applier_gui
+from patch_gui.config import AppConfig
 from tests._pytest_typing import typed_parametrize
+
+try:  # pragma: no cover - environment-dependent
+    from PySide6 import QtWidgets  # type: ignore[import-not-found]
+except Exception as exc:  # pragma: no cover - optional dependency
+    QtWidgets = None  # type: ignore[assignment]
+    _QT_IMPORT_ERROR = exc
+else:  # pragma: no cover - exercised when bindings are available
+    _QT_IMPORT_ERROR = None
 
 
 GUI_RESULT = 42
 CLI_RESULT = 17
 CONFIG_RESULT = 7
+
+
+@pytest.fixture()
+def qt_app() -> Any:
+    if QtWidgets is None:
+        pytest.skip(f"PySide6 non disponibile: {_QT_IMPORT_ERROR}")
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    return app
 
 
 @typed_parametrize(
@@ -106,3 +126,106 @@ def test_main_dispatches_between_gui_and_cli(
 
     assert result == expected_result
     assert calls == expected_calls
+
+
+def test_settings_dialog_gathers_config(qt_app: Any, tmp_path: Path) -> None:
+    if QtWidgets is None:
+        pytest.skip(f"PySide6 non disponibile: {_QT_IMPORT_ERROR}")
+
+    from patch_gui import app as app_module
+
+    base = tmp_path / "backups"
+    config = AppConfig(
+        threshold=0.75,
+        exclude_dirs=("build", "dist"),
+        backup_base=base,
+        log_level="warning",
+        dry_run_default=True,
+        write_reports=True,
+    )
+
+    dialog = app_module.SettingsDialog(None, config=config)
+    dialog.threshold_spin.setValue(0.91)
+    dialog.exclude_edit.setText("one, two, two , three")
+    new_backup = tmp_path / "custom"
+    dialog.backup_edit.setText(str(new_backup))
+    index = dialog.log_combo.findData("debug")
+    if index >= 0:
+        dialog.log_combo.setCurrentIndex(index)
+    dialog.dry_run_check.setChecked(False)
+    dialog.reports_check.setChecked(False)
+
+    updated = dialog._gather_config()
+
+    assert updated.threshold == pytest.approx(0.91)
+    assert updated.exclude_dirs == ("one", "two", "three")
+    assert updated.backup_base == new_backup
+    assert updated.log_level == "debug"
+    assert updated.dry_run_default is False
+    assert updated.write_reports is False
+
+
+def test_main_window_applies_settings_dialog(
+    qt_app: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    if QtWidgets is None:
+        pytest.skip(f"PySide6 non disponibile: {_QT_IMPORT_ERROR}")
+
+    from patch_gui import app as app_module
+
+    saved_configs: list[AppConfig] = []
+
+    def fake_save(config: AppConfig, path: Path | None = None) -> Path:
+        saved_configs.append(config)
+        return tmp_path / "settings.toml"
+
+    configured_levels: list[str] = []
+
+    def fake_configure_logging(*, level: str) -> None:
+        configured_levels.append(level)
+
+    monkeypatch.setattr(app_module, "save_config", fake_save)
+    monkeypatch.setattr(app_module, "configure_logging", fake_configure_logging)
+
+    original = AppConfig(
+        threshold=0.8,
+        exclude_dirs=("a",),
+        backup_base=tmp_path / "base",
+        log_level="info",
+        dry_run_default=True,
+        write_reports=True,
+    )
+
+    window = app_module.MainWindow(app_config=original)
+
+    new_config = AppConfig(
+        threshold=0.93,
+        exclude_dirs=("one", "two"),
+        backup_base=tmp_path / "next",
+        log_level="error",
+        dry_run_default=False,
+        write_reports=False,
+    )
+
+    class _FakeDialog:
+        def __init__(self, result: AppConfig) -> None:
+            self.result_config = result
+
+        def exec(self) -> Any:
+            return QtWidgets.QDialog.DialogCode.Accepted
+
+    fake_dialog = _FakeDialog(new_config)
+    monkeypatch.setattr(window, "_create_settings_dialog", lambda: fake_dialog)
+
+    window.open_settings_dialog()
+
+    assert window.app_config == new_config
+    assert window.chk_dry.isChecked() is new_config.dry_run_default
+    assert window.exclude_edit.text() == ", ".join(new_config.exclude_dirs)
+    assert window.reports_enabled is new_config.write_reports
+    assert configured_levels == [new_config.log_level]
+    assert saved_configs[-1] == new_config
+
+    window.close()


### PR DESCRIPTION
## Summary
- add a Settings dialog that loads and saves AppConfig values while updating the GUI widgets immediately
- extend AppConfig and CLI persistence to cover dry-run defaults and report generation settings
- update translations and test coverage for the settings workflow and new configuration options

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cac1ff77d48326b48c951aaae4bb52