### PR TITLE
Add CLI summary format controls and JSON output

### DIFF
--- a/patch_gui/executor.py
+++ b/patch_gui/executor.py
@@ -143,6 +143,8 @@ def apply_patchset(
     report_json: Path | str | None = None,
     report_txt: Path | str | None = None,
     write_report_files: bool = True,
+    write_json_report: bool = True,
+    write_txt_report: bool = True,
     exclude_dirs: Sequence[str] | None = None,
     config: AppConfig | None = None,
 ) -> ApplySession:
@@ -180,12 +182,14 @@ def apply_patchset(
         fr = _apply_file_patch(root, pf, rel, session, interactive=interactive)
         session.results.append(fr)
 
-    write_session_reports(
-        session,
-        report_json=report_json,
-        report_txt=report_txt,
-        enable_reports=write_report_files,
-    )
+        write_session_reports(
+            session,
+            report_json=report_json,
+            report_txt=report_txt,
+            enable_reports=write_report_files,
+            write_json=write_json_report,
+            write_txt=write_txt_report,
+        )
 
     return session
 

--- a/patch_gui/parser.py
+++ b/patch_gui/parser.py
@@ -102,6 +102,16 @@ def build_parser(
         % REPORT_TXT,
     )
     parser.add_argument(
+        "--summary-format",
+        action="append",
+        choices=("text", "json"),
+        metavar="FORMAT",
+        help=_(
+            "Summary format to print on stdout (text, json). Repeat the option to "
+            "select multiple formats. Defaults to text."
+        ),
+    )
+    parser.add_argument(
         "--no-report",
         action="store_true",
         help=_("Do not create JSON/TXT report files."),

--- a/patch_gui/reporting.py
+++ b/patch_gui/reporting.py
@@ -16,6 +16,8 @@ def write_session_reports(
     report_json: Path | str | None,
     report_txt: Path | str | None,
     enable_reports: bool,
+    write_json: bool = True,
+    write_txt: bool = True,
 ) -> Tuple[Optional[Path], Optional[Path]]:
     if not enable_reports:
         session.report_json_path = None
@@ -29,8 +31,8 @@ def write_session_reports(
         session,
         json_path=json_path,
         txt_path=txt_path,
-        write_json=True,
-        write_txt=True,
+        write_json=write_json,
+        write_txt=write_txt,
     )
     session.report_json_path, session.report_txt_path = written
     return written


### PR DESCRIPTION
## Summary
- add a --summary-format option to the CLI parser so callers can request text and/or JSON summaries
- update run_cli to respect the requested formats, keep logs off stdout when JSON is emitted, and only write matching report files
- allow write_session_reports/write_reports to honour write_json/write_txt flags and cover the new behaviour with CLI tests

## Testing
- pytest tests/test_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68cbb67f4acc8326aabc9cc6b9ab37ef