### PR TITLE
Add auto-accept mode for CLI diff application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ e il progetto aderisce alla [Versionamento Semantico](https://semver.org/lang/it
 - Sezione iniziale del changelog pronta per essere aggiornata con le prossime modifiche.
 - Migliorata l'esperienza del diff interattivo con badge e colori più leggibili per le aggiunte e le rimozioni.
 - Ampliate le impostazioni persistenti: ora è possibile configurare percorso del file di log, rotazione e numero di backup direttamente da CLI e GUI.
+- Nuova opzione CLI `--auto-accept` per applicare automaticamente il candidato migliore quando il diff richiede conferma manuale.
 
 ### Modificato
 - L'anteprima diff interattiva mostra le vere linee di file coinvolte nelle modifiche con colonne numerate in stile Visual Studio, facilitando il riferimento al codice originale.
 - Raffinata l'interfaccia del diff interattivo con intestazioni e contenitori più strutturati per facilitare la lettura delle patch.
 - Resa più vivace la schermata del diff interattivo con gradienti, badge neutri e pulsanti colorati che mettono in evidenza le azioni disponibili e lo stato dei file.
+- Aggiornata la documentazione CLI per illustrare le nuove modalità di applicazione automatica delle patch e le combinazioni consigliate con `--non-interactive`.
 
 ## [0.1.0] - 2025-09-18
 ### Aggiunto

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ git diff | patch-gui apply --root . --backup ~/diff_backups -
 patch-gui apply --root . --dry-run --log-level debug diff.patch
 # per disabilitare le richieste interattive in caso di ambiguità
 patch-gui apply --root . --non-interactive diff.patch
+# per accettare automaticamente il candidato migliore senza prompt
+patch-gui apply --root . --auto-accept diff.patch
 ```
 
 - `--dry-run` simula l'applicazione lasciando i file invariati; i report vengono generati a meno di `--no-report`.
@@ -146,6 +148,7 @@ patch-gui apply --root . --non-interactive diff.patch
 - `--exclude-dir NAME` permette di aggiungere directory personalizzate all'elenco di esclusione (puoi passare l'opzione più volte o separare i valori con virgole).
 - `--no-default-exclude` disabilita la lista predefinita di esclusioni (es. `.git`, `.venv`, `node_modules`, `.diff_backups`) così da poter patchare anche file normalmente ignorati.
 - `--non-interactive` mantiene il comportamento storico: se il percorso è ambiguo il file viene saltato senza prompt.
+- `--auto-accept` sceglie autonomamente il candidato migliore per file e hunk ambigui, includendo i casi fuzzy: nessun input richiesto, ma la patch viene comunque applicata.
 - `--log-level` imposta la verbosità del logger (`debug`, `info`, `warning`, `error`, `critical`; default `warning`). La variabile `PATCH_GUI_LOG_LEVEL` fornisce lo stesso controllo.
 - L'uscita termina con codice `0` solo se tutti gli hunk vengono applicati.
 
@@ -235,7 +238,7 @@ PATCH_GUI_LANG=it patch-gui apply --root . diff.patch
 
 - **Soglia fuzzy**: regola la tolleranza nel confronto del contesto (`difflib.SequenceMatcher`).
 - **EOL**: preserva lo stile originale (LF/CRLF) al salvataggio.
-- **Ricerca file**: tenta prima il percorso relativo esatto (ripulendo prefissi `a/`/`b/`), poi ricerca per nome in modo ricorsivo; in caso di multipli chiede quale usare. Con `--non-interactive` i file ambigui vengono saltati.
+- **Ricerca file**: tenta prima il percorso relativo esatto (ripulendo prefissi `a/`/`b/`), poi ricerca per nome in modo ricorsivo; in caso di multipli chiede quale usare. Con `--non-interactive` i file ambigui vengono saltati, mentre `--auto-accept` seleziona automaticamente il match con punteggio più alto.
 - **Formati supportati**: qualsiasi file di testo (JS, TS, HTML, CSS, MD, Rust, …).
 - **Logging**:
   - `PATCH_GUI_LOG_LEVEL` controlla la verbosità (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` o valori numerici come `20`). Default `INFO`.

--- a/patch_gui/cli.py
+++ b/patch_gui/cli.py
@@ -115,6 +115,10 @@ def run_cli(argv: Sequence[str] | None = None) -> int:
         force=True,
     )
 
+    interactive = not args.non_interactive
+    if args.auto_accept:
+        interactive = True
+
     try:
         patch = load_patch(args.patch, encoding=args.encoding)
         raw_backup = args.backup
@@ -134,7 +138,8 @@ def run_cli(argv: Sequence[str] | None = None) -> int:
             dry_run=args.dry_run,
             threshold=args.threshold,
             backup_base=backup_base,
-            interactive=not args.non_interactive,
+            interactive=interactive,
+            auto_accept=args.auto_accept,
             report_json=report_json_arg,
             report_txt=report_txt_arg,
             write_report_files=not args.no_report,

--- a/patch_gui/executor.py
+++ b/patch_gui/executor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import logging
 import os
 import shutil
@@ -141,6 +142,7 @@ def apply_patchset(
     threshold: float,
     backup_base: Optional[Path] = None,
     interactive: bool = True,
+    auto_accept: bool = False,
     report_json: Path | str | None = None,
     report_txt: Path | str | None = None,
     write_report_files: bool = True,
@@ -199,9 +201,18 @@ def apply_patchset(
         started_at=started_at,
     )
 
+    effective_interactive = interactive or auto_accept
+
     for pf in patch:
         rel = _relative_path_from_patch(pf)
-        fr = _apply_file_patch(root, pf, rel, session, interactive=interactive)
+        fr = _apply_file_patch(
+            root,
+            pf,
+            rel,
+            session,
+            interactive=effective_interactive,
+            auto_accept=auto_accept,
+        )
         session.results.append(fr)
 
     try:
@@ -282,6 +293,7 @@ def _apply_file_patch(
     session: ApplySession,
     *,
     interactive: bool,
+    auto_accept: bool,
 ) -> FileResult:
     fr = FileResult(file_path=Path(), relative_to_root=rel_path)
     fr.hunks_total = len(pf)
@@ -364,7 +376,9 @@ def _apply_file_patch(
                         )
                         return fr
                     selected_source = _prompt_candidate_selection(
-                        project_root, source_candidates
+                        project_root,
+                        source_candidates,
+                        auto_accept_first=auto_accept,
                     )
                     if selected_source is None:
                         fr.skipped_reason = _ambiguous_paths_message(
@@ -411,7 +425,9 @@ def _apply_file_patch(
         if not interactive:
             fr.skipped_reason = _ambiguous_paths_message(project_root, candidates)
             return fr
-        selected = _prompt_candidate_selection(project_root, candidates)
+        selected = _prompt_candidate_selection(
+            project_root, candidates, auto_accept_first=auto_accept
+        )
         if selected is None:
             fr.skipped_reason = _ambiguous_paths_message(project_root, candidates)
             return fr
@@ -551,11 +567,15 @@ def _apply_file_patch(
             )
             return fr
 
+    manual_resolver = functools.partial(
+        _cli_manual_resolver, auto_accept=auto_accept
+    )
+
     lines, decisions, applied = apply_hunks(
         lines,
         pf,
         threshold=session.threshold,
-        manual_resolver=_cli_manual_resolver,
+        manual_resolver=manual_resolver,
     )
 
     fr.hunks_applied = applied
@@ -636,11 +656,22 @@ def _apply_file_patch(
 
 
 def _prompt_candidate_selection(
-    project_root: Path, candidates: Sequence[Path]
+    project_root: Path,
+    candidates: Sequence[Path],
+    *,
+    auto_accept_first: bool = False,
 ) -> Optional[Path]:
     display_paths: List[str] = []
     for path in candidates:
         display_paths.append(display_relative_path(path, project_root))
+
+    if auto_accept_first and candidates:
+        selected = candidates[0]
+        message = _(
+            "Automatically selected {path} (--auto-accept)."
+        ).format(path=display_relative_path(selected, project_root))
+        print(message)
+        return selected
 
     print(_("Multiple files match the patch path:"))
     for idx, value in enumerate(display_paths, start=1):
@@ -694,9 +725,29 @@ def _cli_manual_resolver(
     candidates: List[Tuple[int, float]],
     decision: HunkDecision,
     reason: str,
+    *,
+    auto_accept: bool = False,
 ) -> Optional[int]:
     decision.candidates = list(candidates)
     decision.strategy = "manual"
+
+    if auto_accept and candidates:
+        pos, score = candidates[0]
+        try:
+            candidate_index = candidates.index((pos, score)) + 1
+        except ValueError:  # pragma: no cover - defensive fallback
+            candidate_index = 1
+        decision.selected_pos = pos
+        decision.similarity = score
+        decision.message = _(
+            "Automatically selected candidate {index} (--auto-accept)."
+        ).format(index=candidate_index)
+        print(
+            _(
+                "Auto-applied hunk {header} at position {position} (--auto-accept, candidate {index})."
+            ).format(header=hv.header, position=pos, index=candidate_index)
+        )
+        return pos
 
     header_message = _("Reviewing hunk: {header}").format(header=hv.header)
     if reason == "fuzzy":

--- a/patch_gui/parser.py
+++ b/patch_gui/parser.py
@@ -134,6 +134,15 @@ def build_parser(
         ),
     )
     parser.add_argument(
+        "--auto-accept",
+        action="store_true",
+        help=_(
+            "Automatically accept the best candidate when manual intervention would "
+            "normally be required. Can be combined with --non-interactive to avoid "
+            "prompts entirely."
+        ),
+    )
+    parser.add_argument(
         "--encoding",
         default=None,
         help=_(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1655,3 +1655,64 @@ def test_cli_manual_resolver_handles_context_candidates(
         assert decision.strategy == "manual"
         assert decision.selected_pos == expected_pos
         assert decision.similarity is not None
+
+def test_cli_auto_accept_resolves_fuzzy_candidates(tmp_path: Path) -> None:
+    project = tmp_path / "auto_fuzzy"
+    project.mkdir()
+    (project / "sample.txt").write_text(
+        "old apple1\nold banana1\nmiddle line\nold apple2\nold banana2\n",
+        encoding="utf-8",
+    )
+
+    session = executor.apply_patchset(
+        PatchSet(FUZZY_MANUAL_DIFF),
+        project,
+        dry_run=True,
+        threshold=0.8,
+        write_report_files=False,
+        interactive=False,
+        auto_accept=True,
+    )
+
+    result = session.results[0]
+    assert result.hunks_applied == 1
+    assert executor.session_completed(session) is True
+    decision = result.decisions[0]
+    assert decision.selected_pos is not None
+    assert decision.similarity is not None
+    assert decision.message
+    assert "auto-accept" in decision.message
+
+
+def test_cli_auto_accept_resolves_context_candidates(tmp_path: Path) -> None:
+    project = tmp_path / "auto_context"
+    project.mkdir()
+    (project / "sample.txt").write_text(
+        "line keep\n"
+        "line existing one\n"
+        "line end\n"
+        "----\n"
+        "line keep\n"
+        "line existing two\n"
+        "line end\n",
+        encoding="utf-8",
+    )
+
+    session = executor.apply_patchset(
+        PatchSet(CONTEXT_MANUAL_DIFF),
+        project,
+        dry_run=True,
+        threshold=0.7,
+        write_report_files=False,
+        interactive=False,
+        auto_accept=True,
+    )
+
+    result = session.results[0]
+    assert result.hunks_applied == 1
+    assert executor.session_completed(session) is True
+    decision = result.decisions[0]
+    assert decision.selected_pos is not None
+    assert decision.similarity is not None
+    assert decision.message
+    assert "auto-accept" in decision.message

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -426,6 +426,7 @@ def test_apply_file_patch_removes_file_and_keeps_backup(tmp_path: Path) -> None:
         rel_path,
         session,
         interactive=False,
+        auto_accept=False,
     )
 
     assert fr.skipped_reason is None


### PR DESCRIPTION
## Summary
- add a `--auto-accept` option to the CLI so ambiguous files and hunks are resolved automatically without user input
- teach the executor to auto-select the best candidate for file path and hunk placement when auto-accept is enabled
- document the new behaviour in the README and changelog and cover it with dedicated regression tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbe5208acc83268230868157f00d62