### PR TITLE
Add optional AI notes to interactive diff view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ e il progetto aderisce al [Versionamento Semantico](https://semver.org/lang/it/)
 - Nuovi controlli nelle preferenze della GUI e nel dialog dei candidati per
   mostrare confidenza, spiegazione e consentire l'applicazione rapida del
   suggerimento AI.
+- Note AI contestuali nella vista diff interattiva, abilitate da una nuova
+  preferenza e mostrate direttamente nell'elenco e nell'anteprima.
 ### Modificato
 - La configurazione persistente include ora le impostazioni dedicate
   all'assistente AI ed è documentata nella guida d'uso.

--- a/patch_gui/app.py
+++ b/patch_gui/app.py
@@ -979,6 +979,14 @@ class SettingsDialog(_QDialogBase):
         self.ai_auto_check.setChecked(self._original_config.ai_auto_apply)
         form.addRow("", self.ai_auto_check)
 
+        self.ai_diff_notes_check = QtWidgets.QCheckBox(
+            _("Mostra note AI nel diff interattivo")
+        )
+        self.ai_diff_notes_check.setChecked(
+            self._original_config.ai_diff_notes_enabled
+        )
+        form.addRow("", self.ai_diff_notes_check)
+
         self.buttons = QtWidgets.QDialogButtonBox(
             QtWidgets.QDialogButtonBox.StandardButton.Ok
             | QtWidgets.QDialogButtonBox.StandardButton.Cancel
@@ -1054,6 +1062,7 @@ class SettingsDialog(_QDialogBase):
             backup_retention_days=backup_retention_days,
             ai_assistant_enabled=self.ai_assistant_check.isChecked(),
             ai_auto_apply=self.ai_auto_check.isChecked(),
+            ai_diff_notes_enabled=self.ai_diff_notes_check.isChecked(),
         )
 
     @staticmethod
@@ -1394,6 +1403,7 @@ class MainWindow(_QMainWindowBase):
         self.reports_enabled: bool = self.app_config.write_reports
         self.ai_assistant_enabled: bool = self.app_config.ai_assistant_enabled
         self.ai_auto_apply: bool = self.app_config.ai_auto_apply
+        self.ai_diff_notes_enabled: bool = self.app_config.ai_diff_notes_enabled
         self._qt_log_handler: Optional[GuiLogHandler] = None
         self._current_worker: Optional[PatchApplyWorker] = None
 
@@ -1625,7 +1635,9 @@ class MainWindow(_QMainWindowBase):
         self._preview_highlighter = DiffHighlighter(self.preview_view.document())
         self.diff_tabs.addTab(self.preview_view, _("Anteprima"))
 
-        self.interactive_diff = InteractiveDiffWidget()
+        self.interactive_diff = InteractiveDiffWidget(
+            ai_notes_enabled=self.app_config.ai_diff_notes_enabled
+        )
         self.interactive_diff.diffReordered.connect(self._on_diff_reordered)
         self.diff_tabs.addTab(self.interactive_diff, _("Diff interattivo"))
 
@@ -1699,10 +1711,12 @@ class MainWindow(_QMainWindowBase):
         self.reports_enabled = bool(self.app_config.write_reports)
         self.ai_assistant_enabled = bool(self.app_config.ai_assistant_enabled)
         self.ai_auto_apply = bool(self.app_config.ai_auto_apply)
+        self.ai_diff_notes_enabled = bool(self.app_config.ai_diff_notes_enabled)
         self.spin_thresh.setValue(self.threshold)
         excludes_text = ", ".join(self.exclude_dirs) if self.exclude_dirs else ""
         self.exclude_edit.setText(excludes_text)
         self.chk_dry.setChecked(self.app_config.dry_run_default)
+        self.interactive_diff.set_ai_notes_enabled(self.ai_diff_notes_enabled)
 
     def _create_settings_dialog(self) -> SettingsDialog:
         return SettingsDialog(self, config=self.app_config)
@@ -1767,6 +1781,7 @@ class MainWindow(_QMainWindowBase):
         self.app_config.write_reports = self.reports_enabled
         self.app_config.ai_assistant_enabled = self.ai_assistant_enabled
         self.app_config.ai_auto_apply = self.ai_auto_apply
+        self.app_config.ai_diff_notes_enabled = self.ai_diff_notes_enabled
         self.threshold = self.app_config.threshold
         self.exclude_dirs = self.app_config.exclude_dirs
         self.reports_enabled = self.app_config.write_reports

--- a/patch_gui/cli.py
+++ b/patch_gui/cli.py
@@ -63,6 +63,7 @@ _CONFIG_KEYS = (
     "backup_retention_days",
     "ai_assistant_enabled",
     "ai_auto_apply",
+    "ai_diff_notes_enabled",
 )
 
 
@@ -461,6 +462,8 @@ def config_reset(
             config.ai_assistant_enabled = defaults.ai_assistant_enabled
         elif key == "ai_auto_apply":
             config.ai_auto_apply = defaults.ai_auto_apply
+        elif key == "ai_diff_notes_enabled":
+            config.ai_diff_notes_enabled = defaults.ai_diff_notes_enabled
         save_config(config, path)
         message = _("{key} reset to default.").format(key=key)
 
@@ -535,7 +538,7 @@ def _apply_config_value(
             config.write_reports = config_value
         return
 
-    if key in {"ai_assistant_enabled", "ai_auto_apply"}:
+    if key in {"ai_assistant_enabled", "ai_auto_apply", "ai_diff_notes_enabled"}:
         if len(values) != 1:
             raise ConfigCommandError(
                 _("The {key} key expects exactly one value.").format(key=key),
@@ -543,8 +546,10 @@ def _apply_config_value(
         config_value = _parse_bool(values[0])
         if key == "ai_assistant_enabled":
             config.ai_assistant_enabled = config_value
-        else:
+        elif key == "ai_auto_apply":
             config.ai_auto_apply = config_value
+        else:
+            config.ai_diff_notes_enabled = config_value
         return
 
     if key == "log_file":

--- a/patch_gui/config.py
+++ b/patch_gui/config.py
@@ -45,6 +45,7 @@ _DEFAULT_LOG_BACKUP_COUNT = 0
 _DEFAULT_BACKUP_RETENTION_DAYS = 0
 _DEFAULT_AI_ASSISTANT = False
 _DEFAULT_AI_AUTO_APPLY = False
+_DEFAULT_AI_DIFF_NOTES = False
 
 
 def _default_log_file() -> Path:
@@ -88,6 +89,7 @@ class AppConfig:
     backup_retention_days: int = DEFAULT_BACKUP_RETENTION_DAYS
     ai_assistant_enabled: bool = _DEFAULT_AI_ASSISTANT
     ai_auto_apply: bool = _DEFAULT_AI_AUTO_APPLY
+    ai_diff_notes_enabled: bool = _DEFAULT_AI_DIFF_NOTES
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any]) -> "AppConfig":
@@ -117,6 +119,9 @@ class AppConfig:
             data.get("ai_assistant_enabled"), base.ai_assistant_enabled
         )
         ai_auto_apply = _coerce_bool(data.get("ai_auto_apply"), base.ai_auto_apply)
+        ai_diff_notes = _coerce_bool(
+            data.get("ai_diff_notes_enabled"), base.ai_diff_notes_enabled
+        )
 
         return cls(
             threshold=threshold,
@@ -131,6 +136,7 @@ class AppConfig:
             backup_retention_days=backup_retention_days,
             ai_assistant_enabled=ai_enabled,
             ai_auto_apply=ai_auto_apply,
+            ai_diff_notes_enabled=ai_diff_notes,
         )
 
     def to_mapping(self) -> MutableMapping[str, Any]:
@@ -149,6 +155,7 @@ class AppConfig:
             "backup_retention_days": int(self.backup_retention_days),
             "ai_assistant_enabled": bool(self.ai_assistant_enabled),
             "ai_auto_apply": bool(self.ai_auto_apply),
+            "ai_diff_notes_enabled": bool(self.ai_diff_notes_enabled),
         }
 
 
@@ -217,6 +224,7 @@ def save_config(config: AppConfig, path: Path | None = None) -> Path:
     backup_retention_repr = json.dumps(mapping["backup_retention_days"])
     ai_assistant_repr = json.dumps(mapping["ai_assistant_enabled"])
     ai_auto_apply_repr = json.dumps(mapping["ai_auto_apply"])
+    ai_diff_notes_repr = json.dumps(mapping["ai_diff_notes_enabled"])
 
     content_lines = [
         f"[{_CONFIG_SECTION}]",
@@ -232,6 +240,7 @@ def save_config(config: AppConfig, path: Path | None = None) -> Path:
         f"backup_retention_days = {backup_retention_repr}",
         f"ai_assistant_enabled = {ai_assistant_repr}",
         f"ai_auto_apply = {ai_auto_apply_repr}",
+        f"ai_diff_notes_enabled = {ai_diff_notes_repr}",
         "",
     ]
 

--- a/patch_gui/interactive_diff_model.py
+++ b/patch_gui/interactive_diff_model.py
@@ -1,0 +1,75 @@
+"""Shared data structures and helpers for the interactive diff widget."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Protocol
+
+from .localization import gettext as _
+
+__all__ = [
+    "FileDiffEntry",
+    "enrich_entry_with_ai_note",
+    "set_diff_note_client",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class FileDiffEntry:
+    """Store information about a file diff block."""
+
+    file_label: str
+    diff_text: str
+    annotated_diff_text: str
+    additions: int
+    deletions: int
+    ai_note: str | None = None
+
+    @property
+    def display_text(self) -> str:
+        additions = _("+{count}").format(count=self.additions)
+        deletions = _("-{count}").format(count=self.deletions)
+        return _("{name} · {additions} / {deletions}").format(
+            name=self.file_label,
+            additions=additions,
+            deletions=deletions,
+        )
+
+
+class _DiffNoteClient(Protocol):
+    """Protocol describing the minimal AI client for diff notes."""
+
+    def generate_diff_note(self, file_label: str, diff_text: str) -> str | None:
+        """Return a short note for the provided ``diff_text``."""
+
+
+_ai_note_client: _DiffNoteClient | None = None
+
+
+def set_diff_note_client(client: _DiffNoteClient | None) -> None:
+    """Register the shared AI client used to enrich diff entries."""
+
+    global _ai_note_client
+    _ai_note_client = client
+
+
+def enrich_entry_with_ai_note(
+    entry: FileDiffEntry, *, enabled: bool
+) -> FileDiffEntry:
+    """Populate ``entry`` with an AI-generated note when possible."""
+
+    if not enabled or _ai_note_client is None:
+        return entry
+
+    if entry.ai_note is not None:
+        return entry
+
+    try:
+        note = _ai_note_client.generate_diff_note(entry.file_label, entry.diff_text)
+    except Exception:  # pragma: no cover - defensive guard
+        note = None
+
+    if not note:
+        return entry
+
+    return replace(entry, ai_note=note)


### PR DESCRIPTION
## Summary
- add a shared FileDiffEntry helper with optional AI notes and use it from the interactive diff UI
- expose a preference and CLI/config support for enabling AI notes in the diff viewer
- cover the AI note helper with unit tests and document the enhancement

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccfa0b38088326986121cbaf651671