### PR TITLE
Add CLI summary format option and report toggles

### DIFF
--- a/patch_gui/executor.py
+++ b/patch_gui/executor.py
@@ -143,6 +143,8 @@ def apply_patchset(
     report_json: Path | str | None = None,
     report_txt: Path | str | None = None,
     write_report_files: bool = True,
+    write_report_json: bool | None = None,
+    write_report_txt: bool | None = None,
     exclude_dirs: Sequence[str] | None = None,
     config: AppConfig | None = None,
 ) -> ApplySession:
@@ -185,6 +187,8 @@ def apply_patchset(
         report_json=report_json,
         report_txt=report_txt,
         enable_reports=write_report_files,
+        write_json=True if write_report_json is None else write_report_json,
+        write_txt=True if write_report_txt is None else write_report_txt,
     )
 
     return session

--- a/patch_gui/parser.py
+++ b/patch_gui/parser.py
@@ -102,6 +102,14 @@ def build_parser(
         % REPORT_TXT,
     )
     parser.add_argument(
+        "--summary-format",
+        choices=("txt", "json", "none"),
+        help=_(
+            "Format of the CLI summary printed to stdout: 'txt' (default), "
+            "'json', or 'none'."
+        ),
+    )
+    parser.add_argument(
         "--no-report",
         action="store_true",
         help=_("Do not create JSON/TXT report files."),

--- a/patch_gui/reporting.py
+++ b/patch_gui/reporting.py
@@ -16,8 +16,10 @@ def write_session_reports(
     report_json: Path | str | None,
     report_txt: Path | str | None,
     enable_reports: bool,
+    write_json: bool = True,
+    write_txt: bool = True,
 ) -> Tuple[Optional[Path], Optional[Path]]:
-    if not enable_reports:
+    if not enable_reports or (not write_json and not write_txt):
         session.report_json_path = None
         session.report_txt_path = None
         return None, None
@@ -29,8 +31,8 @@ def write_session_reports(
         session,
         json_path=json_path,
         txt_path=txt_path,
-        write_json=True,
-        write_txt=True,
+        write_json=write_json,
+        write_txt=write_txt,
     )
     session.report_json_path, session.report_txt_path = written
     return written


### PR DESCRIPTION
## Summary
- add a --summary-format option to the CLI parser to control stdout output
- honor the summary format in run_cli by emitting JSON when requested and routing report messages without polluting structured output
- allow executor/reporting to skip unrequested report files and cover the new flows with CLI tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbb679acbc8326953bb9da19a0af85