### PR TITLE
Add CLI summary format selection and respect report preferences

### DIFF
--- a/patch_gui/executor.py
+++ b/patch_gui/executor.py
@@ -144,6 +144,8 @@ def apply_patchset(
     report_json: Path | str | None = None,
     report_txt: Path | str | None = None,
     write_report_files: bool = True,
+    write_report_json: bool | None = None,
+    write_report_txt: bool | None = None,
     exclude_dirs: Sequence[str] | None = None,
     config: AppConfig | None = None,
 ) -> ApplySession:
@@ -194,6 +196,8 @@ def apply_patchset(
         report_json=report_json,
         report_txt=report_txt,
         enable_reports=write_report_files,
+        write_json=write_report_json,
+        write_txt=write_report_txt,
     )
 
     return session

--- a/patch_gui/parser.py
+++ b/patch_gui/parser.py
@@ -30,8 +30,14 @@ class _HelpFormatter(argparse.ArgumentDefaultsHelpFormatter):
         self._width = max(self._width, minimum_total_width)
 
 
+REPORT_JSON_UNSET = object()
+REPORT_TXT_UNSET = object()
+
+
 __all__ = [
     "_LOG_LEVEL_CHOICES",
+    "REPORT_JSON_UNSET",
+    "REPORT_TXT_UNSET",
     "build_parser",
     "parse_exclude_dirs",
     "threshold_value",
@@ -93,11 +99,13 @@ def build_parser(
     )
     parser.add_argument(
         "--report-json",
+        default=REPORT_JSON_UNSET,
         help=_("Path of the generated JSON report; defaults to '<backup>/%s'.")
         % REPORT_JSON,
     )
     parser.add_argument(
         "--report-txt",
+        default=REPORT_TXT_UNSET,
         help=_("Path of the generated text report; defaults to '<backup>/%s'.")
         % REPORT_TXT,
     )
@@ -105,6 +113,15 @@ def build_parser(
         "--no-report",
         action="store_true",
         help=_("Do not create JSON/TXT report files."),
+    )
+    parser.add_argument(
+        "--summary-format",
+        action="append",
+        choices=("text", "json", "none"),
+        help=_(
+            "Choose one or more summary formats to print on stdout (defaults to text). "
+            "Repeat the option to combine formats; use 'none' to suppress summaries."
+        ),
     )
     parser.add_argument(
         "--non-interactive",

--- a/patch_gui/reporting.py
+++ b/patch_gui/reporting.py
@@ -16,8 +16,18 @@ def write_session_reports(
     report_json: Path | str | None,
     report_txt: Path | str | None,
     enable_reports: bool,
+    write_json: bool | None = None,
+    write_txt: bool | None = None,
 ) -> Tuple[Optional[Path], Optional[Path]]:
     if not enable_reports:
+        session.report_json_path = None
+        session.report_txt_path = None
+        return None, None
+
+    effective_write_json = True if write_json is None else write_json
+    effective_write_txt = True if write_txt is None else write_txt
+
+    if not effective_write_json and not effective_write_txt:
         session.report_json_path = None
         session.report_txt_path = None
         return None, None
@@ -29,8 +39,8 @@ def write_session_reports(
         session,
         json_path=json_path,
         txt_path=txt_path,
-        write_json=True,
-        write_txt=True,
+        write_json=effective_write_json,
+        write_txt=effective_write_txt,
     )
     session.report_json_path, session.report_txt_path = written
     return written

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ import io
 import os
 import json
 import logging
+import shutil
 import sys
 import time
 import types
@@ -1001,6 +1002,86 @@ def test_run_cli_emits_logs_to_stderr(
     assert "verbose log message" in captured.err
 
 
+def test_run_cli_prints_json_summary_and_skips_text_report(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    project = _create_project(tmp_path)
+    patch_path = tmp_path / "json-summary.diff"
+    patch_path.write_text(SAMPLE_DIFF, encoding="utf-8")
+
+    utils.DEFAULT_REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+    before_reports = set(utils.DEFAULT_REPORTS_DIR.glob("*"))
+
+    exit_code = cli.run_cli(
+        [
+            "--root",
+            str(project),
+            "--dry-run",
+            "--summary-format",
+            "json",
+            str(patch_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    stdout = captured.out.strip()
+    assert stdout
+    data = json.loads(stdout)
+    assert isinstance(data, dict)
+    assert "files" in data
+    assert "Summary" not in captured.out
+
+    after_reports = set(utils.DEFAULT_REPORTS_DIR.glob("*"))
+    new_reports = [path for path in after_reports if path not in before_reports]
+    try:
+        assert len(new_reports) == 1
+        report_dir = new_reports[0]
+        assert (report_dir / REPORT_JSON).exists()
+        assert not (report_dir / REPORT_TXT).exists()
+    finally:
+        for path in new_reports:
+            shutil.rmtree(path, ignore_errors=True)
+
+
+def test_run_cli_text_summary_skips_json_report(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    project = _create_project(tmp_path)
+    patch_path = tmp_path / "text-summary.diff"
+    patch_path.write_text(SAMPLE_DIFF, encoding="utf-8")
+
+    utils.DEFAULT_REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+    before_reports = set(utils.DEFAULT_REPORTS_DIR.glob("*"))
+
+    exit_code = cli.run_cli(
+        [
+            "--root",
+            str(project),
+            "--dry-run",
+            "--summary-format",
+            "text",
+            str(patch_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Summary" in captured.out
+    after_reports = set(utils.DEFAULT_REPORTS_DIR.glob("*"))
+    new_reports = [path for path in after_reports if path not in before_reports]
+    try:
+        assert len(new_reports) == 1
+        report_dir = new_reports[0]
+        assert not (report_dir / REPORT_JSON).exists()
+        assert (report_dir / REPORT_TXT).exists()
+    finally:
+        for path in new_reports:
+            shutil.rmtree(path, ignore_errors=True)
+
+
 class _DummySession:
     def __init__(self, tmp_path: Path) -> None:
         self.dry_run = True
@@ -1012,6 +1093,9 @@ class _DummySession:
 
     def to_txt(self) -> str:
         return "Summary"
+
+    def to_json(self) -> dict[str, object]:
+        return {"summary": self.to_txt()}
 
 
 def _create_dummy_session(tmp_path: Path) -> _DummySession:
@@ -1098,8 +1182,8 @@ def test_run_cli_reports_backup_creation_error(
 
     assert excinfo.value.code == 1
     captured = capsys.readouterr()
-    assert "Failed to create backup" in captured.out
-    assert "sample.txt" in captured.out
+    assert "Failed to create backup" in captured.err
+    assert "sample.txt" in captured.err
 
 
 def test_run_cli_reports_directory_creation_error(
@@ -1124,8 +1208,8 @@ def test_run_cli_reports_directory_creation_error(
 
     assert excinfo.value.code == 1
     captured = capsys.readouterr()
-    assert "Failed to create directory" in captured.out
-    assert "docs" in captured.out
+    assert "Failed to create directory" in captured.err
+    assert "docs" in captured.err
 
 
 def test_run_cli_reports_write_error(
@@ -1146,8 +1230,8 @@ def test_run_cli_reports_write_error(
 
     assert excinfo.value.code == 1
     captured = capsys.readouterr()
-    assert "Failed to write updated content" in captured.out
-    assert "sample.txt" in captured.out
+    assert "Failed to write updated content" in captured.err
+    assert "sample.txt" in captured.err
 
 
 def test_config_show_outputs_json(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a --summary-format option to the CLI parser and track report argument defaults
- emit text or JSON summaries on demand while routing supplemental messages appropriately
- adjust report writers to honour requested formats and extend CLI tests for the new behaviours

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbb942953c832696bc8cf4f4c75db6