### PR TITLE
Expand configurable logging options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ e il progetto aderisce alla [Versionamento Semantico](https://semver.org/lang/it
 ### Aggiunto
 - Sezione iniziale del changelog pronta per essere aggiornata con le prossime modifiche.
 - Migliorata l'esperienza del diff interattivo con badge e colori più leggibili per le aggiunte e le rimozioni.
+- Ampliate le impostazioni persistenti: ora è possibile configurare percorso del file di log, rotazione e numero di backup direttamente da CLI e GUI.
 
 ### Modificato
 - L'anteprima diff interattiva mostra le vere linee di file coinvolte nelle modifiche con colonne numerate in stile Visual Studio, facilitando il riferimento al codice originale.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1368,6 +1368,9 @@ def test_config_show_outputs_json(tmp_path: Path) -> None:
         exclude_dirs=("one", "two"),
         backup_base=tmp_path / "backups",
         log_level="debug",
+        log_file=tmp_path / "custom.log",
+        log_max_bytes=2048,
+        log_backup_count=5,
     )
     save_config(config, path=config_path)
 
@@ -1380,6 +1383,9 @@ def test_config_show_outputs_json(tmp_path: Path) -> None:
     assert payload["exclude_dirs"] == list(config.exclude_dirs)
     assert payload["backup_base"] == str(config.backup_base)
     assert payload["log_level"] == config.log_level
+    assert payload["log_file"] == str(config.log_file)
+    assert payload["log_max_bytes"] == config.log_max_bytes
+    assert payload["log_backup_count"] == config.log_backup_count
 
 
 def test_config_set_updates_values(tmp_path: Path) -> None:
@@ -1435,6 +1441,32 @@ def test_config_set_updates_values(tmp_path: Path) -> None:
     )
     assert load_config(config_path).write_reports is False
 
+    cli.config_set(
+        "log_file",
+        [str(tmp_path / "logs" / "session.log")],
+        path=config_path,
+        stream=io.StringIO(),
+    )
+    assert load_config(config_path).log_file == (
+        tmp_path / "logs" / "session.log"
+    ).expanduser()
+
+    cli.config_set(
+        "log_max_bytes",
+        ["4096"],
+        path=config_path,
+        stream=io.StringIO(),
+    )
+    assert load_config(config_path).log_max_bytes == 4096
+
+    cli.config_set(
+        "log_backup_count",
+        ["2"],
+        path=config_path,
+        stream=io.StringIO(),
+    )
+    assert load_config(config_path).log_backup_count == 2
+
 
 def test_config_reset_values(tmp_path: Path) -> None:
     config_path = tmp_path / "settings.toml"
@@ -1458,6 +1490,9 @@ def test_config_reset_values(tmp_path: Path) -> None:
     assert reset.backup_base == defaults.backup_base
     assert reset.dry_run_default == defaults.dry_run_default
     assert reset.write_reports == defaults.write_reports
+    assert reset.log_file == defaults.log_file
+    assert reset.log_max_bytes == defaults.log_max_bytes
+    assert reset.log_backup_count == defaults.log_backup_count
 
 
 def test_run_config_reports_invalid_log_level(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,6 +17,9 @@ def test_load_config_returns_defaults_when_missing(tmp_path: Path) -> None:
     assert loaded.log_level == defaults.log_level
     assert loaded.dry_run_default == defaults.dry_run_default
     assert loaded.write_reports == defaults.write_reports
+    assert loaded.log_file == defaults.log_file
+    assert loaded.log_max_bytes == defaults.log_max_bytes
+    assert loaded.log_backup_count == defaults.log_backup_count
 
 
 def test_save_and_load_roundtrip(tmp_path: Path) -> None:
@@ -30,6 +33,9 @@ def test_save_and_load_roundtrip(tmp_path: Path) -> None:
         log_level="debug",
         dry_run_default=False,
         write_reports=False,
+        log_file=tmp_path / "custom.log",
+        log_max_bytes=1048576,
+        log_backup_count=3,
     )
 
     save_config(original, path=config_path)
@@ -50,6 +56,9 @@ def test_load_config_invalid_values_fallback(tmp_path: Path) -> None:
                 "log_level = 123",
                 'dry_run_default = "maybe"',
                 'write_reports = "sometimes"',
+                'log_file = "   "',
+                "log_max_bytes = -1",
+                "log_backup_count = -5",
                 "",
             ]
         ),
@@ -65,6 +74,9 @@ def test_load_config_invalid_values_fallback(tmp_path: Path) -> None:
     assert loaded.log_level == defaults.log_level
     assert loaded.dry_run_default == defaults.dry_run_default
     assert loaded.write_reports == defaults.write_reports
+    assert loaded.log_file == defaults.log_file
+    assert loaded.log_max_bytes == defaults.log_max_bytes
+    assert loaded.log_backup_count == defaults.log_backup_count
 
 
 def test_load_config_accepts_empty_exclude_list(tmp_path: Path) -> None:
@@ -79,6 +91,9 @@ def test_load_config_accepts_empty_exclude_list(tmp_path: Path) -> None:
                 'log_level = "warning"',
                 "dry_run_default = false",
                 "write_reports = true",
+                'log_file = "' + str(tmp_path / "log.txt") + '"',
+                "log_max_bytes = 1024",
+                "log_backup_count = 4",
                 "",
             ]
         ),
@@ -93,3 +108,6 @@ def test_load_config_accepts_empty_exclude_list(tmp_path: Path) -> None:
     assert loaded.backup_base == (tmp_path / "backups")
     assert loaded.dry_run_default is False
     assert loaded.write_reports is True
+    assert loaded.log_file == (tmp_path / "log.txt")
+    assert loaded.log_max_bytes == 1024
+    assert loaded.log_backup_count == 4


### PR DESCRIPTION
## Summary
- add persistent configuration options for log file path and rotation settings
- surface the new options in the GUI settings dialog and CLI config commands
- use the persisted values when configuring application logging

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbe1c3cf3c8326a175904cd24679a2