### PR TITLE
feat(gui): redesign interactive diff with side-by-side editing

### DIFF
--- a/tests/test_interactive_diff_formatting.py
+++ b/tests/test_interactive_diff_formatting.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from unidiff import PatchSet
 
-from patch_gui.diff_formatting import format_diff_with_line_numbers
+from patch_gui.diff_formatting import (
+    format_diff_side_by_side,
+    format_diff_with_line_numbers,
+)
 
 
 def test_format_diff_with_line_numbers_includes_real_positions() -> None:
@@ -41,3 +44,47 @@ def test_format_diff_with_line_numbers_returns_fallback_for_binary() -> None:
     formatted = format_diff_with_line_numbers(patched_file, diff_text)
 
     assert formatted == diff_text
+
+
+def test_format_diff_side_by_side_produces_two_columns() -> None:
+    diff_text = """diff --git a/foo.txt b/foo.txt\nindex 1234567..89abcde 100644\n--- a/foo.txt\n+++ b/foo.txt\n@@ -1,2 +1,3 @@\n line1\n-line2\n+line2 changed\n+line3\n"""
+
+    patch = PatchSet(diff_text)
+    patched_file = patch[0]
+
+    left, right = format_diff_side_by_side(patched_file, diff_text)
+
+    assert left.splitlines() == [
+        "diff --git a/foo.txt b/foo.txt",
+        "index 1234567..89abcde 100644",
+        "--- a/foo.txt",
+        "@@ -1,2 +1,3 @@",
+        "     1 │  line1",
+        "     2 │ -line2",
+        "       │ ",
+        "       │ ",
+    ]
+    assert right.splitlines() == [
+        "diff --git a/foo.txt b/foo.txt",
+        "index 1234567..89abcde 100644",
+        "+++ b/foo.txt",
+        "@@ -1,2 +1,3 @@",
+        "     1 │  line1",
+        "       │ ",
+        "     2 │ +line2 changed",
+        "     3 │ +line3",
+    ]
+
+
+def test_format_diff_side_by_side_returns_fallback_for_binary() -> None:
+    diff_text = """diff --git a/image.png b/image.png\nindex 1234567..89abcde 100644\nBinary files a/image.png and b/image.png differ\n"""
+
+    patch = PatchSet(diff_text)
+    patched_file = patch[0]
+
+    assert patched_file.is_binary_file is True
+
+    left, right = format_diff_side_by_side(patched_file, diff_text)
+
+    assert left == diff_text
+    assert right == diff_text


### PR DESCRIPTION
## Summary
- redesign the interactive diff tab with a Visual Studio–style side-by-side preview, an inline diff editor, and live validation feedback
- keep list entries and badges in sync while users edit patches, rebuilding previews from the modified diff text
- expose a helper to render diffs as aligned columns and cover it with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc080b08048326aab2f2226492cd9e