### PR TITLE
Validate threshold range in executor

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -32,7 +32,7 @@ Questa guida passo‑passo descrive il workflow tipico per applicare una patch c
    - Selezionando un elemento puoi vedere il contesto e le modifiche.
 4. **Configura l'esecuzione**
    - La modalità **Dry‑run** è abilitata di default e consente di simulare l'applicazione senza modificare i file.
-   - Imposta la **Soglia fuzzy** (es. `0.85`) per controllare la tolleranza nel matching del contesto.
+   - Imposta la **Soglia fuzzy** (es. `0.85`) per controllare la tolleranza nel matching del contesto. I valori validi sono maggiori di 0 e non superano 1.
 5. **Applica la patch**
    - Con Dry‑run attivo clicca **Applica patch** per vedere l'anteprima dei risultati.
    - Quando sei soddisfatto, disattiva Dry‑run e premi nuovamente **Applica patch** per modificare realmente i file.

--- a/patch_gui/executor.py
+++ b/patch_gui/executor.py
@@ -146,11 +146,19 @@ def apply_patchset(
     exclude_dirs: Sequence[str] | None = None,
     config: AppConfig | None = None,
 ) -> ApplySession:
-    """Apply ``patch`` to ``project_root`` and return the :class:`ApplySession`."""
+    """Apply ``patch`` to ``project_root`` and return the :class:`ApplySession`.
+
+    ``threshold`` must be within the range ``(0, 1]`` to match CLI validation.
+    """
 
     root = project_root.expanduser().resolve()
     if not root.exists() or not root.is_dir():
         raise CLIError(_("Invalid project root: {path}").format(path=project_root))
+
+    if not 0 < threshold <= 1:
+        raise CLIError(
+            _("Threshold must be between 0 (exclusive) and 1 (inclusive).")
+        )
 
     resolved_config = config or load_config()
     started_at = time.time()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -178,6 +178,18 @@ def test_apply_patchset_dry_run(tmp_path: Path) -> None:
     assert file_result.file_type == "text"
 
 
+def test_apply_patchset_invalid_threshold(tmp_path: Path) -> None:
+    project = _create_project(tmp_path)
+
+    with pytest.raises(executor.CLIError):
+        executor.apply_patchset(
+            PatchSet(SAMPLE_DIFF),
+            project,
+            dry_run=True,
+            threshold=0.0,
+        )
+
+
 def test_session_report_highlights_missing_changes(tmp_path: Path) -> None:
     session = executor.ApplySession(
         project_root=tmp_path,


### PR DESCRIPTION
## Summary
- enforce the CLI threshold guard in `apply_patchset` for programmatic use
- document the valid fuzzy threshold range for users
- cover the new validation with a regression test

## Testing
- pytest tests/test_cli.py::test_apply_patchset_invalid_threshold

------
https://chatgpt.com/codex/tasks/task_e_68cbb6744ca08326b5894710c5111a41