### PR TITLE
Handle filesystem errors gracefully

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1065,3 +1065,66 @@ def test_threshold_value_rejects_invalid_inputs(
         parser.threshold_value(raw)
 
     assert str(excinfo.value) == expected_message
+
+
+def test_run_cli_reports_backup_directory_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    project = _create_project(tmp_path)
+    patch_path = tmp_path / "permission.diff"
+    patch_path.write_text(SAMPLE_DIFF, encoding="utf-8")
+
+    def fake_prepare_backup_dir(*args: object, **kwargs: object) -> Path:
+        raise PermissionError("permission denied")
+
+    monkeypatch.setattr(executor, "prepare_backup_dir", fake_prepare_backup_dir)
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.run_cli([
+            "--root",
+            str(project),
+            str(patch_path),
+        ])
+
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert "Failed to prepare backup directory" in captured.err
+    assert utils.BACKUP_DIR in captured.err
+    assert "permission denied" in captured.err
+    assert "Traceback" not in captured.err
+    assert captured.out == ""
+
+
+def test_run_cli_reports_session_report_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    project = _create_project(tmp_path)
+    patch_path = tmp_path / "report.diff"
+    patch_path.write_text(SAMPLE_DIFF, encoding="utf-8")
+
+    target = tmp_path / "reports" / REPORT_JSON
+
+    def fake_write_session_reports(*args: object, **kwargs: object) -> None:
+        raise PermissionError(13, "Permission denied", str(target))
+
+    monkeypatch.setattr(executor, "write_session_reports", fake_write_session_reports)
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.run_cli([
+            "--root",
+            str(project),
+            "--dry-run",
+            str(patch_path),
+        ])
+
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert "Failed to write session report" in captured.err
+    assert REPORT_JSON in captured.err
+    assert "Permission denied" in captured.err
+    assert "Traceback" not in captured.err
+    assert captured.out == ""


### PR DESCRIPTION
## Summary
- raise clear CLI errors when preparing backup directories or writing reports fails
- treat backup copy failures as file-level skips with failed hunk decisions
- add CLI regression tests that cover permission errors during backup and report generation

## Testing
- pytest tests/test_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68cbb67bdf448326ba420b79d078d377