### PR TITLE
Log CLI output to stderr

### DIFF
--- a/patch_gui/cli.py
+++ b/patch_gui/cli.py
@@ -68,7 +68,7 @@ def run_cli(argv: Sequence[str] | None = None) -> int:
     logging.basicConfig(
         level=getattr(logging, level_name, logging.WARNING),
         format="%(levelname)s: %(message)s",
-        stream=sys.stdout,
+        stream=sys.stderr,
         force=True,
     )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -832,7 +832,7 @@ def test_run_cli_configures_requested_log_level(tmp_path: Path) -> None:
         configured_logger = logging.getLogger()
         assert configured_logger.level == logging.DEBUG
         assert any(
-            isinstance(handler, logging.StreamHandler) and handler.stream is sys.stdout
+            isinstance(handler, logging.StreamHandler) and handler.stream is sys.stderr
             for handler in configured_logger.handlers
         )
     finally:


### PR DESCRIPTION
## Summary
- configure the CLI logging to write to stderr so logs do not mix with session summaries
- adjust the CLI logging test to expect the stderr stream

## Testing
- pytest tests/test_cli.py::test_run_cli_configures_requested_log_level

------
https://chatgpt.com/codex/tasks/task_e_68cbb67af98483268b8e48b6e24e7498