### PR TITLE
Add AI summaries to patch session reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ e il progetto aderisce al [Versionamento Semantico](https://semver.org/lang/it/)
 - Nuovi controlli nelle preferenze della GUI e nel dialog dei candidati per
   mostrare confidenza, spiegazione e consentire l'applicazione rapida del
   suggerimento AI.
+- Generazione opzionale di sintesi AI della sessione con endpoint configurabile,
+  integrazione nei report e nella GUI.
 ### Modificato
 - La configurazione persistente include ora le impostazioni dedicate
   all'assistente AI ed è documentata nella guida d'uso.

--- a/README.md
+++ b/README.md
@@ -147,6 +147,21 @@ utili:
 - `--log-level`: livello di logging (`debug`, `info`, `warning`, `error`,
   `critical`).
 
+### Integrazione AI
+
+Oltre al suggerimento dei candidati ambigui, l'applicazione può richiedere a un
+servizio esterno la generazione di brevi sintesi della sessione appena
+conclusa. Le sintesi vengono visualizzate nel log della CLI e della GUI, nei
+dialoghi finali e all'interno dei report (`to_json` / `to_txt`).
+
+Per abilitare la funzionalità è necessario impostare la variabile di ambiente
+`PATCH_GUI_AI_SUMMARY_ENDPOINT` con l'URL dell'endpoint HTTP da contattare.
+Facoltativamente è possibile definire `PATCH_GUI_AI_SUMMARY_TOKEN` (o
+riutilizzare `PATCH_GUI_AI_TOKEN`) per inviare un header `Authorization`.
+L'endpoint deve accettare un payload JSON con i `FileResult` e gli
+`HunkDecision` della sessione e rispondere con un oggetto che includa almeno il
+campo `summary` oppure l'elenco `files` con le descrizioni per file.
+
 Comandi aggiuntivi:
 
 - `patch-gui download-exe`: scarica l'eseguibile Windows dalla pagina delle

--- a/patch_gui/ai_summaries.py
+++ b/patch_gui/ai_summaries.py
@@ -1,0 +1,179 @@
+"""Helpers for retrieving AI-generated summaries of patch sessions."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+from .patcher import ApplySession
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["AISummary", "generate_session_summary", "AISummaryError"]
+
+
+class AISummaryError(RuntimeError):
+    """Raised when the AI summary service cannot produce a result."""
+
+
+@dataclass(slots=True)
+class AISummary:
+    """Container for the overall and per-file summaries returned by the AI."""
+
+    overall: Optional[str] = None
+    per_file: Dict[str, str] = field(default_factory=dict)
+
+    def is_empty(self) -> bool:
+        return not (self.overall or self.per_file)
+
+
+_DEFAULT_TIMEOUT = 15.0
+_MAX_DECISIONS_PER_FILE = 50
+_MAX_CANDIDATES_PER_DECISION = 5
+
+
+def _build_payload(session: ApplySession) -> dict[str, object]:
+    files: list[dict[str, object]] = []
+    for file_result in session.results:
+        decisions: list[dict[str, object]] = []
+        for decision in file_result.decisions[:_MAX_DECISIONS_PER_FILE]:
+            entry: dict[str, object] = {
+                "header": decision.hunk_header,
+                "strategy": decision.strategy,
+                "position": decision.selected_pos,
+                "similarity": decision.similarity,
+                "message": decision.message,
+                "ai_recommendation": decision.ai_recommendation,
+                "ai_confidence": decision.ai_confidence,
+                "ai_source": decision.ai_source,
+            }
+            candidates = decision.candidates[:_MAX_CANDIDATES_PER_DECISION]
+            if candidates:
+                entry["candidates"] = [list(candidate) for candidate in candidates]
+            if decision.ai_explanation:
+                entry["ai_explanation"] = decision.ai_explanation
+            decisions.append(entry)
+
+        file_payload: dict[str, object] = {
+            "path": file_result.relative_to_root,
+            "absolute_path": str(file_result.file_path) if file_result.file_path else "",
+            "file_type": file_result.file_type,
+            "hunks_applied": file_result.hunks_applied,
+            "hunks_total": file_result.hunks_total,
+            "decisions": decisions,
+        }
+        if file_result.skipped_reason:
+            file_payload["skipped_reason"] = file_result.skipped_reason
+        files.append(file_payload)
+
+    payload: dict[str, object] = {
+        "project_root": str(session.project_root),
+        "dry_run": session.dry_run,
+        "threshold": session.threshold,
+        "started_at": session.started_at,
+        "files": files,
+    }
+    return payload
+
+
+def _call_summary_service(payload: dict[str, object]) -> dict[str, object]:
+    endpoint = os.getenv("PATCH_GUI_AI_SUMMARY_ENDPOINT")
+    if not endpoint:
+        raise AISummaryError(
+            "AI summary endpoint not configured (set PATCH_GUI_AI_SUMMARY_ENDPOINT)."
+        )
+
+    token = os.getenv("PATCH_GUI_AI_SUMMARY_TOKEN") or os.getenv("PATCH_GUI_AI_TOKEN")
+
+    data = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(endpoint, data=data, method="POST")
+    request.add_header("Content-Type", "application/json")
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+
+    try:
+        with urllib.request.urlopen(request, timeout=_DEFAULT_TIMEOUT) as response:
+            body = response.read()
+            charset = response.headers.get_content_charset("utf-8")
+    except urllib.error.HTTPError as exc:  # pragma: no cover - network error paths
+        raise AISummaryError(f"HTTP error {exc.code}: {exc.reason}") from exc
+    except urllib.error.URLError as exc:  # pragma: no cover - network error paths
+        raise AISummaryError(str(exc)) from exc
+
+    try:
+        decoded = body.decode(charset or "utf-8")
+    except UnicodeDecodeError as exc:  # pragma: no cover - rare
+        raise AISummaryError("Cannot decode AI summary response") from exc
+
+    try:
+        parsed = json.loads(decoded)
+    except json.JSONDecodeError as exc:
+        raise AISummaryError("Invalid JSON from AI summary endpoint") from exc
+
+    if not isinstance(parsed, dict):
+        raise AISummaryError("AI summary response must be a JSON object")
+
+    return parsed
+
+
+def _normalise_summary_text(value: object) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _parse_summary_response(response: dict[str, object]) -> AISummary:
+    overall = _normalise_summary_text(
+        response.get("summary")
+        or response.get("overall")
+        or response.get("session")
+        or response.get("text")
+    )
+
+    per_file: Dict[str, str] = {}
+    files_obj = response.get("files") or response.get("per_file")
+    if isinstance(files_obj, dict):
+        for key, value in files_obj.items():
+            key_str = str(key).strip()
+            text = _normalise_summary_text(value)
+            if key_str and text:
+                per_file[key_str] = text
+    elif isinstance(files_obj, list):
+        for item in files_obj:
+            if not isinstance(item, dict):
+                continue
+            path = item.get("file") or item.get("path") or item.get("name")
+            text = item.get("summary") or item.get("text") or item.get("description")
+            path_str = _normalise_summary_text(path)
+            text_str = _normalise_summary_text(text)
+            if path_str and text_str:
+                per_file[path_str] = text_str
+
+    return AISummary(overall=overall, per_file=per_file)
+
+
+def generate_session_summary(session: ApplySession) -> Optional[AISummary]:
+    """Return the AI-generated summary for ``session`` if configured."""
+
+    try:
+        payload = _build_payload(session)
+        response = _call_summary_service(payload)
+        summary = _parse_summary_response(response)
+    except AISummaryError as exc:
+        logger.info("AI summary unavailable: %s", exc)
+        return None
+    except Exception as exc:  # pragma: no cover - defensive guard
+        logger.exception("Unexpected error while retrieving AI summary: %s", exc)
+        return None
+
+    if summary.is_empty():
+        logger.info("AI summary response did not contain any text")
+        return None
+
+    return summary

--- a/patch_gui/app.py
+++ b/patch_gui/app.py
@@ -22,6 +22,7 @@ from PySide6.QtWidgets import QDialog, QMainWindow
 from unidiff import PatchSet
 
 from .ai_candidate_selector import AISuggestion, rank_candidates
+from .ai_summaries import generate_session_summary
 from .config import (
     AppConfig,
     DEFAULT_LOG_BACKUP_COUNT,
@@ -2057,12 +2058,37 @@ class MainWindow(_QMainWindowBase):
         self, session: ApplySession
     ) -> None:  # pragma: no cover - UI feedback
         self._current_worker = None
+        summary = generate_session_summary(session)
+        if summary is not None:
+            session.ai_summary = summary.overall
+            session.file_summaries = summary.per_file
+            if summary.per_file:
+                for fr in session.results:
+                    candidate_keys = [fr.relative_to_root, str(fr.file_path)]
+                    for key in candidate_keys:
+                        if key and key in summary.per_file:
+                            fr.ai_summary = summary.per_file[key]
+                            break
         write_session_reports(
             session,
             report_json=None,
             report_txt=None,
             enable_reports=self.app_config.write_reports,
         )
+        if session.ai_summary:
+            text = _("Sintesi AI: {text}").format(text=session.ai_summary)
+            logger.info(text)
+            self.log.appendPlainText(text)
+        if session.file_summaries:
+            per_file_header = _("Dettaglio sintesi AI per file:")
+            logger.info(per_file_header)
+            self.log.appendPlainText(per_file_header)
+            for path, summary_text in session.file_summaries.items():
+                detail = _("- {path}: {summary}").format(
+                    path=path, summary=summary_text
+                )
+                logger.info(detail)
+                self.log.appendPlainText(detail)
         logger.info(_("\n=== RISULTATO ===\n%s"), session.to_txt())
         self._set_busy(False)
         self.progress_bar.setValue(100)
@@ -2076,6 +2102,10 @@ class MainWindow(_QMainWindowBase):
             completion_message = _(
                 "Operazione terminata. Report disabilitati nelle impostazioni."
             )
+        if session.ai_summary:
+            completion_message += "\n\n" + _(
+                "Sintesi AI: {summary}"
+            ).format(summary=session.ai_summary)
         QtWidgets.QMessageBox.information(
             self,
             _("Completato"),

--- a/patch_gui/executor.py
+++ b/patch_gui/executor.py
@@ -15,6 +15,7 @@ from unidiff import PatchSet
 from unidiff.errors import UnidiffParseError
 
 from .ai_candidate_selector import AISuggestion, rank_candidates
+from .ai_summaries import generate_session_summary
 from .config import AppConfig, load_config
 from .filetypes import inspect_file_type
 from .localization import gettext as _
@@ -235,6 +236,20 @@ def apply_patchset(
             ai_auto_select=ai_auto_select,
         )
         session.results.append(fr)
+
+    summary = generate_session_summary(session)
+    if summary is not None:
+        session.ai_summary = summary.overall
+        session.file_summaries = summary.per_file
+        if summary.per_file:
+            for fr in session.results:
+                candidate_keys = [fr.relative_to_root, str(fr.file_path)]
+                for key in candidate_keys:
+                    if key and key in summary.per_file:
+                        fr.ai_summary = summary.per_file[key]
+                        break
+        if summary.overall:
+            logger.info(_("AI summary: %s"), summary.overall)
 
     try:
         write_session_reports(


### PR DESCRIPTION
## Summary
- add an AI summary helper that calls a configurable endpoint and returns overall/per-file summaries
- persist AI summaries on ApplySession/FileResult objects and include them in reports and UI logging
- document the new integration and changelog entry

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccf9f8f394832686c83dcda53203cd