### PR TITLE
Ensure resource URL helper returns string

### DIFF
--- a/patch_gui/theme.py
+++ b/patch_gui/theme.py
@@ -91,7 +91,7 @@ _RESOURCE_DIR = Path(__file__).resolve().parent / "resources"
 
 def _resource_url(name: str) -> str:
     path = (_RESOURCE_DIR / name).resolve()
-    return QtCore.QUrl.fromLocalFile(str(path)).toString()
+    return str(QtCore.QUrl.fromLocalFile(str(path)).toString())
 
 
 def _build_stylesheet() -> str:


### PR DESCRIPTION
## Summary
- ensure the `_resource_url` helper wraps the Qt URL string in `str()` so mypy sees a concrete `str` return type

## Testing
- `poetry run mypy` *(fails: existing `Qt.NoPen` attr-defined errors)*

------
https://chatgpt.com/codex/tasks/task_e_68cadf2be2848326bd36a291d274883d