### PR TITLE
Ensure QtWidgets is non-null in qt_app fixture

### DIFF
--- a/tests/test_diff_applier_gui.py
+++ b/tests/test_diff_applier_gui.py
@@ -28,9 +28,11 @@ CONFIG_RESULT = 7
 def qt_app() -> Any:
     if QtWidgets is None:
         pytest.skip(f"PySide6 non disponibile: {_QT_IMPORT_ERROR}")
-    app = QtWidgets.QApplication.instance()
+    assert QtWidgets is not None
+    qt_widgets = QtWidgets
+    app = qt_widgets.QApplication.instance()
     if app is None:
-        app = QtWidgets.QApplication([])
+        app = qt_widgets.QApplication([])
     return app
 
 


### PR DESCRIPTION
## Summary
- assert the PySide6 QtWidgets import succeeded before using it in the qt_app fixture
- reuse a non-optional alias so mypy can recognize QApplication access as safe

## Testing
- mypy

------
https://chatgpt.com/codex/tasks/task_e_68cad9987d8c8326941e9f20d3f33f1e