### PR TITLE
Add AI note support to interactive diff view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ e il progetto aderisce al [Versionamento Semantico](https://semver.org/lang/it/)
 
 ## [Non rilasciato]
 
+- Arricchita la vista diff interattiva con note opzionali generate da un client
+  AI condiviso e abilitate da una nuova preferenza dell'applicazione.
+
 ## [0.2.0] - 2025-09-18
 ### Aggiunto
 - Sottocomando `patch-gui download-exe` per scaricare rapidamente l'eseguibile

--- a/patch_gui/config.py
+++ b/patch_gui/config.py
@@ -84,6 +84,7 @@ class AppConfig:
     log_max_bytes: int = DEFAULT_LOG_MAX_BYTES
     log_backup_count: int = DEFAULT_LOG_BACKUP_COUNT
     backup_retention_days: int = DEFAULT_BACKUP_RETENTION_DAYS
+    ai_diff_notes: bool = False
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any]) -> "AppConfig":
@@ -99,6 +100,7 @@ class AppConfig:
             data.get("dry_run_default"), base.dry_run_default
         )
         write_reports = _coerce_bool(data.get("write_reports"), base.write_reports)
+        ai_diff_notes = _coerce_bool(data.get("ai_diff_notes"), base.ai_diff_notes)
         log_file = _coerce_path(data.get("log_file"), base.log_file)
         log_max_bytes = _coerce_non_negative_int(
             data.get("log_max_bytes"), base.log_max_bytes
@@ -117,6 +119,7 @@ class AppConfig:
             log_level=log_level,
             dry_run_default=dry_run_default,
             write_reports=write_reports,
+            ai_diff_notes=ai_diff_notes,
             log_file=log_file,
             log_max_bytes=log_max_bytes,
             log_backup_count=log_backup_count,
@@ -133,6 +136,7 @@ class AppConfig:
             "log_level": str(self.log_level),
             "dry_run_default": bool(self.dry_run_default),
             "write_reports": bool(self.write_reports),
+            "ai_diff_notes": bool(self.ai_diff_notes),
             "log_file": str(self.log_file),
             "log_max_bytes": int(self.log_max_bytes),
             "log_backup_count": int(self.log_backup_count),
@@ -198,6 +202,7 @@ def save_config(config: AppConfig, path: Path | None = None) -> Path:
     log_level_repr = json.dumps(mapping["log_level"])
     dry_run_repr = json.dumps(mapping["dry_run_default"])
     write_reports_repr = json.dumps(mapping["write_reports"])
+    ai_diff_notes_repr = json.dumps(mapping["ai_diff_notes"])
     backup_repr = json.dumps(mapping["backup_base"])
     log_file_repr = json.dumps(mapping["log_file"])
     log_max_bytes_repr = json.dumps(mapping["log_max_bytes"])
@@ -212,6 +217,7 @@ def save_config(config: AppConfig, path: Path | None = None) -> Path:
         f"log_level = {log_level_repr}",
         f"dry_run_default = {dry_run_repr}",
         f"write_reports = {write_reports_repr}",
+        f"ai_diff_notes = {ai_diff_notes_repr}",
         f"log_file = {log_file_repr}",
         f"log_max_bytes = {log_max_bytes_repr}",
         f"log_backup_count = {log_backup_count_repr}",

--- a/tests/test_interactive_diff_formatting.py
+++ b/tests/test_interactive_diff_formatting.py
@@ -2,9 +2,26 @@
 
 from __future__ import annotations
 
+import pytest
 from unidiff import PatchSet
 
 from patch_gui.diff_formatting import format_diff_with_line_numbers
+
+try:  # pragma: no cover - optional dependency for GUI-only features
+    from patch_gui.interactive_diff import (
+        FileDiffEntry,
+        InteractiveDiffWidget,
+        with_ai_note,
+    )
+except ImportError:  # pragma: no cover - gracefully skip when PySide6 is missing
+    InteractiveDiffWidget = None  # type: ignore[assignment]
+    FileDiffEntry = None  # type: ignore[assignment]
+    with_ai_note = None  # type: ignore[assignment]
+    _HAS_QT = False
+else:  # pragma: no cover - exercised when PySide6 is available
+    from PySide6 import QtCore, QtWidgets
+
+    _HAS_QT = True
 
 
 def test_format_diff_with_line_numbers_includes_real_positions() -> None:
@@ -41,3 +58,126 @@ def test_format_diff_with_line_numbers_returns_fallback_for_binary() -> None:
     formatted = format_diff_with_line_numbers(patched_file, diff_text)
 
     assert formatted == diff_text
+
+
+def _ensure_qapplication() -> QtWidgets.QApplication:
+    if not _HAS_QT or InteractiveDiffWidget is None:  # pragma: no cover - guard
+        pytest.skip("PySide6 non disponibile nel test runner")
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    return app
+
+
+class _RecordingProvider:
+    def __init__(self, note: str | None, *, fail: bool = False) -> None:
+        self.note = note
+        self.fail = fail
+        self.calls: list[tuple[str, str]] = []
+
+    def build_note(self, file_label: str, diff_text: str) -> str | None:
+        self.calls.append((file_label, diff_text))
+        if self.fail:
+            raise RuntimeError("boom")
+        return self.note
+
+
+def _make_entry() -> FileDiffEntry:
+    assert FileDiffEntry is not None
+    return FileDiffEntry(
+        file_label="foo.py",
+        diff_text="--- a/foo.py\n+++ b/foo.py\n+print('hi')\n",
+        annotated_diff_text="annotated",
+        additions=1,
+        deletions=0,
+    )
+
+
+@pytest.mark.skipif(not _HAS_QT, reason="PySide6 non disponibile nel test runner")
+def test_with_ai_note_uses_provider_response() -> None:
+    assert with_ai_note is not None
+    entry = _make_entry()
+    provider = _RecordingProvider("nota sintetica")
+
+    enriched = with_ai_note(entry, provider)
+
+    assert enriched.ai_note == "nota sintetica"
+    assert provider.calls == [(entry.file_label, entry.diff_text)]
+    assert entry.ai_note is None
+
+
+@pytest.mark.skipif(not _HAS_QT, reason="PySide6 non disponibile nel test runner")
+def test_with_ai_note_swallows_provider_errors() -> None:
+    assert with_ai_note is not None
+    entry = _make_entry()
+    provider = _RecordingProvider(None, fail=True)
+
+    enriched = with_ai_note(entry, provider)
+
+    assert enriched.ai_note is None
+    assert provider.calls == [(entry.file_label, entry.diff_text)]
+
+
+@pytest.mark.skipif(not _HAS_QT, reason="PySide6 non disponibile nel test runner")
+def test_interactive_diff_set_patch_populates_ai_notes() -> None:
+    _ensure_qapplication()
+    assert InteractiveDiffWidget is not None
+    widget = InteractiveDiffWidget()
+    provider = _RecordingProvider("nota sintetica")
+    widget.set_ai_note_provider(provider)
+
+    diff_text = """diff --git a/foo.py b/foo.py\nindex 1111111..2222222 100644\n--- a/foo.py\n+++ b/foo.py\n@@ -0,0 +1 @@\n+print('hi')\n"""
+    patch = PatchSet(diff_text)
+
+    widget.set_patch(patch)
+
+    item = widget._list_widget.item(0)
+    entry = item.data(QtCore.Qt.ItemDataRole.UserRole)
+
+    assert isinstance(entry, FileDiffEntry)
+    assert entry.ai_note == "nota sintetica"
+    assert provider.calls
+    widget.deleteLater()
+
+
+@pytest.mark.skipif(not _HAS_QT, reason="PySide6 non disponibile nel test runner")
+def test_interactive_diff_set_patch_handles_provider_failure() -> None:
+    _ensure_qapplication()
+    assert InteractiveDiffWidget is not None
+    widget = InteractiveDiffWidget()
+    provider = _RecordingProvider(None, fail=True)
+    widget.set_ai_note_provider(provider)
+
+    diff_text = """diff --git a/foo.py b/foo.py\nindex 1111111..2222222 100644\n--- a/foo.py\n+++ b/foo.py\n@@ -0,0 +1 @@\n+print('hi')\n"""
+    patch = PatchSet(diff_text)
+
+    widget.set_patch(patch)
+
+    item = widget._list_widget.item(0)
+    entry = item.data(QtCore.Qt.ItemDataRole.UserRole)
+
+    assert isinstance(entry, FileDiffEntry)
+    assert entry.ai_note is None
+    widget.deleteLater()
+
+
+@pytest.mark.skipif(not _HAS_QT, reason="PySide6 non disponibile nel test runner")
+def test_interactive_diff_disabling_provider_clears_notes() -> None:
+    _ensure_qapplication()
+    assert InteractiveDiffWidget is not None
+    widget = InteractiveDiffWidget()
+    provider = _RecordingProvider("nota sintetica")
+    widget.set_ai_note_provider(provider)
+
+    diff_text = """diff --git a/foo.py b/foo.py\nindex 1111111..2222222 100644\n--- a/foo.py\n+++ b/foo.py\n@@ -0,0 +1 @@\n+print('hi')\n"""
+    patch = PatchSet(diff_text)
+    widget.set_patch(patch)
+
+    widget.set_ai_note_provider(None)
+
+    item = widget._list_widget.item(0)
+    entry = item.data(QtCore.Qt.ItemDataRole.UserRole)
+
+    assert isinstance(entry, FileDiffEntry)
+    assert entry.ai_note is None
+    widget.deleteLater()


### PR DESCRIPTION
## Summary
- add optional AI-generated notes to interactive diff entries and surface them in the list and preview
- add an application preference and persisted config flag to toggle interactive diff AI notes
- extend the changelog and automated tests to cover AI note enrichment and failure handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc14cd410c8326a0f2a8504e83ecbb