### PR TITLE
Add branded toolbar icons

### DIFF
--- a/images/icons/analyze.svg
+++ b/images/icons/analyze.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <defs>
+    <linearGradient id="playGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#4a7bd6" />
+      <stop offset="1" stop-color="#2f4f9d" />
+    </linearGradient>
+  </defs>
+  <circle cx="12" cy="12" r="9" fill="#1f2b4d"/>
+  <path d="M10.25 8.5v7l5.5-3.5z" fill="url(#playGradient)"/>
+  <path d="M7.5 10.2v3.6" stroke="#4a7bd6" stroke-width="1.4" stroke-linecap="round"/>
+  <path d="M6 12h3" stroke="#4a7bd6" stroke-width="1.4" stroke-linecap="round"/>
+</svg>

--- a/images/icons/choose_root.svg
+++ b/images/icons/choose_root.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <defs>
+    <linearGradient id="folderGradient" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#4a7bd6" />
+      <stop offset="1" stop-color="#3557a1" />
+    </linearGradient>
+  </defs>
+  <path d="M3 6.5a2.5 2.5 0 0 1 2.5-2.5h3l1.5 1.5H19a2 2 0 0 1 2 2V10H3Z" fill="url(#folderGradient)"/>
+  <path d="M3 10h18v7.5A2.5 2.5 0 0 1 18.5 20h-13A2.5 2.5 0 0 1 3 17.5Z" fill="#1f2b4d"/>
+  <path d="m9.4 14.6 1.6 1.6 3.6-3.6" fill="none" stroke="#f2f5ff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8"/>
+</svg>

--- a/images/icons/from_clipboard.svg
+++ b/images/icons/from_clipboard.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect x="6" y="5" width="12" height="15" rx="2" ry="2" fill="#1f2b4d"/>
+  <path d="M15 4h-6a1 1 0 0 0-1 1v1h8V5a1 1 0 0 0-1-1z" fill="#4a7bd6"/>
+  <rect x="9" y="2.5" width="6" height="3" rx="1" ry="1" fill="#92a9f0"/>
+  <path d="m9.2 12.2 2.1 2.2 3.5-3.6" fill="none" stroke="#f2f5ff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6"/>
+</svg>

--- a/images/icons/from_text.svg
+++ b/images/icons/from_text.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <defs>
+    <linearGradient id="textGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#4a7bd6" />
+      <stop offset="1" stop-color="#1f2b4d" />
+    </linearGradient>
+  </defs>
+  <rect x="5" y="3.5" width="14" height="17" rx="2" ry="2" fill="url(#textGradient)"/>
+  <rect x="7.5" y="7" width="9" height="1.6" rx="0.8" fill="#f2f5ff"/>
+  <rect x="7.5" y="10" width="7.5" height="1.6" rx="0.8" fill="#d7e1ff"/>
+  <rect x="7.5" y="13" width="9" height="1.6" rx="0.8" fill="#f2f5ff"/>
+  <path d="M12 17.5h4" stroke="#f2f5ff" stroke-linecap="round" stroke-width="1.6"/>
+</svg>

--- a/images/icons/load_diff.svg
+++ b/images/icons/load_diff.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <circle cx="12" cy="12" r="9" fill="#1f2b4d"/>
+  <path d="M12 6.5v11" stroke="#f2f5ff" stroke-width="1.8" stroke-linecap="round"/>
+  <path d="M7.5 12h9" stroke="#4a7bd6" stroke-width="1.8" stroke-linecap="round"/>
+  <path d="M10.5 9.25 12 11l1.5-1.75" fill="none" stroke="#4a7bd6" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M10.5 14.75 12 13l1.5 1.75" fill="none" stroke="#4a7bd6" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/images/icons/load_file.svg
+++ b/images/icons/load_file.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <defs>
+    <linearGradient id="fileGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#4a7bd6" />
+      <stop offset="1" stop-color="#1f2b4d" />
+    </linearGradient>
+  </defs>
+  <path d="M7 3h6l5 5v11a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z" fill="url(#fileGradient)"/>
+  <path d="M13 3v4a1 1 0 0 0 1 1h4" fill="#92a9f0"/>
+  <path d="M12 11v5.25" stroke="#f2f5ff" stroke-linecap="round" stroke-width="1.8"/>
+  <path d="m9.75 14.5 2.25 2.75 2.25-2.75" fill="none" stroke="#f2f5ff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8"/>
+</svg>

--- a/patch_gui/app.py
+++ b/patch_gui/app.py
@@ -779,11 +779,24 @@ class MainWindow(_QMainWindowBase):
         layout.addSpacing(6)
 
         style = self.style()
+        icons_dir = Path(__file__).resolve().parent.parent / "images" / "icons"
+
+        def load_icon(
+            filename: str,
+            fallback: QtWidgets.QStyle.StandardPixmap,
+        ) -> QtGui.QIcon:
+            icon_path = icons_dir / filename
+            if icon_path.exists():
+                icon = QtGui.QIcon(str(icon_path))
+                if not icon.isNull():
+                    return icon
+            return style.standardIcon(fallback)
 
         self.toolbar = QtWidgets.QToolBar(_("Azioni"))
         self.toolbar.setToolButtonStyle(
             QtCore.Qt.ToolButtonStyle.ToolButtonTextBesideIcon
         )
+        self.toolbar.setIconSize(QtCore.QSize(28, 28))
         self.addToolBar(QtCore.Qt.ToolBarArea.TopToolBarArea, self.toolbar)
 
         self.root_edit = QtWidgets.QLineEdit()
@@ -797,7 +810,7 @@ class MainWindow(_QMainWindowBase):
         self.toolbar.addAction(root_widget_action)
 
         self.action_choose_root = QtGui.QAction(
-            style.standardIcon(QtWidgets.QStyle.StandardPixmap.SP_DirOpenIcon),
+            load_icon("choose_root.svg", QtWidgets.QStyle.StandardPixmap.SP_DirOpenIcon),
             _("Scegli root…"),
             self,
         )
@@ -813,7 +826,7 @@ class MainWindow(_QMainWindowBase):
         self.toolbar.addSeparator()
 
         self.action_load_file = QtGui.QAction(
-            style.standardIcon(QtWidgets.QStyle.StandardPixmap.SP_DialogOpenButton),
+            load_icon("load_file.svg", QtWidgets.QStyle.StandardPixmap.SP_DialogOpenButton),
             _("Apri file diff…"),
             self,
         )
@@ -822,7 +835,7 @@ class MainWindow(_QMainWindowBase):
         self.action_load_file.triggered.connect(self.load_diff_file)
 
         self.action_from_clip = QtGui.QAction(
-            style.standardIcon(QtWidgets.QStyle.StandardPixmap.SP_DialogYesButton),
+            load_icon("from_clipboard.svg", QtWidgets.QStyle.StandardPixmap.SP_DialogYesButton),
             _("Da appunti"),
             self,
         )
@@ -833,9 +846,7 @@ class MainWindow(_QMainWindowBase):
         self.action_from_clip.triggered.connect(self.load_from_clipboard)
 
         self.action_from_text = QtGui.QAction(
-            style.standardIcon(
-                QtWidgets.QStyle.StandardPixmap.SP_FileDialogDetailedView
-            ),
+            load_icon("from_text.svg", QtWidgets.QStyle.StandardPixmap.SP_FileDialogDetailedView),
             _("Da testo"),
             self,
         )
@@ -855,7 +866,7 @@ class MainWindow(_QMainWindowBase):
         self.load_diff_button = QtWidgets.QToolButton()
         self.load_diff_button.setText(_("Carica diff"))
         self.load_diff_button.setIcon(
-            style.standardIcon(QtWidgets.QStyle.StandardPixmap.SP_FileDialogStart)
+            load_icon("load_diff.svg", QtWidgets.QStyle.StandardPixmap.SP_FileDialogStart)
         )
         self.load_diff_button.setToolTip(
             _("Scegli come caricare o analizzare il diff da elaborare")
@@ -876,7 +887,7 @@ class MainWindow(_QMainWindowBase):
         self.toolbar.addAction(load_diff_widget_action)
 
         self.action_analyze = QtGui.QAction(
-            style.standardIcon(QtWidgets.QStyle.StandardPixmap.SP_MediaPlay),
+            load_icon("analyze.svg", QtWidgets.QStyle.StandardPixmap.SP_MediaPlay),
             _("Analizza diff"),
             self,
         )


### PR DESCRIPTION
## Summary
- add a new set of branded SVG toolbar icons
- load the icons in the main window with fallback to standard style icons
- standardize toolbar icon sizing for consistent appearance

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cad99d43e08326991e2dc8db30565f