### PR TITLE
Add AI notes support to interactive diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Il formato segue le convenzioni di [Keep a Changelog](https://keepachangelog.com
 e il progetto aderisce al [Versionamento Semantico](https://semver.org/lang/it/).
 
 ## [Non rilasciato]
+### Aggiunto
+- Vista diff interattiva arricchita con note AI opzionali, controllabili da
+  preferenze dedicate e con fallback automatico in caso di errori del servizio.
 
 ## [0.2.0] - 2025-09-18
 ### Aggiunto

--- a/patch_gui/app.py
+++ b/patch_gui/app.py
@@ -896,6 +896,12 @@ class SettingsDialog(_QDialogBase):
         self.reports_check.setChecked(self._original_config.write_reports)
         form.addRow("", self.reports_check)
 
+        self.ai_notes_check = QtWidgets.QCheckBox(
+            _("Mostra note AI nel diff interattivo (sperimentale)")
+        )
+        self.ai_notes_check.setChecked(self._original_config.ai_notes_enabled)
+        form.addRow("", self.ai_notes_check)
+
         self.buttons = QtWidgets.QDialogButtonBox(
             QtWidgets.QDialogButtonBox.StandardButton.Ok
             | QtWidgets.QDialogButtonBox.StandardButton.Cancel
@@ -969,6 +975,7 @@ class SettingsDialog(_QDialogBase):
             log_max_bytes=log_max_bytes,
             log_backup_count=log_backup_count,
             backup_retention_days=backup_retention_days,
+            ai_notes_enabled=self.ai_notes_check.isChecked(),
         )
 
     @staticmethod
@@ -1256,6 +1263,7 @@ class MainWindow(_QMainWindowBase):
         self.threshold: float = self.app_config.threshold
         self.exclude_dirs: tuple[str, ...] = self.app_config.exclude_dirs
         self.reports_enabled: bool = self.app_config.write_reports
+        self.ai_notes_enabled: bool = self.app_config.ai_notes_enabled
         self._qt_log_handler: Optional[GuiLogHandler] = None
         self._current_worker: Optional[PatchApplyWorker] = None
 
@@ -1488,6 +1496,7 @@ class MainWindow(_QMainWindowBase):
         self.diff_tabs.addTab(self.preview_view, _("Anteprima"))
 
         self.interactive_diff = InteractiveDiffWidget()
+        self.interactive_diff.set_ai_notes_enabled(self.ai_notes_enabled)
         self.interactive_diff.diffReordered.connect(self._on_diff_reordered)
         self.diff_tabs.addTab(self.interactive_diff, _("Diff interattivo"))
 
@@ -1559,10 +1568,12 @@ class MainWindow(_QMainWindowBase):
         self.threshold = float(self.app_config.threshold)
         self.exclude_dirs = tuple(self.app_config.exclude_dirs)
         self.reports_enabled = bool(self.app_config.write_reports)
+        self.ai_notes_enabled = bool(self.app_config.ai_notes_enabled)
         self.spin_thresh.setValue(self.threshold)
         excludes_text = ", ".join(self.exclude_dirs) if self.exclude_dirs else ""
         self.exclude_edit.setText(excludes_text)
         self.chk_dry.setChecked(self.app_config.dry_run_default)
+        self.interactive_diff.set_ai_notes_enabled(self.ai_notes_enabled)
 
     def _create_settings_dialog(self) -> SettingsDialog:
         return SettingsDialog(self, config=self.app_config)
@@ -1625,9 +1636,11 @@ class MainWindow(_QMainWindowBase):
             self.app_config.log_level = level_name.lower()
         self.app_config.dry_run_default = self.chk_dry.isChecked()
         self.app_config.write_reports = self.reports_enabled
+        self.app_config.ai_notes_enabled = self.ai_notes_enabled
         self.threshold = self.app_config.threshold
         self.exclude_dirs = self.app_config.exclude_dirs
         self.reports_enabled = self.app_config.write_reports
+        self.ai_notes_enabled = self.app_config.ai_notes_enabled
         save_config(self.app_config)
 
     def choose_root(self) -> None:

--- a/patch_gui/cli.py
+++ b/patch_gui/cli.py
@@ -57,6 +57,7 @@ _CONFIG_KEYS = (
     "log_level",
     "dry_run_default",
     "write_reports",
+    "ai_notes_enabled",
     "log_file",
     "log_max_bytes",
     "log_backup_count",
@@ -440,6 +441,8 @@ def config_reset(
             config.dry_run_default = defaults.dry_run_default
         elif key == "write_reports":
             config.write_reports = defaults.write_reports
+        elif key == "ai_notes_enabled":
+            config.ai_notes_enabled = defaults.ai_notes_enabled
         elif key == "log_file":
             config.log_file = defaults.log_file
         elif key == "log_max_bytes":
@@ -510,7 +513,7 @@ def _apply_config_value(
         config.exclude_dirs = parsed
         return
 
-    if key in {"dry_run_default", "write_reports"}:
+    if key in {"dry_run_default", "write_reports", "ai_notes_enabled"}:
         if len(values) != 1:
             raise ConfigCommandError(
                 _("The {key} key expects exactly one value.").format(key=key),
@@ -518,8 +521,10 @@ def _apply_config_value(
         config_value = _parse_bool(values[0])
         if key == "dry_run_default":
             config.dry_run_default = config_value
-        else:
+        elif key == "write_reports":
             config.write_reports = config_value
+        else:
+            config.ai_notes_enabled = config_value
         return
 
     if key == "log_file":

--- a/patch_gui/config.py
+++ b/patch_gui/config.py
@@ -84,6 +84,7 @@ class AppConfig:
     log_max_bytes: int = DEFAULT_LOG_MAX_BYTES
     log_backup_count: int = DEFAULT_LOG_BACKUP_COUNT
     backup_retention_days: int = DEFAULT_BACKUP_RETENTION_DAYS
+    ai_notes_enabled: bool = False
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any]) -> "AppConfig":
@@ -99,6 +100,9 @@ class AppConfig:
             data.get("dry_run_default"), base.dry_run_default
         )
         write_reports = _coerce_bool(data.get("write_reports"), base.write_reports)
+        ai_notes_enabled = _coerce_bool(
+            data.get("ai_notes_enabled"), base.ai_notes_enabled
+        )
         log_file = _coerce_path(data.get("log_file"), base.log_file)
         log_max_bytes = _coerce_non_negative_int(
             data.get("log_max_bytes"), base.log_max_bytes
@@ -121,6 +125,7 @@ class AppConfig:
             log_max_bytes=log_max_bytes,
             log_backup_count=log_backup_count,
             backup_retention_days=backup_retention_days,
+            ai_notes_enabled=ai_notes_enabled,
         )
 
     def to_mapping(self) -> MutableMapping[str, Any]:
@@ -133,6 +138,7 @@ class AppConfig:
             "log_level": str(self.log_level),
             "dry_run_default": bool(self.dry_run_default),
             "write_reports": bool(self.write_reports),
+            "ai_notes_enabled": bool(self.ai_notes_enabled),
             "log_file": str(self.log_file),
             "log_max_bytes": int(self.log_max_bytes),
             "log_backup_count": int(self.log_backup_count),
@@ -198,6 +204,7 @@ def save_config(config: AppConfig, path: Path | None = None) -> Path:
     log_level_repr = json.dumps(mapping["log_level"])
     dry_run_repr = json.dumps(mapping["dry_run_default"])
     write_reports_repr = json.dumps(mapping["write_reports"])
+    ai_notes_repr = json.dumps(mapping["ai_notes_enabled"])
     backup_repr = json.dumps(mapping["backup_base"])
     log_file_repr = json.dumps(mapping["log_file"])
     log_max_bytes_repr = json.dumps(mapping["log_max_bytes"])
@@ -212,6 +219,7 @@ def save_config(config: AppConfig, path: Path | None = None) -> Path:
         f"log_level = {log_level_repr}",
         f"dry_run_default = {dry_run_repr}",
         f"write_reports = {write_reports_repr}",
+        f"ai_notes_enabled = {ai_notes_repr}",
         f"log_file = {log_file_repr}",
         f"log_max_bytes = {log_max_bytes_repr}",
         f"log_backup_count = {log_backup_count_repr}",

--- a/patch_gui/interactive_diff_models.py
+++ b/patch_gui/interactive_diff_models.py
@@ -1,0 +1,87 @@
+"""Shared data structures for the interactive diff widget."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+import logging
+from typing import Protocol
+
+from .localization import gettext as _
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class FileDiffEntry:
+    """Store information about a file diff block."""
+
+    file_label: str
+    diff_text: str
+    annotated_diff_text: str
+    additions: int
+    deletions: int
+    ai_note: str | None = None
+
+    @property
+    def display_text(self) -> str:
+        additions = _("+{count}").format(count=self.additions)
+        deletions = _("-{count}").format(count=self.deletions)
+        return _("{name} · {additions} / {deletions}").format(
+            name=self.file_label,
+            additions=additions,
+            deletions=deletions,
+        )
+
+
+class DiffAiNoteClient(Protocol):
+    """Protocol for services that can summarise diff entries."""
+
+    def note_for_diff(self, entry: FileDiffEntry) -> str | None:
+        """Return a short note for ``entry`` or ``None`` if not available."""
+
+
+_AI_NOTE_CLIENT: DiffAiNoteClient | None = None
+
+
+def set_diff_ai_note_client(client: DiffAiNoteClient | None) -> None:
+    """Register ``client`` as the shared provider for AI notes."""
+
+    global _AI_NOTE_CLIENT
+    _AI_NOTE_CLIENT = client
+
+
+def get_diff_ai_note_client() -> DiffAiNoteClient | None:
+    """Return the configured AI note provider, if any."""
+
+    return _AI_NOTE_CLIENT
+
+
+def populate_ai_note(entry: FileDiffEntry) -> FileDiffEntry:
+    """Return ``entry`` enriched with an AI note when possible."""
+
+    client = get_diff_ai_note_client()
+    if client is None:
+        return entry
+
+    try:
+        raw_note = client.note_for_diff(entry)
+    except Exception:  # pragma: no cover - best effort logging
+        logger.debug("AI note client failed", exc_info=True)
+        raw_note = None
+
+    note = (str(raw_note).strip() if raw_note is not None else None) or None
+    if note == entry.ai_note:
+        return entry
+    if note is None and entry.ai_note is None:
+        return entry
+    return replace(entry, ai_note=note)
+
+
+__all__ = [
+    "DiffAiNoteClient",
+    "FileDiffEntry",
+    "get_diff_ai_note_client",
+    "populate_ai_note",
+    "set_diff_ai_note_client",
+]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1373,6 +1373,7 @@ def test_config_show_outputs_json(tmp_path: Path) -> None:
         log_max_bytes=2048,
         log_backup_count=5,
         backup_retention_days=12,
+        ai_notes_enabled=True,
     )
     save_config(config, path=config_path)
 
@@ -1389,6 +1390,7 @@ def test_config_show_outputs_json(tmp_path: Path) -> None:
     assert payload["log_max_bytes"] == config.log_max_bytes
     assert payload["log_backup_count"] == config.log_backup_count
     assert payload["backup_retention_days"] == config.backup_retention_days
+    assert payload["ai_notes_enabled"] is True
 
 
 def test_config_set_updates_values(tmp_path: Path) -> None:
@@ -1445,6 +1447,14 @@ def test_config_set_updates_values(tmp_path: Path) -> None:
     assert load_config(config_path).write_reports is False
 
     cli.config_set(
+        "ai_notes_enabled",
+        ["yes"],
+        path=config_path,
+        stream=io.StringIO(),
+    )
+    assert load_config(config_path).ai_notes_enabled is True
+
+    cli.config_set(
         "log_file",
         [str(tmp_path / "logs" / "session.log")],
         path=config_path,
@@ -1484,6 +1494,12 @@ def test_config_reset_values(tmp_path: Path) -> None:
     config_path = tmp_path / "settings.toml"
     cli.config_set("threshold", ["0.92"], path=config_path, stream=io.StringIO())
     cli.config_set("log_level", ["debug"], path=config_path, stream=io.StringIO())
+    cli.config_set(
+        "ai_notes_enabled",
+        ["true"],
+        path=config_path,
+        stream=io.StringIO(),
+    )
 
     cli.config_reset("threshold", path=config_path, stream=io.StringIO())
     loaded = load_config(config_path)
@@ -1506,6 +1522,7 @@ def test_config_reset_values(tmp_path: Path) -> None:
     assert reset.log_max_bytes == defaults.log_max_bytes
     assert reset.log_backup_count == defaults.log_backup_count
     assert reset.backup_retention_days == defaults.backup_retention_days
+    assert reset.ai_notes_enabled == defaults.ai_notes_enabled
 
 
 def test_run_config_reports_invalid_log_level(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,6 +17,7 @@ def test_load_config_returns_defaults_when_missing(tmp_path: Path) -> None:
     assert loaded.log_level == defaults.log_level
     assert loaded.dry_run_default == defaults.dry_run_default
     assert loaded.write_reports == defaults.write_reports
+    assert loaded.ai_notes_enabled == defaults.ai_notes_enabled
     assert loaded.log_file == defaults.log_file
     assert loaded.log_max_bytes == defaults.log_max_bytes
     assert loaded.log_backup_count == defaults.log_backup_count
@@ -38,6 +39,7 @@ def test_save_and_load_roundtrip(tmp_path: Path) -> None:
         log_max_bytes=1048576,
         log_backup_count=3,
         backup_retention_days=14,
+        ai_notes_enabled=True,
     )
 
     save_config(original, path=config_path)
@@ -58,6 +60,7 @@ def test_load_config_invalid_values_fallback(tmp_path: Path) -> None:
                 "log_level = 123",
                 'dry_run_default = "maybe"',
                 'write_reports = "sometimes"',
+                'ai_notes_enabled = "maybe"',
                 'log_file = "   "',
                 "log_max_bytes = -1",
                 "log_backup_count = -5",
@@ -77,6 +80,7 @@ def test_load_config_invalid_values_fallback(tmp_path: Path) -> None:
     assert loaded.log_level == defaults.log_level
     assert loaded.dry_run_default == defaults.dry_run_default
     assert loaded.write_reports == defaults.write_reports
+    assert loaded.ai_notes_enabled == defaults.ai_notes_enabled
     assert loaded.log_file == defaults.log_file
     assert loaded.log_max_bytes == defaults.log_max_bytes
     assert loaded.log_backup_count == defaults.log_backup_count
@@ -95,6 +99,7 @@ def test_load_config_accepts_empty_exclude_list(tmp_path: Path) -> None:
                 'log_level = "warning"',
                 "dry_run_default = false",
                 "write_reports = true",
+                "ai_notes_enabled = true",
                 'log_file = "' + str(tmp_path / "log.txt") + '"',
                 "log_max_bytes = 1024",
                 "log_backup_count = 4",
@@ -117,3 +122,4 @@ def test_load_config_accepts_empty_exclude_list(tmp_path: Path) -> None:
     assert loaded.log_max_bytes == 1024
     assert loaded.log_backup_count == 4
     assert loaded.backup_retention_days == 30
+    assert loaded.ai_notes_enabled is True

--- a/tests/test_diff_applier_gui.py
+++ b/tests/test_diff_applier_gui.py
@@ -161,6 +161,7 @@ def test_settings_dialog_gathers_config(qt_app: Any, tmp_path: Path) -> None:
         dialog.log_combo.setCurrentIndex(index)
     dialog.dry_run_check.setChecked(False)
     dialog.reports_check.setChecked(False)
+    dialog.ai_notes_check.setChecked(True)
     new_log_file = tmp_path / "logs" / "custom.log"
     dialog.log_file_edit.setText(str(new_log_file))
     dialog.log_max_edit.setText("8192")
@@ -179,6 +180,7 @@ def test_settings_dialog_gathers_config(qt_app: Any, tmp_path: Path) -> None:
     assert updated.log_max_bytes == 8192
     assert updated.log_backup_count == 5
     assert updated.backup_retention_days == 7
+    assert updated.ai_notes_enabled is True
 
 
 def test_main_window_applies_settings_dialog(
@@ -228,6 +230,7 @@ def test_main_window_applies_settings_dialog(
         log_file=tmp_path / "logs" / "app.log",
         log_max_bytes=0,
         log_backup_count=0,
+        ai_notes_enabled=False,
     )
 
     window = app_module.MainWindow(app_config=original)
@@ -242,6 +245,7 @@ def test_main_window_applies_settings_dialog(
         log_file=tmp_path / "logs" / "custom.log",
         log_max_bytes=2048,
         log_backup_count=3,
+        ai_notes_enabled=True,
     )
 
     class _FakeDialog:
@@ -261,6 +265,7 @@ def test_main_window_applies_settings_dialog(
     assert window.chk_dry.isChecked() is new_config.dry_run_default
     assert window.exclude_edit.text() == ", ".join(new_config.exclude_dirs)
     assert window.reports_enabled is new_config.write_reports
+    assert window.ai_notes_enabled is new_config.ai_notes_enabled
     assert configured_invocations == [
         {
             "level": new_config.log_level,


### PR DESCRIPTION
## Summary
- add a shared helper and data model to attach optional AI notes to diff entries
- surface AI notes in the interactive diff UI with a user preference persisted in the app config and CLI
- cover the new behaviour with targeted unit tests and changelog documentation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc14d439e08326aa3a81df081f3fd6