### PR TITLE
Handle CLI patch write errors with context

### DIFF
--- a/patch_gui/executor.py
+++ b/patch_gui/executor.py
@@ -304,7 +304,15 @@ def _apply_file_patch(
         lines = []
 
     if not session.dry_run and not is_new_file:
-        backup_file(project_root, path, session.backup_dir)
+        try:
+            backup_file(project_root, path, session.backup_dir)
+        except OSError as exc:
+            relative_path = display_relative_path(path, project_root)
+            message = _(
+                "Failed to create backup for {path}: {error}"
+            ).format(path=relative_path, error=exc)
+            logger.error(message)
+            raise CLIError(message) from exc
 
     lines, decisions, applied = apply_hunks(
         lines,
@@ -337,11 +345,27 @@ def _apply_file_patch(
                 )
         else:
             if is_new_file:
-                path.parent.mkdir(parents=True, exist_ok=True)
+                try:
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                except OSError as exc:
+                    relative_dir = display_relative_path(path.parent, project_root)
+                    message = _(
+                        "Failed to create directory for {path}: {error}"
+                    ).format(path=relative_dir, error=exc)
+                    logger.error(message)
+                    raise CLIError(message) from exc
             new_text = "".join(lines)
             if not is_new_file:
                 new_text = new_text.replace("\n", orig_eol)
-            write_text_preserving_encoding(path, new_text, file_encoding)
+            try:
+                write_text_preserving_encoding(path, new_text, file_encoding)
+            except OSError as exc:
+                relative_path = display_relative_path(path, project_root)
+                message = _(
+                    "Failed to write updated content to {path}: {error}"
+                ).format(path=relative_path, error=exc)
+                logger.error(message)
+                raise CLIError(message) from exc
 
     return fr
 


### PR DESCRIPTION
## Summary
- guard backup creation, directory creation, and file writing in the CLI executor with contextual CLIError messages that include the affected path
- add CLI tests that simulate failures in backup creation, directory creation, and writing to ensure run_cli exits cleanly with the new errors

## Testing
- pytest tests/test_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68cbb6756eb083269befbbc7f521639a