### PR TITLE
Direct CLI logging to stderr

### DIFF
--- a/patch_gui/cli.py
+++ b/patch_gui/cli.py
@@ -68,7 +68,7 @@ def run_cli(argv: Sequence[str] | None = None) -> int:
     logging.basicConfig(
         level=getattr(logging, level_name, logging.WARNING),
         format="%(levelname)s: %(message)s",
-        stream=sys.stdout,
+        stream=sys.stderr,
         force=True,
     )
 


### PR DESCRIPTION
## Summary
- route CLI logging output to stderr so the summary remains on stdout
- update CLI log level test and add coverage ensuring verbose logs land on stderr only

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbb6664e908326942bdcae20f7c35b