### PR TITLE
feat: show real line numbers in diff preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ e il progetto aderisce alla [Versionamento Semantico](https://semver.org/lang/it
 - Sezione iniziale del changelog pronta per essere aggiornata con le prossime modifiche.
 - Migliorata l'esperienza del diff interattivo con badge e colori più leggibili per le aggiunte e le rimozioni.
 
+### Modificato
+- L'anteprima diff interattiva mostra le vere linee di file coinvolte nelle modifiche con colonne numerate in stile Visual Studio, facilitando il riferimento al codice originale.
+
 ## [0.1.0] - 2025-09-18
 ### Aggiunto
 - Prima versione pubblica dell'applicazione `patch-gui`.

--- a/patch_gui/diff_formatting.py
+++ b/patch_gui/diff_formatting.py
@@ -1,0 +1,64 @@
+"""Utilities to enrich diff previews with additional metadata."""
+
+from __future__ import annotations
+
+from unidiff.patch import Hunk, Line as UnidiffLine, PatchedFile
+
+
+def format_diff_with_line_numbers(patched_file: PatchedFile, fallback_text: str) -> str:
+    """Decorate a diff with source/target line numbers when possible."""
+
+    if getattr(patched_file, "is_binary_file", False):
+        return fallback_text
+
+    if len(patched_file) == 0:
+        return fallback_text
+
+    try:
+        lines: list[str] = []
+
+        patch_info = getattr(patched_file, "patch_info", "")
+        if patch_info:
+            for info_line in str(patch_info).splitlines():
+                lines.append(info_line)
+
+        source_file = getattr(patched_file, "source_file", None) or "-"
+        target_file = getattr(patched_file, "target_file", None) or "-"
+        lines.append(f"--- {source_file}")
+        lines.append(f"+++ {target_file}")
+
+        for hunk in patched_file:
+            lines.append(_format_hunk_header(hunk))
+            for diff_line in hunk:
+                lines.append(_format_numbered_line(diff_line))
+
+        return "\n".join(lines) + "\n"
+    except Exception:  # pragma: no cover - defensive, falls back to raw diff text
+        return fallback_text
+
+
+def _format_hunk_header(hunk: Hunk) -> str:
+    """Render the unified diff header for ``hunk``."""
+
+    return "@@ -{source} +{target} @@{section}".format(
+        source=_format_hunk_range(hunk.source_start, hunk.source_length),
+        target=_format_hunk_range(hunk.target_start, hunk.target_length),
+        section=f" {hunk.section_header}" if hunk.section_header else "",
+    )
+
+
+def _format_hunk_range(start: int, length: int) -> str:
+    if length == 1:
+        return str(start)
+    return f"{start},{length}"
+
+
+def _format_numbered_line(line: UnidiffLine) -> str:
+    left = _format_line_number(line.source_line_no)
+    right = _format_line_number(line.target_line_no)
+    content = str(line).rstrip("\n")
+    return f"{left} │ {right} │ {content}"
+
+
+def _format_line_number(value: int | None) -> str:
+    return f"{value:>6}" if value is not None else " " * 6

--- a/patch_gui/highlighter.py
+++ b/patch_gui/highlighter.py
@@ -54,7 +54,8 @@ class DiffHighlighter(_QSyntaxHighlighter):
         if not text:
             return
 
-        first = text[0]
+        marker_text = _extract_marker_text(text)
+        first = marker_text[0] if marker_text else text[0]
         fmt: QtGui.QTextCharFormat | None
 
         if (
@@ -65,16 +66,34 @@ class DiffHighlighter(_QSyntaxHighlighter):
             fmt = self._header_format
         elif text.startswith("---") or text.startswith("+++"):
             fmt = self._header_format
+        elif marker_text.startswith("\\ No newline"):
+            fmt = self._meta_format
         elif first == "+":
             fmt = self._addition_format
         elif first == "-":
             fmt = self._removal_format
         elif first == " " or first == "\t":
             fmt = self._context_format
-        elif text.startswith("\\ No newline"):
-            fmt = self._meta_format
         else:
             fmt = None
 
         if fmt is not None:
             self.setFormat(0, len(text), fmt)
+
+
+def _extract_marker_text(text: str) -> str:
+    """Return the portion of ``text`` containing the diff marker."""
+
+    if "│" in text:
+        parts = text.split("│", 2)
+        if len(parts) == 3:
+            candidate = parts[2]
+            stripped_candidate = candidate.lstrip()
+            if stripped_candidate:
+                return stripped_candidate
+            if candidate:
+                return candidate
+    stripped = text.lstrip()
+    if stripped:
+        return stripped
+    return text

--- a/patch_gui/interactive_diff.py
+++ b/patch_gui/interactive_diff.py
@@ -10,6 +10,7 @@ from PySide6 import QtCore, QtWidgets
 
 from .highlighter import DiffHighlighter
 from .localization import gettext as _
+from .diff_formatting import format_diff_with_line_numbers
 
 
 @dataclass(frozen=True, slots=True)
@@ -18,6 +19,7 @@ class FileDiffEntry:
 
     file_label: str
     diff_text: str
+    annotated_diff_text: str
     additions: int
     deletions: int
 
@@ -181,10 +183,12 @@ class InteractiveDiffWidget(QtWidgets.QWidget):
             if not diff_text.endswith("\n"):
                 diff_text += "\n"
             additions, deletions = _count_changes(diff_text)
+            annotated_text = format_diff_with_line_numbers(patched_file, diff_text)
             entries.append(
                 FileDiffEntry(
                     file_label=file_label,
                     diff_text=diff_text,
+                    annotated_diff_text=annotated_text,
                     additions=additions,
                     deletions=deletions,
                 )
@@ -258,7 +262,7 @@ class InteractiveDiffWidget(QtWidgets.QWidget):
             return
         entry = current.data(QtCore.Qt.ItemDataRole.UserRole)
         if isinstance(entry, FileDiffEntry):
-            self._preview.setPlainText(entry.diff_text)
+            self._preview.setPlainText(entry.annotated_diff_text)
         self._refresh_item_selection()
 
     def _apply_reordered_diff(self) -> None:
@@ -448,3 +452,4 @@ def _join_diff_entries(entries: Iterable[FileDiffEntry]) -> str:
             text += "\n"
         parts.append(text)
     return "".join(parts)
+

--- a/tests/test_interactive_diff_formatting.py
+++ b/tests/test_interactive_diff_formatting.py
@@ -1,0 +1,43 @@
+"""Tests for line-number formatting in the interactive diff preview."""
+
+from __future__ import annotations
+
+from unidiff import PatchSet
+
+from patch_gui.diff_formatting import format_diff_with_line_numbers
+
+
+def test_format_diff_with_line_numbers_includes_real_positions() -> None:
+    diff_text = """diff --git a/foo.txt b/foo.txt\nindex 1234567..89abcde 100644\n--- a/foo.txt\n+++ b/foo.txt\n@@ -1,2 +1,3 @@\n line1\n-line2\n+line2 changed\n+line3\n"""
+
+    patch = PatchSet(diff_text)
+    patched_file = patch[0]
+
+    formatted = format_diff_with_line_numbers(patched_file, diff_text)
+
+    expected_lines = [
+        "diff --git a/foo.txt b/foo.txt",
+        "index 1234567..89abcde 100644",
+        "--- a/foo.txt",
+        "+++ b/foo.txt",
+        "@@ -1,2 +1,3 @@",
+        "     1 │      1 │  line1",
+        "     2 │        │ -line2",
+        "       │      2 │ +line2 changed",
+        "       │      3 │ +line3",
+    ]
+
+    assert formatted == "\n".join(expected_lines) + "\n"
+
+
+def test_format_diff_with_line_numbers_returns_fallback_for_binary() -> None:
+    diff_text = """diff --git a/image.png b/image.png\nindex 1234567..89abcde 100644\nBinary files a/image.png and b/image.png differ\n"""
+
+    patch = PatchSet(diff_text)
+    patched_file = patch[0]
+
+    assert patched_file.is_binary_file is True
+
+    formatted = format_diff_with_line_numbers(patched_file, diff_text)
+
+    assert formatted == diff_text


### PR DESCRIPTION
## Summary
- add a reusable formatter that annotates diff hunks with real source/target line numbers for the GUI preview
- update the interactive diff widget and syntax highlighter to render the numbered columns while preserving highlighting
- cover the formatter with unit tests and document the enhancement in the changelog

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbc840d2208326a15c5e8d64e671c5