### PR TITLE
Add AI-assisted candidate ranking and auto-selection features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Il formato segue le convenzioni di [Keep a Changelog](https://keepachangelog.com
 e il progetto aderisce al [Versionamento Semantico](https://semver.org/lang/it/).
 
 ## [Non rilasciato]
+### Aggiunto
+- Modulo `ai_candidate_selector` con supporto all'invio del contesto a un modello
+  AI e recupero del suggerimento migliore per gli hunk ambigui, incluso fallback
+  locale se l'endpoint non risponde.
+- Opzioni CLI `--ai-assistant` / `--no-ai-assistant` e `--ai-select` per
+  controllare l'assistente e applicare automaticamente il suggerimento.
+- Nuovi controlli nelle preferenze della GUI e nel dialog dei candidati per
+  mostrare confidenza, spiegazione e consentire l'applicazione rapida del
+  suggerimento AI.
+### Modificato
+- La configurazione persistente include ora le impostazioni dedicate
+  all'assistente AI ed è documentata nella guida d'uso.
 
 ## [0.2.0] - 2025-09-18
 ### Aggiunto

--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ utili:
 - `--non-interactive`: evita prompt e salta i conflitti.
 - `--auto-accept`: accetta automaticamente il candidato migliore senza
   richiedere input.
+- `--ai-assistant` / `--no-ai-assistant`: abilita o disabilita il supporto AI
+  per classificare i candidati manuali.
+- `--ai-select`: applica automaticamente il suggerimento restituito
+  dall'assistente (con fallback locale se l'endpoint non è configurato).
 - `--log-level`: livello di logging (`debug`, `info`, `warning`, `error`,
   `critical`).
 
@@ -196,7 +200,9 @@ Le impostazioni vengono salvate in `settings.toml` sotto:
 - Windows: `%APPDATA%\Patch GUI\`
 
 La configurazione include soglia fuzzy, directory escluse, percorsi di backup,
-livello di log, gestione dei report e parametri di rotazione del file di log.
+livello di log, gestione dei report, parametri di rotazione del file di log e
+l'impostazione dell'assistente AI (inclusa l'applicazione automatica del
+suggerimento).
 Puoi modificarla dalla GUI o tramite `patch-gui config`.
 
 ## Sviluppo e test

--- a/USAGE.md
+++ b/USAGE.md
@@ -39,7 +39,8 @@ Questa guida passo‑passo descrive il workflow tipico per applicare una patch c
    - Durante l'esecuzione la barra di stato mostra una barra di avanzamento numerica con la percentuale di file/hunk già elaborati.
 6. **Gestisci eventuali ambiguità**
    - Se la patch può essere applicata in più punti plausibili, viene aperto un dialog che mostra tutte le opzioni con il relativo contesto.
-   - Scegli manualmente il posizionamento corretto.
+   - Se l'assistente AI è abilitato nelle preferenze, il dialog evidenzia la scelta consigliata con confidenza ed eventuale spiegazione; puoi applicarla con il pulsante *Applica suggerimento*.
+   - In assenza di conferma manuale puoi sempre scegliere il posizionamento corretto tra le alternative presentate.
 7. **Consulta backup e report**
    - Ogni esecuzione reale crea una cartella `~/.diff_backups/<timestamp-ms>/` con copie dei file originali (a meno di impostare un percorso diverso con `--backup`). Il suffisso `<timestamp-ms>` usa il formato `YYYYMMDD-HHMMSS-fff`, includendo i millisecondi per evitare collisioni.
    - I report `apply-report.json` e `apply-report.txt` vengono salvati in `~/.diff_backups/reports/results/<timestamp-ms>/`
@@ -77,3 +78,9 @@ Oltre a usare la GUI, puoi ispezionare e modificare le impostazioni persistenti 
 - `patch-gui config reset [chiave]` ripristina un singolo valore o l'intera configurazione ai default.
 
 Se vuoi operare su un file alternativo (per test o ambienti portabili) aggiungi `--config-path /percorso/custom/settings.toml` dopo il nome del sottocomando.
+
+## Assistente AI (sperimentale)
+
+- L'assistente può essere abilitato o disabilitato sia dalla GUI (Preferenze → *Suggerisci automaticamente con l'assistente AI*) sia tramite CLI con `--ai-assistant` / `--no-ai-assistant`.
+- Per applicare automaticamente il suggerimento migliore quando viene richiesta una scelta manuale usa la spunta *Applica il suggerimento AI senza chiedere* nella GUI o la flag `--ai-select` in CLI.
+- Il servizio AI utilizza l'endpoint configurato tramite la variabile d'ambiente `PATCH_GUI_AI_ENDPOINT` (opzionalmente con token `PATCH_GUI_AI_TOKEN`). Se non è disponibile, il programma ricade su una valutazione locale basata sulla similarità del testo.

--- a/patch_gui/ai_candidate_selector.py
+++ b/patch_gui/ai_candidate_selector.py
@@ -1,0 +1,252 @@
+"""Utilities for ranking ambiguous hunk candidates with the help of an AI model."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from typing import Iterable, Optional, Sequence
+
+from .patcher import HunkView
+
+logger = logging.getLogger(__name__)
+
+
+class AIAssistantError(RuntimeError):
+    """Raised when the AI assistant cannot provide a suggestion."""
+
+
+@dataclass(slots=True)
+class AISuggestion:
+    """Suggestion returned by :func:`rank_candidates`."""
+
+    candidate_index: int
+    position: int
+    confidence: float
+    explanation: str | None
+    source: str  # "assistant" | "local"
+
+
+_DEFAULT_TIMEOUT = 10.0
+_MAX_SNIPPET_CHARS = 400
+
+
+def _build_payload(
+    file_lines: Sequence[str],
+    hv: HunkView,
+    candidates: Sequence[tuple[int, float]],
+) -> dict[str, object]:
+    """Return the JSON payload describing the ambiguous hunk context."""
+
+    window_len = len(hv.before_lines) or len(hv.after_lines) or 1
+    snippets: list[dict[str, object]] = []
+    for index, (position, similarity) in enumerate(candidates, start=1):
+        snippet_lines = file_lines[position : position + window_len]
+        snippet = "".join(snippet_lines)
+        if len(snippet) > _MAX_SNIPPET_CHARS:
+            snippet = snippet[: _MAX_SNIPPET_CHARS - 1] + "…"
+        snippets.append(
+            {
+                "index": index,
+                "position": position,
+                "similarity": similarity,
+                "excerpt": snippet,
+            }
+        )
+
+    return {
+        "header": hv.header,
+        "before": hv.before_lines,
+        "after": hv.after_lines,
+        "context": hv.context_lines,
+        "candidates": snippets,
+    }
+
+
+def _call_ai_service(payload: dict[str, object]) -> dict[str, object]:
+    """Send ``payload`` to the configured AI endpoint and return the response."""
+
+    endpoint = os.getenv("PATCH_GUI_AI_ENDPOINT")
+    if not endpoint:
+        raise AIAssistantError(
+            "AI endpoint not configured (set PATCH_GUI_AI_ENDPOINT)."
+        )
+
+    token = os.getenv("PATCH_GUI_AI_TOKEN")
+    data = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(endpoint, data=data, method="POST")
+    request.add_header("Content-Type", "application/json")
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+
+    try:
+        with urllib.request.urlopen(request, timeout=_DEFAULT_TIMEOUT) as response:
+            body = response.read()
+            charset = response.headers.get_content_charset("utf-8")
+    except urllib.error.HTTPError as exc:  # pragma: no cover - network error paths
+        raise AIAssistantError(f"HTTP error {exc.code}: {exc.reason}") from exc
+    except urllib.error.URLError as exc:  # pragma: no cover - network error paths
+        raise AIAssistantError(str(exc)) from exc
+
+    try:
+        decoded = body.decode(charset or "utf-8")
+    except UnicodeDecodeError as exc:  # pragma: no cover - rare
+        raise AIAssistantError("Cannot decode AI response") from exc
+
+    try:
+        parsed = json.loads(decoded)
+    except json.JSONDecodeError as exc:
+        raise AIAssistantError("Invalid JSON from AI endpoint") from exc
+
+    if not isinstance(parsed, dict):
+        raise AIAssistantError("AI response must be a JSON object")
+
+    return parsed
+
+
+def _parse_ai_choice(
+    response: dict[str, object],
+    candidate_positions: dict[int, int],
+) -> AISuggestion:
+    """Extract an :class:`AISuggestion` from the AI ``response``."""
+
+    choice_obj = response.get("choice") or response.get("best") or response
+    if not isinstance(choice_obj, dict):
+        raise AIAssistantError("AI response missing 'choice' object")
+
+    candidate_index: Optional[int] = None
+    if "candidate_index" in choice_obj:
+        try:
+            candidate_index = int(choice_obj["candidate_index"])
+        except (TypeError, ValueError) as exc:
+            raise AIAssistantError("Invalid candidate_index in AI response") from exc
+    elif "index" in choice_obj:
+        try:
+            candidate_index = int(choice_obj["index"])
+        except (TypeError, ValueError) as exc:
+            raise AIAssistantError("Invalid index in AI response") from exc
+
+    position: Optional[int] = None
+    if "position" in choice_obj:
+        try:
+            position = int(choice_obj["position"])
+        except (TypeError, ValueError) as exc:
+            raise AIAssistantError("Invalid position in AI response") from exc
+
+    if candidate_index is not None and candidate_index in candidate_positions:
+        position = candidate_positions[candidate_index]
+    elif position is not None:
+        # Align to known candidate index if possible.
+        for idx, pos in candidate_positions.items():
+            if pos == position:
+                candidate_index = idx
+                break
+
+    if candidate_index is None or candidate_index not in candidate_positions:
+        raise AIAssistantError("AI response did not reference a valid candidate")
+
+    raw_confidence = choice_obj.get("confidence")
+    try:
+        confidence = float(raw_confidence) if raw_confidence is not None else 0.0
+    except (TypeError, ValueError) as exc:
+        raise AIAssistantError("Invalid confidence value from AI response") from exc
+
+    explanation = choice_obj.get("explanation")
+    if explanation is not None:
+        explanation = str(explanation)
+
+    return AISuggestion(
+        candidate_index=candidate_index,
+        position=candidate_positions[candidate_index],
+        confidence=confidence,
+        explanation=explanation,
+        source="assistant",
+    )
+
+
+def _local_best_candidate(
+    file_lines: Sequence[str],
+    hv: HunkView,
+    candidates: Sequence[tuple[int, float]],
+) -> Optional[AISuggestion]:
+    """Return the best candidate using local heuristics only."""
+
+    if not candidates:
+        return None
+
+    reference_lines = hv.before_lines or hv.after_lines
+    block_len = len(reference_lines)
+    if block_len == 0 and hv.after_lines:
+        block_len = len(hv.after_lines)
+    if block_len <= 0:
+        block_len = 1
+
+    reference_text = "".join(reference_lines) or "".join(hv.after_lines)
+
+    best: Optional[AISuggestion] = None
+    for index, (position, similarity) in enumerate(candidates, start=1):
+        if similarity is not None:
+            score = float(similarity)
+        elif reference_text:
+            snippet = "".join(file_lines[position : position + block_len])
+            if not snippet and 0 <= position < len(file_lines):
+                snippet = file_lines[position]
+            score = SequenceMatcher(None, reference_text, snippet).ratio()
+        else:
+            continue
+
+        explanation = (
+            "Local heuristic based on textual similarity."
+        )
+        if best is None or score > best.confidence:
+            best = AISuggestion(
+                candidate_index=index,
+                position=position,
+                confidence=score,
+                explanation=explanation,
+                source="local",
+            )
+
+    return best
+
+
+def rank_candidates(
+    file_lines: Sequence[str],
+    hv: HunkView,
+    candidates: Sequence[tuple[int, float]],
+    *,
+    use_ai: bool,
+    logger_override: Optional[logging.Logger] = None,
+) -> Optional[AISuggestion]:
+    """Return the best candidate suggestion using AI with local fallback."""
+
+    log = logger_override or logger
+
+    local_choice = _local_best_candidate(file_lines, hv, candidates)
+    if not candidates:
+        return None
+
+    if not use_ai:
+        return local_choice
+
+    try:
+        payload = _build_payload(file_lines, hv, candidates)
+        candidate_positions = {
+            index: position for index, (position, _) in enumerate(candidates, start=1)
+        }
+        response = _call_ai_service(payload)
+        ai_choice = _parse_ai_choice(response, candidate_positions)
+        if ai_choice.confidence <= 0 and local_choice is not None:
+            # Avoid zero-confidence suggestions when a heuristic score is available.
+            ai_choice.confidence = local_choice.confidence
+        if ai_choice.explanation is None and local_choice is not None:
+            ai_choice.explanation = local_choice.explanation
+        return ai_choice
+    except AIAssistantError as exc:
+        log.warning("AI assistant unavailable: %s", exc)
+        return local_choice
+

--- a/patch_gui/config.py
+++ b/patch_gui/config.py
@@ -43,6 +43,8 @@ _DEFAULT_LOG_FILE_NAME = ".patch_gui.log"
 _DEFAULT_LOG_MAX_BYTES = 0
 _DEFAULT_LOG_BACKUP_COUNT = 0
 _DEFAULT_BACKUP_RETENTION_DAYS = 0
+_DEFAULT_AI_ASSISTANT = False
+_DEFAULT_AI_AUTO_APPLY = False
 
 
 def _default_log_file() -> Path:
@@ -84,6 +86,8 @@ class AppConfig:
     log_max_bytes: int = DEFAULT_LOG_MAX_BYTES
     log_backup_count: int = DEFAULT_LOG_BACKUP_COUNT
     backup_retention_days: int = DEFAULT_BACKUP_RETENTION_DAYS
+    ai_assistant_enabled: bool = _DEFAULT_AI_ASSISTANT
+    ai_auto_apply: bool = _DEFAULT_AI_AUTO_APPLY
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any]) -> "AppConfig":
@@ -109,6 +113,10 @@ class AppConfig:
         backup_retention_days = _coerce_non_negative_int(
             data.get("backup_retention_days"), base.backup_retention_days
         )
+        ai_enabled = _coerce_bool(
+            data.get("ai_assistant_enabled"), base.ai_assistant_enabled
+        )
+        ai_auto_apply = _coerce_bool(data.get("ai_auto_apply"), base.ai_auto_apply)
 
         return cls(
             threshold=threshold,
@@ -121,6 +129,8 @@ class AppConfig:
             log_max_bytes=log_max_bytes,
             log_backup_count=log_backup_count,
             backup_retention_days=backup_retention_days,
+            ai_assistant_enabled=ai_enabled,
+            ai_auto_apply=ai_auto_apply,
         )
 
     def to_mapping(self) -> MutableMapping[str, Any]:
@@ -137,6 +147,8 @@ class AppConfig:
             "log_max_bytes": int(self.log_max_bytes),
             "log_backup_count": int(self.log_backup_count),
             "backup_retention_days": int(self.backup_retention_days),
+            "ai_assistant_enabled": bool(self.ai_assistant_enabled),
+            "ai_auto_apply": bool(self.ai_auto_apply),
         }
 
 
@@ -203,6 +215,8 @@ def save_config(config: AppConfig, path: Path | None = None) -> Path:
     log_max_bytes_repr = json.dumps(mapping["log_max_bytes"])
     log_backup_count_repr = json.dumps(mapping["log_backup_count"])
     backup_retention_repr = json.dumps(mapping["backup_retention_days"])
+    ai_assistant_repr = json.dumps(mapping["ai_assistant_enabled"])
+    ai_auto_apply_repr = json.dumps(mapping["ai_auto_apply"])
 
     content_lines = [
         f"[{_CONFIG_SECTION}]",
@@ -216,6 +230,8 @@ def save_config(config: AppConfig, path: Path | None = None) -> Path:
         f"log_max_bytes = {log_max_bytes_repr}",
         f"log_backup_count = {log_backup_count_repr}",
         f"backup_retention_days = {backup_retention_repr}",
+        f"ai_assistant_enabled = {ai_assistant_repr}",
+        f"ai_auto_apply = {ai_auto_apply_repr}",
         "",
     ]
 

--- a/patch_gui/parser.py
+++ b/patch_gui/parser.py
@@ -142,6 +142,40 @@ def build_parser(
             "prompts entirely."
         ),
     )
+    ai_group = parser.add_mutually_exclusive_group()
+    ai_group.add_argument(
+        "--ai-assistant",
+        dest="ai_assistant",
+        action="store_true",
+        help=_(
+            "Enable the AI assistant when ranking ambiguous hunk candidates (overrides the configuration)."
+        ),
+    )
+    ai_group.add_argument(
+        "--no-ai-assistant",
+        dest="ai_assistant",
+        action="store_false",
+        help=_(
+            "Disable the AI assistant for candidate ranking (overrides the configuration)."
+        ),
+    )
+    parser.set_defaults(ai_assistant=resolved_config.ai_assistant_enabled)
+    ai_select_group = parser.add_mutually_exclusive_group()
+    ai_select_group.add_argument(
+        "--ai-select",
+        dest="ai_select",
+        action="store_true",
+        help=_(
+            "Automatically choose the candidate suggested by the assistant when manual selection is required."
+        ),
+    )
+    ai_select_group.add_argument(
+        "--no-ai-select",
+        dest="ai_select",
+        action="store_false",
+        help=_("Disable automatic application of the assistant suggestion."),
+    )
+    parser.set_defaults(ai_select=resolved_config.ai_auto_apply)
     parser.add_argument(
         "--encoding",
         default=None,

--- a/patch_gui/patcher.py
+++ b/patch_gui/patcher.py
@@ -64,6 +64,10 @@ class HunkDecision:
     similarity: Optional[float] = None
     candidates: list[tuple[int, float]] = field(default_factory=list)  # (pos, score)
     message: str = ""
+    ai_recommendation: Optional[int] = None
+    ai_confidence: Optional[float] = None
+    ai_explanation: Optional[str] = None
+    ai_source: Optional[str] = None
 
 
 @dataclass
@@ -137,6 +141,10 @@ class ApplySession:
                             "similarity": d.similarity,
                             "candidates": d.candidates,
                             "message": d.message,
+                            "ai_recommendation": d.ai_recommendation,
+                            "ai_confidence": d.ai_confidence,
+                            "ai_explanation": d.ai_explanation,
+                            "ai_source": d.ai_source,
                         }
                         for d in fr.decisions
                     ],
@@ -226,6 +234,31 @@ class ApplySession:
                     )
                 if d.message:
                     lines.append(_("      Notes: {notes}").format(notes=d.message))
+                if d.ai_recommendation is not None:
+                    origin = d.ai_source or "assistant"
+                    if d.ai_confidence is not None:
+                        lines.append(
+                            _(
+                                "      AI suggestion ({origin}): pos {position} (confidence {confidence:.3f})"
+                            ).format(
+                                origin=origin,
+                                position=d.ai_recommendation,
+                                confidence=d.ai_confidence,
+                            )
+                        )
+                    else:
+                        lines.append(
+                            _(
+                                "      AI suggestion ({origin}): pos {position}"
+                            ).format(
+                                origin=origin,
+                                position=d.ai_recommendation,
+                            )
+                        )
+                    if d.ai_explanation:
+                        lines.append(
+                            _("        Explanation: {text}").format(text=d.ai_explanation)
+                        )
             lines.append("")
         return "\n".join(lines)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,6 +21,8 @@ def test_load_config_returns_defaults_when_missing(tmp_path: Path) -> None:
     assert loaded.log_max_bytes == defaults.log_max_bytes
     assert loaded.log_backup_count == defaults.log_backup_count
     assert loaded.backup_retention_days == defaults.backup_retention_days
+    assert loaded.ai_assistant_enabled == defaults.ai_assistant_enabled
+    assert loaded.ai_auto_apply == defaults.ai_auto_apply
 
 
 def test_save_and_load_roundtrip(tmp_path: Path) -> None:
@@ -38,6 +40,8 @@ def test_save_and_load_roundtrip(tmp_path: Path) -> None:
         log_max_bytes=1048576,
         log_backup_count=3,
         backup_retention_days=14,
+        ai_assistant_enabled=True,
+        ai_auto_apply=True,
     )
 
     save_config(original, path=config_path)
@@ -62,6 +66,8 @@ def test_load_config_invalid_values_fallback(tmp_path: Path) -> None:
                 "log_max_bytes = -1",
                 "log_backup_count = -5",
                 "backup_retention_days = -10",
+                'ai_assistant_enabled = "maybe"',
+                'ai_auto_apply = "\""',
                 "",
             ]
         ),
@@ -81,6 +87,8 @@ def test_load_config_invalid_values_fallback(tmp_path: Path) -> None:
     assert loaded.log_max_bytes == defaults.log_max_bytes
     assert loaded.log_backup_count == defaults.log_backup_count
     assert loaded.backup_retention_days == defaults.backup_retention_days
+    assert loaded.ai_assistant_enabled == defaults.ai_assistant_enabled
+    assert loaded.ai_auto_apply == defaults.ai_auto_apply
 
 
 def test_load_config_accepts_empty_exclude_list(tmp_path: Path) -> None:
@@ -99,6 +107,8 @@ def test_load_config_accepts_empty_exclude_list(tmp_path: Path) -> None:
                 "log_max_bytes = 1024",
                 "log_backup_count = 4",
                 "backup_retention_days = 30",
+                "ai_assistant_enabled = true",
+                "ai_auto_apply = true",
                 "",
             ]
         ),
@@ -117,3 +127,5 @@ def test_load_config_accepts_empty_exclude_list(tmp_path: Path) -> None:
     assert loaded.log_max_bytes == 1024
     assert loaded.log_backup_count == 4
     assert loaded.backup_retention_days == 30
+    assert loaded.ai_assistant_enabled is True
+    assert loaded.ai_auto_apply is True

--- a/tests/test_diff_applier_gui.py
+++ b/tests/test_diff_applier_gui.py
@@ -149,6 +149,8 @@ def test_settings_dialog_gathers_config(qt_app: Any, tmp_path: Path) -> None:
         log_max_bytes=1024,
         log_backup_count=2,
         backup_retention_days=4,
+        ai_assistant_enabled=True,
+        ai_auto_apply=False,
     )
 
     dialog = app_module.SettingsDialog(None, config=config)
@@ -166,6 +168,8 @@ def test_settings_dialog_gathers_config(qt_app: Any, tmp_path: Path) -> None:
     dialog.log_max_edit.setText("8192")
     dialog.log_backup_edit.setText("5")
     dialog.backup_retention_edit.setText("7")
+    dialog.ai_assistant_check.setChecked(False)
+    dialog.ai_auto_check.setChecked(True)
 
     updated = dialog._gather_config()
 
@@ -179,6 +183,8 @@ def test_settings_dialog_gathers_config(qt_app: Any, tmp_path: Path) -> None:
     assert updated.log_max_bytes == 8192
     assert updated.log_backup_count == 5
     assert updated.backup_retention_days == 7
+    assert updated.ai_assistant_enabled is False
+    assert updated.ai_auto_apply is True
 
 
 def test_main_window_applies_settings_dialog(
@@ -228,6 +234,8 @@ def test_main_window_applies_settings_dialog(
         log_file=tmp_path / "logs" / "app.log",
         log_max_bytes=0,
         log_backup_count=0,
+        ai_assistant_enabled=False,
+        ai_auto_apply=False,
     )
 
     window = app_module.MainWindow(app_config=original)
@@ -242,6 +250,8 @@ def test_main_window_applies_settings_dialog(
         log_file=tmp_path / "logs" / "custom.log",
         log_max_bytes=2048,
         log_backup_count=3,
+        ai_assistant_enabled=True,
+        ai_auto_apply=True,
     )
 
     class _FakeDialog:
@@ -261,6 +271,8 @@ def test_main_window_applies_settings_dialog(
     assert window.chk_dry.isChecked() is new_config.dry_run_default
     assert window.exclude_edit.text() == ", ".join(new_config.exclude_dirs)
     assert window.reports_enabled is new_config.write_reports
+    assert window.ai_assistant_enabled is new_config.ai_assistant_enabled
+    assert window.ai_auto_apply is new_config.ai_auto_apply
     assert configured_invocations == [
         {
             "level": new_config.log_level,

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -7,6 +7,7 @@ import pytest
 from unidiff import PatchSet
 
 import patch_gui.executor as executor
+from patch_gui.config import AppConfig
 from patch_gui.patcher import (
     ApplySession,
     HunkDecision,
@@ -476,6 +477,7 @@ def test_apply_file_patch_removes_file_and_keeps_backup(tmp_path: Path) -> None:
         session,
         interactive=False,
         auto_accept=False,
+        config=AppConfig(),
     )
 
     assert fr.skipped_reason is None


### PR DESCRIPTION
## Summary
- add `ai_candidate_selector` module to call a remote AI service (with local fallback) for ranking ambiguous hunk candidates and share the result with CLI/GUI flows
- extend CLI/parser/configuration handling with AI assistant toggles, auto-select behaviour, and persisted settings used in both interfaces
- surface assistant recommendations in CLI/manual resolution, GUI dialogs, and reports while updating docs and changelog

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc14b6be888326b2f8dfb9ab4a6156