### PR TITLE
Add configurable backup retention cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ e il progetto aderisce alla [Versionamento Semantico](https://semver.org/lang/it
 - Sezione iniziale del changelog pronta per essere aggiornata con le prossime modifiche.
 - Migliorata l'esperienza del diff interattivo con badge e colori più leggibili per le aggiunte e le rimozioni.
 - Ampliate le impostazioni persistenti: ora è possibile configurare percorso del file di log, rotazione e numero di backup direttamente da CLI e GUI.
+- Pulizia automatica dei backup più vecchi dopo un numero configurabile di giorni, impostabile sia da interfaccia grafica sia da CLI.
 
 ### Modificato
 - L'anteprima diff interattiva mostra le vere linee di file coinvolte nelle modifiche con colonne numerate in stile Visual Studio, facilitando il riferimento al codice originale.

--- a/patch_gui/cli.py
+++ b/patch_gui/cli.py
@@ -52,6 +52,7 @@ _CONFIG_KEYS = (
     "log_file",
     "log_max_bytes",
     "log_backup_count",
+    "backup_retention_days",
 )
 
 
@@ -341,6 +342,8 @@ def config_reset(
             config.log_max_bytes = defaults.log_max_bytes
         elif key == "log_backup_count":
             config.log_backup_count = defaults.log_backup_count
+        elif key == "backup_retention_days":
+            config.backup_retention_days = defaults.backup_retention_days
         save_config(config, path)
         message = _("{key} reset to default.").format(key=key)
 
@@ -423,7 +426,7 @@ def _apply_config_value(
         config.log_file = Path(values[0]).expanduser()
         return
 
-    if key in {"log_max_bytes", "log_backup_count"}:
+    if key in {"log_max_bytes", "log_backup_count", "backup_retention_days"}:
         if len(values) != 1:
             raise ConfigCommandError(
                 _("The {key} key expects exactly one value.").format(key=key),
@@ -431,8 +434,10 @@ def _apply_config_value(
         numeric = _parse_non_negative_int(values[0], key=key)
         if key == "log_max_bytes":
             config.log_max_bytes = numeric
-        else:
+        elif key == "log_backup_count":
             config.log_backup_count = numeric
+        else:
+            config.backup_retention_days = numeric
         return
 
     raise ValueError(_("Unknown configuration key: {key}").format(key=key))

--- a/patch_gui/config.py
+++ b/patch_gui/config.py
@@ -42,6 +42,7 @@ _DEFAULT_WRITE_REPORTS = True
 _DEFAULT_LOG_FILE_NAME = ".patch_gui.log"
 _DEFAULT_LOG_MAX_BYTES = 0
 _DEFAULT_LOG_BACKUP_COUNT = 0
+_DEFAULT_BACKUP_RETENTION_DAYS = 0
 
 
 def _default_log_file() -> Path:
@@ -51,10 +52,12 @@ def _default_log_file() -> Path:
 DEFAULT_LOG_FILE: Path = _default_log_file()
 DEFAULT_LOG_MAX_BYTES: int = _DEFAULT_LOG_MAX_BYTES
 DEFAULT_LOG_BACKUP_COUNT: int = _DEFAULT_LOG_BACKUP_COUNT
+DEFAULT_BACKUP_RETENTION_DAYS: int = _DEFAULT_BACKUP_RETENTION_DAYS
 
 
 __all__ = [
     "AppConfig",
+    "DEFAULT_BACKUP_RETENTION_DAYS",
     "DEFAULT_LOG_BACKUP_COUNT",
     "DEFAULT_LOG_FILE",
     "DEFAULT_LOG_MAX_BYTES",
@@ -80,6 +83,7 @@ class AppConfig:
     log_file: Path = field(default_factory=_default_log_file)
     log_max_bytes: int = DEFAULT_LOG_MAX_BYTES
     log_backup_count: int = DEFAULT_LOG_BACKUP_COUNT
+    backup_retention_days: int = DEFAULT_BACKUP_RETENTION_DAYS
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any]) -> "AppConfig":
@@ -102,6 +106,9 @@ class AppConfig:
         log_backup_count = _coerce_non_negative_int(
             data.get("log_backup_count"), base.log_backup_count
         )
+        backup_retention_days = _coerce_non_negative_int(
+            data.get("backup_retention_days"), base.backup_retention_days
+        )
 
         return cls(
             threshold=threshold,
@@ -113,6 +120,7 @@ class AppConfig:
             log_file=log_file,
             log_max_bytes=log_max_bytes,
             log_backup_count=log_backup_count,
+            backup_retention_days=backup_retention_days,
         )
 
     def to_mapping(self) -> MutableMapping[str, Any]:
@@ -128,6 +136,7 @@ class AppConfig:
             "log_file": str(self.log_file),
             "log_max_bytes": int(self.log_max_bytes),
             "log_backup_count": int(self.log_backup_count),
+            "backup_retention_days": int(self.backup_retention_days),
         }
 
 
@@ -193,6 +202,7 @@ def save_config(config: AppConfig, path: Path | None = None) -> Path:
     log_file_repr = json.dumps(mapping["log_file"])
     log_max_bytes_repr = json.dumps(mapping["log_max_bytes"])
     log_backup_count_repr = json.dumps(mapping["log_backup_count"])
+    backup_retention_repr = json.dumps(mapping["backup_retention_days"])
 
     content_lines = [
         f"[{_CONFIG_SECTION}]",
@@ -205,6 +215,7 @@ def save_config(config: AppConfig, path: Path | None = None) -> Path:
         f"log_file = {log_file_repr}",
         f"log_max_bytes = {log_max_bytes_repr}",
         f"log_backup_count = {log_backup_count_repr}",
+        f"backup_retention_days = {backup_retention_repr}",
         "",
     ]
 

--- a/patch_gui/executor.py
+++ b/patch_gui/executor.py
@@ -25,9 +25,12 @@ from .patcher import (
     backup_file,
     find_file_candidates,
     prepare_backup_dir,
+    prune_backup_sessions,
 )
 from .reporting import write_session_reports
 from .utils import (
+    REPORT_RESULTS_SUBDIR,
+    REPORTS_SUBDIR,
     decode_bytes,
     display_relative_path,
     normalize_newlines,
@@ -184,6 +187,20 @@ def apply_patchset(
             "Failed to prepare backup directory at {path}: {error}"
         ).format(path=failure_path, error=exc)
         raise CLIError(message) from exc
+
+    retention_days = getattr(resolved_config, "backup_retention_days", 0)
+    if retention_days > 0:
+        prune_backup_sessions(
+            backup_base_arg,
+            retention_days=retention_days,
+            reference_timestamp=started_at,
+        )
+        reports_base = backup_base_arg / REPORTS_SUBDIR / REPORT_RESULTS_SUBDIR
+        prune_backup_sessions(
+            reports_base,
+            retention_days=retention_days,
+            reference_timestamp=started_at,
+        )
     resolved_excludes = (
         tuple(exclude_dirs)
         if exclude_dirs is not None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1371,6 +1371,7 @@ def test_config_show_outputs_json(tmp_path: Path) -> None:
         log_file=tmp_path / "custom.log",
         log_max_bytes=2048,
         log_backup_count=5,
+        backup_retention_days=12,
     )
     save_config(config, path=config_path)
 
@@ -1386,6 +1387,7 @@ def test_config_show_outputs_json(tmp_path: Path) -> None:
     assert payload["log_file"] == str(config.log_file)
     assert payload["log_max_bytes"] == config.log_max_bytes
     assert payload["log_backup_count"] == config.log_backup_count
+    assert payload["backup_retention_days"] == config.backup_retention_days
 
 
 def test_config_set_updates_values(tmp_path: Path) -> None:
@@ -1467,6 +1469,14 @@ def test_config_set_updates_values(tmp_path: Path) -> None:
     )
     assert load_config(config_path).log_backup_count == 2
 
+    cli.config_set(
+        "backup_retention_days",
+        ["30"],
+        path=config_path,
+        stream=io.StringIO(),
+    )
+    assert load_config(config_path).backup_retention_days == 30
+
 
 def test_config_reset_values(tmp_path: Path) -> None:
     config_path = tmp_path / "settings.toml"
@@ -1493,6 +1503,7 @@ def test_config_reset_values(tmp_path: Path) -> None:
     assert reset.log_file == defaults.log_file
     assert reset.log_max_bytes == defaults.log_max_bytes
     assert reset.log_backup_count == defaults.log_backup_count
+    assert reset.backup_retention_days == defaults.backup_retention_days
 
 
 def test_run_config_reports_invalid_log_level(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,6 +20,7 @@ def test_load_config_returns_defaults_when_missing(tmp_path: Path) -> None:
     assert loaded.log_file == defaults.log_file
     assert loaded.log_max_bytes == defaults.log_max_bytes
     assert loaded.log_backup_count == defaults.log_backup_count
+    assert loaded.backup_retention_days == defaults.backup_retention_days
 
 
 def test_save_and_load_roundtrip(tmp_path: Path) -> None:
@@ -36,6 +37,7 @@ def test_save_and_load_roundtrip(tmp_path: Path) -> None:
         log_file=tmp_path / "custom.log",
         log_max_bytes=1048576,
         log_backup_count=3,
+        backup_retention_days=14,
     )
 
     save_config(original, path=config_path)
@@ -59,6 +61,7 @@ def test_load_config_invalid_values_fallback(tmp_path: Path) -> None:
                 'log_file = "   "',
                 "log_max_bytes = -1",
                 "log_backup_count = -5",
+                "backup_retention_days = -10",
                 "",
             ]
         ),
@@ -77,6 +80,7 @@ def test_load_config_invalid_values_fallback(tmp_path: Path) -> None:
     assert loaded.log_file == defaults.log_file
     assert loaded.log_max_bytes == defaults.log_max_bytes
     assert loaded.log_backup_count == defaults.log_backup_count
+    assert loaded.backup_retention_days == defaults.backup_retention_days
 
 
 def test_load_config_accepts_empty_exclude_list(tmp_path: Path) -> None:
@@ -94,6 +98,7 @@ def test_load_config_accepts_empty_exclude_list(tmp_path: Path) -> None:
                 'log_file = "' + str(tmp_path / "log.txt") + '"',
                 "log_max_bytes = 1024",
                 "log_backup_count = 4",
+                "backup_retention_days = 30",
                 "",
             ]
         ),
@@ -111,3 +116,4 @@ def test_load_config_accepts_empty_exclude_list(tmp_path: Path) -> None:
     assert loaded.log_file == (tmp_path / "log.txt")
     assert loaded.log_max_bytes == 1024
     assert loaded.log_backup_count == 4
+    assert loaded.backup_retention_days == 30

--- a/tests/test_diff_applier_gui.py
+++ b/tests/test_diff_applier_gui.py
@@ -148,6 +148,7 @@ def test_settings_dialog_gathers_config(qt_app: Any, tmp_path: Path) -> None:
         log_file=tmp_path / "logs" / "app.log",
         log_max_bytes=1024,
         log_backup_count=2,
+        backup_retention_days=4,
     )
 
     dialog = app_module.SettingsDialog(None, config=config)
@@ -164,6 +165,7 @@ def test_settings_dialog_gathers_config(qt_app: Any, tmp_path: Path) -> None:
     dialog.log_file_edit.setText(str(new_log_file))
     dialog.log_max_edit.setText("8192")
     dialog.log_backup_edit.setText("5")
+    dialog.backup_retention_edit.setText("7")
 
     updated = dialog._gather_config()
 
@@ -176,6 +178,7 @@ def test_settings_dialog_gathers_config(qt_app: Any, tmp_path: Path) -> None:
     assert updated.log_file == new_log_file
     assert updated.log_max_bytes == 8192
     assert updated.log_backup_count == 5
+    assert updated.backup_retention_days == 7
 
 
 def test_main_window_applies_settings_dialog(


### PR DESCRIPTION
## Summary
- introduce un'impostazione "backup_retention_days" persistente accessibile da GUI e CLI
- esegui la pulizia automatica delle cartelle di backup e dei report più vecchi della soglia configurata
- aggiorna test e changelog per coprire la nuova funzionalità

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbe4fc39f08326b3ba9d5572729546