### PR TITLE
Add CLI command to download Windows executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ e il progetto aderisce alla [Versionamento Semantico](https://semver.org/lang/it
 - Sezione iniziale del changelog pronta per essere aggiornata con le prossime modifiche.
 - Migliorata l'esperienza del diff interattivo con badge e colori più leggibili per le aggiunte e le rimozioni.
 - Ampliate le impostazioni persistenti: ora è possibile configurare percorso del file di log, rotazione e numero di backup direttamente da CLI e GUI.
+- Sottocomando `patch-gui download-exe` per scaricare rapidamente l'eseguibile Windows dalle release del progetto.
 
 ### Modificato
 - L'anteprima diff interattiva mostra le vere linee di file coinvolte nelle modifiche con colonne numerate in stile Visual Studio, facilitando il riferimento al codice originale.

--- a/README.md
+++ b/README.md
@@ -149,6 +149,16 @@ patch-gui apply --root . --non-interactive diff.patch
 - `--log-level` imposta la verbosità del logger (`debug`, `info`, `warning`, `error`, `critical`; default `warning`). La variabile `PATCH_GUI_LOG_LEVEL` fornisce lo stesso controllo.
 - L'uscita termina con codice `0` solo se tutti gli hunk vengono applicati.
 
+### 📦 Scaricare l'eseguibile Windows
+
+Per ottenere rapidamente il file `patch-gui.exe` distribuito nelle release ufficiali usa il nuovo comando dedicato:
+
+```bash
+patch-gui download-exe
+```
+
+Per impostazione predefinita l'eseguibile viene salvato nella cartella corrente; con `--output` puoi specificare un percorso personalizzato (anche una directory). Le opzioni `--repo`, `--asset-name` e `--tag` consentono di puntare a repository o release diversi, mentre `--force` permette di sovrascrivere un file già esistente.
+
 ---
 
 ## ✅ Test

--- a/patch_gui/diff_applier_gui.py
+++ b/patch_gui/diff_applier_gui.py
@@ -61,6 +61,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args[0] == "config":
         return cli.run_config(args[1:])
 
+    if args[0] == "download-exe":
+        return cli.run_download_exe(args[1:])
+
     if any(opt in {"-h", "--help"} for opt in args):
         _print_help()
         return 0
@@ -123,7 +126,7 @@ def _print_help() -> None:
     parser.add_argument(
         "command",
         nargs="?",
-        choices=["gui", "apply", "config"],
+        choices=["gui", "apply", "config", "download-exe"],
         help=_tr("Command to execute (default: gui)."),
     )
     parser.print_help()
@@ -131,6 +134,8 @@ def _print_help() -> None:
     cli.build_parser().print_help()
     print(_tr("\nConfiguration commands:"), file=sys.stdout)
     cli.build_config_parser().print_help()
+    print(_tr("\nExecutable download command:"), file=sys.stdout)
+    cli.build_download_parser().print_help()
 
 
 def _ensure_translator() -> None:

--- a/patch_gui/downloader.py
+++ b/patch_gui/downloader.py
@@ -1,0 +1,227 @@
+"""Helpers to download pre-built binaries distributed with the project."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO, Iterable, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from .localization import gettext as _
+
+__all__ = [
+    "DEFAULT_REPO",
+    "DEFAULT_ASSET_NAME",
+    "DownloadError",
+    "download_latest_release_exe",
+]
+
+
+# GitHub repository holding the Windows binary. The value can be overridden via the
+# command-line but defaults to the upstream project.
+DEFAULT_REPO = "patch-gui/patch-gui"
+# Conventional filename for the Windows executable asset shipped in releases.
+DEFAULT_ASSET_NAME = "patch-gui.exe"
+
+
+class _Opener(Protocol):
+    """Protocol describing the ``urllib.request.urlopen`` compatible callable."""
+
+    def __call__(self, request: Request) -> BinaryIO:
+        ...
+
+
+class DownloadError(Exception):
+    """Raised when a release asset cannot be retrieved."""
+
+
+@dataclass
+class _ReleaseAsset:
+    name: str
+    download_url: str
+
+
+def download_latest_release_exe(
+    *,
+    repo: str = DEFAULT_REPO,
+    asset_name: str = DEFAULT_ASSET_NAME,
+    destination: Path | None = None,
+    overwrite: bool = False,
+    token: str | None = None,
+    tag: str | None = None,
+    opener: _Opener | None = None,
+) -> Path:
+    """Download ``asset_name`` from the latest release of ``repo``.
+
+    Parameters
+    ----------
+    repo:
+        Repository in the form ``"owner/name"``.
+    asset_name:
+        Name of the asset to search for. Matching is case-insensitive and exact.
+    destination:
+        Path where the executable should be stored. When omitted the file is
+        written inside the current working directory using ``asset_name``.
+        If ``destination`` points to an existing directory the asset name is
+        appended to that path.
+    overwrite:
+        When ``True`` the destination file is replaced if present. Otherwise a
+        ``DownloadError`` is raised when the path already exists.
+    token:
+        Optional GitHub token to authenticate against private repositories.
+    tag:
+        Specific release tag to download instead of the latest published
+        release.
+    opener:
+        Callable compatible with :func:`urllib.request.urlopen` used mostly for
+        testing.
+
+    Returns
+    -------
+    Path
+        The location of the downloaded executable.
+    """
+
+    opener_fn = opener or urlopen
+    release = _fetch_release(repo=repo, token=token, tag=tag, opener=opener_fn)
+    asset = _select_asset(release, asset_name)
+
+    destination_path = _resolve_destination(destination, asset.name)
+    if destination_path.exists() and not overwrite:
+        raise DownloadError(
+            _(
+                "Destination file already exists: {path}. Use --force to overwrite."
+            ).format(path=destination_path)
+        )
+
+    request = _build_request(asset.download_url, token=token)
+    response = opener_fn(request)
+    try:
+        data_stream = _ensure_binary_stream(response)
+        destination_path.parent.mkdir(parents=True, exist_ok=True)
+        with destination_path.open("wb") as handle:
+            _copy_stream(data_stream, handle)
+    finally:
+        try:
+            response.close()
+        except AttributeError:
+            pass
+
+    return destination_path
+
+
+def _fetch_release(
+    *,
+    repo: str,
+    token: str | None,
+    tag: str | None,
+    opener: _Opener,
+) -> dict[str, object]:
+    suffix = f"/tags/{tag}" if tag else "/latest"
+    request = _build_request(
+        f"https://api.github.com/repos/{repo}/releases{suffix}", token=token
+    )
+    try:
+        response = opener(request)
+    except HTTPError as exc:  # pragma: no cover - network failures are rare
+        raise DownloadError(_("Failed to query release metadata: {error}").format(error=exc))
+    except URLError as exc:  # pragma: no cover - network failures are rare
+        raise DownloadError(_("Unable to reach GitHub: {error}").format(error=exc))
+
+    try:
+        payload = response.read()
+    finally:
+        try:
+            response.close()
+        except AttributeError:
+            pass
+
+    try:
+        data = json.loads(payload.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise DownloadError(
+            _("Unexpected response received from GitHub: {error}").format(error=exc)
+        ) from exc
+
+    if isinstance(data, dict) and data.get("message") == "Not Found":
+        if tag:
+            raise DownloadError(
+                _("Release with tag '{tag}' was not found for {repo}.").format(
+                    tag=tag, repo=repo
+                )
+            )
+        raise DownloadError(
+            _("Latest release for {repo} was not found.").format(repo=repo)
+        )
+
+    if not isinstance(data, dict):
+        raise DownloadError(_("Malformed release information returned by GitHub."))
+
+    return data
+
+
+def _select_asset(data: dict[str, object], asset_name: str) -> _ReleaseAsset:
+    assets_obj = data.get("assets")
+    if not isinstance(assets_obj, Iterable):
+        raise DownloadError(_("Release data does not contain any assets."))
+
+    normalized = asset_name.lower()
+    matched = None
+    for entry in assets_obj:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        download_url = entry.get("browser_download_url")
+        if not isinstance(name, str) or not isinstance(download_url, str):
+            continue
+        if name.lower() == normalized:
+            matched = _ReleaseAsset(name=name, download_url=download_url)
+            break
+
+    if matched is None:
+        raise DownloadError(
+            _("Asset '{asset}' was not found in the selected release.").format(
+                asset=asset_name
+            )
+        )
+
+    return matched
+
+
+def _resolve_destination(destination: Path | None, asset_name: str) -> Path:
+    if destination is None:
+        return Path.cwd() / asset_name
+
+    path = Path(destination)
+    if path.exists() and path.is_dir():
+        return path / asset_name
+
+    return path
+
+
+def _build_request(url: str, token: str | None = None) -> Request:
+    request = Request(url)
+    request.add_header("User-Agent", "patch-gui-downloader")
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+    return request
+
+
+def _ensure_binary_stream(handle: BinaryIO) -> BinaryIO:
+    # ``urllib`` returns objects implementing a ``read`` method but not typing's
+    # ``BinaryIO`` protocol. The helper acts as documentation and a central
+    # assertion point.
+    if not hasattr(handle, "read"):
+        raise DownloadError(_("GitHub response is missing the download body."))
+    return handle
+
+
+def _copy_stream(source: BinaryIO, destination: BinaryIO, chunk_size: int = 64 * 1024) -> None:
+    while True:
+        chunk = source.read(chunk_size)
+        if not chunk:
+            break
+        destination.write(chunk)
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1539,6 +1539,63 @@ def test_threshold_value_rejects_invalid_inputs(
     assert str(excinfo.value) == expected_message
 
 
+def test_run_download_exe_invokes_downloader(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    recorded: dict[str, object] = {}
+
+    def fake_download(**kwargs: object) -> Path:
+        recorded.update(kwargs)
+        return tmp_path / "patch-gui.exe"
+
+    monkeypatch.setattr(cli, "download_latest_release_exe", fake_download)
+
+    exit_code = cli.run_download_exe(
+        [
+            "--repo",
+            "owner/project",
+            "--asset-name",
+            "custom.exe",
+            "--output",
+            str(tmp_path / "exports" / "custom.exe"),
+            "--token",
+            "secret",
+            "--tag",
+            "v1.2.3",
+            "--force",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Downloaded custom.exe" in captured.out
+    assert captured.err == ""
+    assert recorded == {
+        "repo": "owner/project",
+        "asset_name": "custom.exe",
+        "destination": Path(tmp_path / "exports" / "custom.exe"),
+        "overwrite": True,
+        "token": "secret",
+        "tag": "v1.2.3",
+    }
+
+
+def test_run_download_exe_reports_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def fake_download(**kwargs: object) -> Path:
+        raise cli.DownloadError("boom")
+
+    monkeypatch.setattr(cli, "download_latest_release_exe", fake_download)
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.run_download_exe([])
+
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert "boom" in captured.err
+
+
 @pytest.mark.parametrize(
     "user_input, expected_applied, expected_completed, expected_pos",
     [("2", 1, True, 3), ("", 0, False, None)],

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -1,0 +1,113 @@
+"""Tests for the release asset downloader helpers."""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from patch_gui import downloader
+
+
+class _FakeResponse:
+    def __init__(self, payload: bytes) -> None:
+        self._buffer = io.BytesIO(payload)
+
+    def read(self, size: int = -1) -> bytes:
+        return self._buffer.read(size)
+
+    def close(self) -> None:  # pragma: no cover - ``BytesIO`` does not require closing
+        self._buffer.close()
+
+
+class _FakeOpener:
+    def __init__(self, responses: list[_FakeResponse]) -> None:
+        self._responses: List[_FakeResponse] = list(responses)
+        self.requests: list[str] = []
+
+    def __call__(self, request) -> _FakeResponse:  # type: ignore[override]
+        self.requests.append(request.full_url)
+        if not self._responses:
+            raise AssertionError("No fake responses left for opener")
+        return self._responses.pop(0)
+
+
+def _release_payload(url: str) -> bytes:
+    body = {
+        "assets": [
+            {
+                "name": downloader.DEFAULT_ASSET_NAME,
+                "browser_download_url": url,
+            }
+        ]
+    }
+    return json.dumps(body).encode("utf-8")
+
+
+def test_download_latest_release_exe_saves_file(tmp_path: Path) -> None:
+    download_url = "https://example.test/patch-gui.exe"
+    responses = _FakeOpener(
+        [
+            _FakeResponse(_release_payload(download_url)),
+            _FakeResponse(b"binary-data"),
+        ]
+    )
+    destination = tmp_path / "artifacts" / "PatchGUI.exe"
+
+    saved = downloader.download_latest_release_exe(
+        destination=destination,
+        overwrite=True,
+        opener=responses,
+    )
+
+    assert saved == destination
+    assert saved.read_bytes() == b"binary-data"
+    assert responses.requests[0].endswith("/releases/latest")
+    assert responses.requests[1] == download_url
+
+
+def test_download_latest_release_exe_appends_asset_name_when_directory(tmp_path: Path) -> None:
+    download_url = "https://example.test/patch-gui.exe"
+    responses = _FakeOpener(
+        [
+            _FakeResponse(_release_payload(download_url)),
+            _FakeResponse(b"payload"),
+        ]
+    )
+    target_dir = tmp_path / "downloads"
+    target_dir.mkdir()
+
+    saved = downloader.download_latest_release_exe(
+        destination=target_dir,
+        overwrite=True,
+        opener=responses,
+    )
+
+    expected = target_dir / downloader.DEFAULT_ASSET_NAME
+    assert saved == expected
+    assert saved.read_bytes() == b"payload"
+
+
+def test_download_latest_release_exe_raises_when_asset_missing(tmp_path: Path) -> None:
+    body = json.dumps({"assets": []}).encode("utf-8")
+    responses = _FakeOpener([_FakeResponse(body)])
+
+    with pytest.raises(downloader.DownloadError) as excinfo:
+        downloader.download_latest_release_exe(opener=responses)
+
+    assert "Asset" in str(excinfo.value)
+
+
+def test_download_latest_release_exe_requires_force_for_existing_file(tmp_path: Path) -> None:
+    existing = tmp_path / downloader.DEFAULT_ASSET_NAME
+    existing.write_bytes(b"old")
+
+    responses = _FakeOpener([_FakeResponse(_release_payload("https://example.test"))])
+
+    with pytest.raises(downloader.DownloadError) as excinfo:
+        downloader.download_latest_release_exe(destination=existing, opener=responses)
+
+    assert "Use --force" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- add a reusable downloader module capable of fetching the packaged Windows executable from GitHub releases
- extend the CLI with a `download-exe` subcommand and document it in the README
- cover the new behavior with dedicated unit tests and update the changelog

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbe52c27fc8326a9e1c4cc539d0015