### PR TITLE
Add optional AI summaries for patch sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ e il progetto aderisce al [Versionamento Semantico](https://semver.org/lang/it/)
 
 ## [Non rilasciato]
 
+### Aggiunto
+- Integrazione opzionale con modelli AI per generare un riepilogo automatico
+  delle applicazioni di patch, incluso nei log, nei dialoghi e nei report.
+
 ## [0.2.0] - 2025-09-18
 ### Aggiunto
 - Sottocomando `patch-gui download-exe` per scaricare rapidamente l'eseguibile

--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ mantenere l'automazione nei flussi di lavoro Git.
 6. [GUI in breve](#gui-in-breve)
 7. [Backup e report](#backup-e-report)
 8. [Configurazione persistente](#configurazione-persistente)
-9. [Sviluppo e test](#sviluppo-e-test)
-10. [Risoluzione problemi](#risoluzione-problemi)
-11. [Licenza](#licenza)
+9. [Integrazione AI](#integrazione-ai)
+10. [Sviluppo e test](#sviluppo-e-test)
+11. [Risoluzione problemi](#risoluzione-problemi)
+12. [Licenza](#licenza)
 
 ## Panoramica
 
@@ -198,6 +199,31 @@ Le impostazioni vengono salvate in `settings.toml` sotto:
 La configurazione include soglia fuzzy, directory escluse, percorsi di backup,
 livello di log, gestione dei report e parametri di rotazione del file di log.
 Puoi modificarla dalla GUI o tramite `patch-gui config`.
+
+## Integrazione AI
+
+Patch GUI può chiedere a un modello linguistico un riepilogo delle modifiche
+applicate. La funzionalità è opzionale e disabilitata finché non viene
+configurato un provider compatibile.
+
+- Installa la dipendenza extra:
+
+  ```bash
+  pip install openai
+  ```
+
+- Esporta una API key valida e, facoltativamente, il modello da usare:
+
+  ```bash
+  export OPENAI_API_KEY="sk-..."
+  export PATCH_GUI_OPENAI_MODEL="gpt-4o-mini"  # opzionale
+  ```
+
+Al termine di ogni esecuzione, CLI e GUI proveranno a generare un riassunto con
+OpenAI. Se l'integrazione non è disponibile viene creato un riepilogo locale
+basato sui risultati, con un avviso nel log. I report `json` e `txt` includono
+i nuovi campi `ai_summary`, `ai_summary_provider` e `ai_summary_error` per una
+tracciabilità completa.
 
 ## Sviluppo e test
 

--- a/patch_gui/ai_summaries.py
+++ b/patch_gui/ai_summaries.py
@@ -1,0 +1,216 @@
+"""Integration helpers for AI-generated summaries of patch results."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Iterable, Optional, Sequence
+
+from .localization import gettext as _
+from .patcher import FileResult
+
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_PROVIDER_ENV = "PATCH_GUI_SUMMARY_PROVIDER"
+DEFAULT_MODEL_ENV = "PATCH_GUI_OPENAI_MODEL"
+DEFAULT_LANGUAGE_ENV = "PATCH_GUI_SUMMARY_LANGUAGE"
+OPENAI_API_KEY_ENV = "OPENAI_API_KEY"
+
+
+@dataclass(slots=True)
+class AISummaryResult:
+    """Container for AI summary metadata."""
+
+    summary: Optional[str]
+    provider: Optional[str] = None
+    error: Optional[str] = None
+
+
+def generate_ai_summary(
+    results: Sequence[FileResult],
+    *,
+    provider: str | None = None,
+    model: str | None = None,
+    language: str | None = None,
+) -> AISummaryResult:
+    """Return a concise AI-generated summary for ``results`` when possible."""
+
+    provider_name = provider or os.getenv(DEFAULT_PROVIDER_ENV, "openai")
+    language = language or os.getenv(DEFAULT_LANGUAGE_ENV, "it")
+
+    ai_result: AISummaryResult | None = None
+
+    if provider_name == "openai":
+        ai_result = _generate_openai_summary(results, model=model, language=language)
+
+    if ai_result and ai_result.summary:
+        return ai_result
+
+    fallback = _generate_fallback_summary(results, language=language)
+    error_message = None
+    if ai_result and ai_result.error:
+        error_message = ai_result.error
+    elif provider_name == "openai" and ai_result is None:
+        error_message = _(
+            "Dipendenza 'openai' non disponibile o API key mancante."
+        )
+
+    return AISummaryResult(
+        summary=fallback,
+        provider="local-fallback" if fallback else provider_name,
+        error=error_message,
+    )
+
+
+def _generate_openai_summary(
+    results: Sequence[FileResult],
+    *,
+    model: str | None,
+    language: str,
+) -> AISummaryResult | None:
+    api_key = os.getenv(OPENAI_API_KEY_ENV)
+    if not api_key:
+        return AISummaryResult(summary=None, provider="openai", error=_("Variabile OPENAI_API_KEY non impostata."))
+
+    try:
+        import openai  # type: ignore[import-not-found]
+    except Exception as exc:  # pragma: no cover - optional dependency
+        logger.debug("Modulo openai non disponibile: %s", exc)
+        return AISummaryResult(summary=None, provider="openai", error=str(exc))
+
+    target_model = model or os.getenv(DEFAULT_MODEL_ENV) or "gpt-4o-mini"
+    prompt = _build_prompt(results, language=language)
+
+    try:
+        if hasattr(openai, "OpenAI"):
+            client = openai.OpenAI(api_key=api_key)
+            response = client.responses.create(
+                model=target_model,
+                input=[
+                    {
+                        "role": "system",
+                        "content": _(
+                            "Sei un assistente che riassume applicazioni di patch. "
+                            "Produci al massimo 5 punti concisi in {language}."
+                        ).format(language=language),
+                    },
+                    {"role": "user", "content": prompt},
+                ],
+                max_output_tokens=250,
+                temperature=0.2,
+            )
+            summary_text = getattr(response, "output_text", "").strip()
+        else:  # pragma: no cover - legacy API path
+            openai.api_key = api_key
+            chat = openai.ChatCompletion.create(
+                model=target_model,
+                messages=[
+                    {
+                        "role": "system",
+                        "content": _(
+                            "Sei un assistente che riassume applicazioni di patch. "
+                            "Produci al massimo 5 punti concisi in {language}."
+                        ).format(language=language),
+                    },
+                    {"role": "user", "content": prompt},
+                ],
+                max_tokens=200,
+                temperature=0.2,
+            )
+            choices = chat.get("choices", [])
+            if choices:
+                summary_text = (
+                    choices[0]
+                    .get("message", {})
+                    .get("content", "")
+                    .strip()
+                )
+            else:
+                summary_text = ""
+    except Exception as exc:  # pragma: no cover - network/runtime failures
+        logger.warning("Generazione riepilogo AI fallita: %s", exc)
+        return AISummaryResult(summary=None, provider="openai", error=str(exc))
+
+    if not summary_text:
+        return AISummaryResult(summary=None, provider="openai", error=_("Risposta vuota dal provider OpenAI."))
+
+    return AISummaryResult(summary=summary_text, provider="openai", error=None)
+
+
+def _build_prompt(results: Sequence[FileResult], *, language: str) -> str:
+    payload: list[dict[str, object]] = []
+    for fr in results:
+        decisions = [
+            {
+                "header": d.hunk_header,
+                "strategy": d.strategy,
+                "selected_pos": d.selected_pos,
+                "similarity": d.similarity,
+                "message": d.message,
+            }
+            for d in fr.decisions
+        ]
+        payload.append(
+            {
+                "path": fr.relative_to_root or str(fr.file_path),
+                "file_type": fr.file_type,
+                "hunks_applied": fr.hunks_applied,
+                "hunks_total": fr.hunks_total,
+                "skipped_reason": fr.skipped_reason,
+                "decisions": decisions,
+            }
+        )
+
+    description = json.dumps(payload, ensure_ascii=False, indent=2)
+    return _(
+        "Riassumi il seguente risultato di applicazione patch in {language} "
+        "con poche frasi o punti elenco:\n{description}"
+    ).format(language=language, description=description)
+
+
+def _generate_fallback_summary(
+    results: Iterable[FileResult],
+    *,
+    language: str,
+) -> str | None:
+    entries: list[str] = []
+    for fr in results:
+        display_path = fr.relative_to_root or str(fr.file_path)
+        if fr.skipped_reason:
+            entries.append(
+                _("{path}: saltato ({reason})").format(
+                    path=display_path, reason=fr.skipped_reason
+                )
+            )
+            continue
+        if fr.hunks_total == 0:
+            entries.append(
+                _("{path}: nessuna modifica da applicare").format(path=display_path)
+            )
+            continue
+        entries.append(
+            _("{path}: applicati {applied}/{total} hunk").format(
+                path=display_path,
+                applied=fr.hunks_applied,
+                total=fr.hunks_total,
+            )
+        )
+
+    if not entries:
+        return None
+
+    limited = entries[:5]
+    bullets = "\n".join(f"- {entry}" for entry in limited)
+    if language.lower().startswith("it"):
+        heading = _("Riepilogo automatico")
+    else:
+        heading = "Automatic summary"
+    return f"{heading}:\n{bullets}"
+
+
+__all__ = ["AISummaryResult", "generate_ai_summary"]
+

--- a/patch_gui/executor.py
+++ b/patch_gui/executor.py
@@ -15,6 +15,7 @@ from typing import Any, Iterable, List, Optional, Sequence, Tuple
 from unidiff import PatchSet
 from unidiff.errors import UnidiffParseError
 
+from .ai_summaries import generate_ai_summary
 from .config import AppConfig, load_config
 from .filetypes import inspect_file_type
 from .localization import gettext as _
@@ -230,6 +231,20 @@ def apply_patchset(
             auto_accept=auto_accept,
         )
         session.results.append(fr)
+
+    summary = generate_ai_summary(session.results)
+    session.ai_summary = summary.summary
+    session.ai_summary_provider = summary.provider
+    session.ai_summary_error = summary.error
+    if summary.summary:
+        logger.info(
+            _("\n=== SINTESI ({provider}) ===\n{summary}").format(
+                provider=summary.provider or _("sconosciuto"),
+                summary=summary.summary,
+            )
+        )
+    elif summary.error:
+        logger.info(_("Sintesi AI non disponibile: %s"), summary.error)
 
     try:
         write_session_reports(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -239,6 +239,11 @@ def test_apply_patchset_dry_run(tmp_path: Path) -> None:
     assert file_result.skipped_reason is None
     assert file_result.hunks_applied == file_result.hunks_total == 1
     assert file_result.file_type == "text"
+    assert session.ai_summary is not None
+    assert session.ai_summary_provider == "local-fallback"
+    assert session.ai_summary_error is not None
+    report_text = session.to_txt()
+    assert "AI summary" in report_text
 
 
 def test_apply_patchset_invalid_threshold(tmp_path: Path) -> None:
@@ -303,6 +308,8 @@ def test_apply_patchset_real_run_creates_backup(tmp_path: Path) -> None:
     data = json.loads(json_report.read_text(encoding="utf-8"))
     assert data["files"][0]["hunks_applied"] == 1
     assert data["files"][0]["file_type"] == "text"
+    assert data["ai_summary"] == session.ai_summary
+    assert data["ai_summary_provider"] == session.ai_summary_provider
 
 
 def test_apply_patchset_removes_file_and_preserves_backup(tmp_path: Path) -> None:

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -409,8 +409,10 @@ def test_apply_patchset_reports_rename_only_details(tmp_path: Path) -> None:
 
     json_report = session.to_json()
     assert json_report["files"][0]["decisions"][0]["strategy"] == "rename"  # type: ignore[index]
+    assert json_report["ai_summary"] == session.ai_summary
     text_report = session.to_txt()
     assert "Hunk rename -> rename" in text_report
+    assert "AI summary" in text_report
 
 
 def test_apply_patchset_reports_rename_with_edit_details(tmp_path: Path) -> None:
@@ -438,8 +440,10 @@ def test_apply_patchset_reports_rename_with_edit_details(tmp_path: Path) -> None
     json_report = session.to_json()
     assert json_report["files"][0]["decisions"][0]["strategy"] == "rename"  # type: ignore[index]
     assert json_report["files"][0]["hunks_applied"] == 1  # type: ignore[index]
+    assert json_report["ai_summary"] == session.ai_summary
     text_report = session.to_txt()
     assert "Hunk rename -> rename" in text_report
+    assert "AI summary" in text_report
 
 
 def test_apply_file_patch_removes_file_and_keeps_backup(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add an AI summary helper that integrates with OpenAI when available and falls back to a deterministic local summary
- extend apply sessions, reporting, and UI logging to include the generated summaries
- document the optional AI dependency and changelog entry

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc14bfd25083268fb1009ad3d31aa0