### PR TITLE
Add optional AI notes to interactive diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ e il progetto aderisce al [Versionamento Semantico](https://semver.org/lang/it/)
 - Nuovi controlli nelle preferenze della GUI e nel dialog dei candidati per
   mostrare confidenza, spiegazione e consentire l'applicazione rapida del
   suggerimento AI.
+- Le voci del diff interattivo possono mostrare note generate da un assistente
+  AI condiviso, attivabili dalle preferenze dell'applicazione.
 ### Modificato
 - La configurazione persistente include ora le impostazioni dedicate
   all'assistente AI ed è documentata nella guida d'uso.

--- a/patch_gui/app.py
+++ b/patch_gui/app.py
@@ -979,6 +979,14 @@ class SettingsDialog(_QDialogBase):
         self.ai_auto_check.setChecked(self._original_config.ai_auto_apply)
         form.addRow("", self.ai_auto_check)
 
+        self.ai_notes_check = QtWidgets.QCheckBox(
+            _("Mostra note AI nel diff interattivo")
+        )
+        self.ai_notes_check.setChecked(
+            self._original_config.ai_diff_notes_enabled
+        )
+        form.addRow("", self.ai_notes_check)
+
         self.buttons = QtWidgets.QDialogButtonBox(
             QtWidgets.QDialogButtonBox.StandardButton.Ok
             | QtWidgets.QDialogButtonBox.StandardButton.Cancel
@@ -1054,6 +1062,7 @@ class SettingsDialog(_QDialogBase):
             backup_retention_days=backup_retention_days,
             ai_assistant_enabled=self.ai_assistant_check.isChecked(),
             ai_auto_apply=self.ai_auto_check.isChecked(),
+            ai_diff_notes_enabled=self.ai_notes_check.isChecked(),
         )
 
     @staticmethod
@@ -1394,6 +1403,7 @@ class MainWindow(_QMainWindowBase):
         self.reports_enabled: bool = self.app_config.write_reports
         self.ai_assistant_enabled: bool = self.app_config.ai_assistant_enabled
         self.ai_auto_apply: bool = self.app_config.ai_auto_apply
+        self.ai_notes_enabled: bool = self.app_config.ai_diff_notes_enabled
         self._qt_log_handler: Optional[GuiLogHandler] = None
         self._current_worker: Optional[PatchApplyWorker] = None
 
@@ -1699,10 +1709,12 @@ class MainWindow(_QMainWindowBase):
         self.reports_enabled = bool(self.app_config.write_reports)
         self.ai_assistant_enabled = bool(self.app_config.ai_assistant_enabled)
         self.ai_auto_apply = bool(self.app_config.ai_auto_apply)
+        self.ai_notes_enabled = bool(self.app_config.ai_diff_notes_enabled)
         self.spin_thresh.setValue(self.threshold)
         excludes_text = ", ".join(self.exclude_dirs) if self.exclude_dirs else ""
         self.exclude_edit.setText(excludes_text)
         self.chk_dry.setChecked(self.app_config.dry_run_default)
+        self.interactive_diff.set_ai_notes_enabled(self.ai_notes_enabled)
 
     def _create_settings_dialog(self) -> SettingsDialog:
         return SettingsDialog(self, config=self.app_config)
@@ -1767,9 +1779,11 @@ class MainWindow(_QMainWindowBase):
         self.app_config.write_reports = self.reports_enabled
         self.app_config.ai_assistant_enabled = self.ai_assistant_enabled
         self.app_config.ai_auto_apply = self.ai_auto_apply
+        self.app_config.ai_diff_notes_enabled = self.ai_notes_enabled
         self.threshold = self.app_config.threshold
         self.exclude_dirs = self.app_config.exclude_dirs
         self.reports_enabled = self.app_config.write_reports
+        self.ai_notes_enabled = self.app_config.ai_diff_notes_enabled
         save_config(self.app_config)
 
     def choose_root(self) -> None:

--- a/patch_gui/cli.py
+++ b/patch_gui/cli.py
@@ -63,6 +63,7 @@ _CONFIG_KEYS = (
     "backup_retention_days",
     "ai_assistant_enabled",
     "ai_auto_apply",
+    "ai_diff_notes_enabled",
 )
 
 
@@ -461,6 +462,8 @@ def config_reset(
             config.ai_assistant_enabled = defaults.ai_assistant_enabled
         elif key == "ai_auto_apply":
             config.ai_auto_apply = defaults.ai_auto_apply
+        elif key == "ai_diff_notes_enabled":
+            config.ai_diff_notes_enabled = defaults.ai_diff_notes_enabled
         save_config(config, path)
         message = _("{key} reset to default.").format(key=key)
 
@@ -535,7 +538,7 @@ def _apply_config_value(
             config.write_reports = config_value
         return
 
-    if key in {"ai_assistant_enabled", "ai_auto_apply"}:
+    if key in {"ai_assistant_enabled", "ai_auto_apply", "ai_diff_notes_enabled"}:
         if len(values) != 1:
             raise ConfigCommandError(
                 _("The {key} key expects exactly one value.").format(key=key),
@@ -543,8 +546,10 @@ def _apply_config_value(
         config_value = _parse_bool(values[0])
         if key == "ai_assistant_enabled":
             config.ai_assistant_enabled = config_value
-        else:
+        elif key == "ai_auto_apply":
             config.ai_auto_apply = config_value
+        else:
+            config.ai_diff_notes_enabled = config_value
         return
 
     if key == "log_file":

--- a/patch_gui/config.py
+++ b/patch_gui/config.py
@@ -45,6 +45,7 @@ _DEFAULT_LOG_BACKUP_COUNT = 0
 _DEFAULT_BACKUP_RETENTION_DAYS = 0
 _DEFAULT_AI_ASSISTANT = False
 _DEFAULT_AI_AUTO_APPLY = False
+_DEFAULT_AI_DIFF_NOTES = False
 
 
 def _default_log_file() -> Path:
@@ -88,6 +89,7 @@ class AppConfig:
     backup_retention_days: int = DEFAULT_BACKUP_RETENTION_DAYS
     ai_assistant_enabled: bool = _DEFAULT_AI_ASSISTANT
     ai_auto_apply: bool = _DEFAULT_AI_AUTO_APPLY
+    ai_diff_notes_enabled: bool = _DEFAULT_AI_DIFF_NOTES
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any]) -> "AppConfig":
@@ -117,6 +119,9 @@ class AppConfig:
             data.get("ai_assistant_enabled"), base.ai_assistant_enabled
         )
         ai_auto_apply = _coerce_bool(data.get("ai_auto_apply"), base.ai_auto_apply)
+        ai_diff_notes = _coerce_bool(
+            data.get("ai_diff_notes_enabled"), base.ai_diff_notes_enabled
+        )
 
         return cls(
             threshold=threshold,
@@ -131,6 +136,7 @@ class AppConfig:
             backup_retention_days=backup_retention_days,
             ai_assistant_enabled=ai_enabled,
             ai_auto_apply=ai_auto_apply,
+            ai_diff_notes_enabled=ai_diff_notes,
         )
 
     def to_mapping(self) -> MutableMapping[str, Any]:
@@ -149,6 +155,7 @@ class AppConfig:
             "backup_retention_days": int(self.backup_retention_days),
             "ai_assistant_enabled": bool(self.ai_assistant_enabled),
             "ai_auto_apply": bool(self.ai_auto_apply),
+            "ai_diff_notes_enabled": bool(self.ai_diff_notes_enabled),
         }
 
 
@@ -217,6 +224,7 @@ def save_config(config: AppConfig, path: Path | None = None) -> Path:
     backup_retention_repr = json.dumps(mapping["backup_retention_days"])
     ai_assistant_repr = json.dumps(mapping["ai_assistant_enabled"])
     ai_auto_apply_repr = json.dumps(mapping["ai_auto_apply"])
+    ai_diff_notes_repr = json.dumps(mapping["ai_diff_notes_enabled"])
 
     content_lines = [
         f"[{_CONFIG_SECTION}]",
@@ -232,6 +240,7 @@ def save_config(config: AppConfig, path: Path | None = None) -> Path:
         f"backup_retention_days = {backup_retention_repr}",
         f"ai_assistant_enabled = {ai_assistant_repr}",
         f"ai_auto_apply = {ai_auto_apply_repr}",
+        f"ai_diff_notes_enabled = {ai_diff_notes_repr}",
         "",
     ]
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,6 +23,7 @@ def test_load_config_returns_defaults_when_missing(tmp_path: Path) -> None:
     assert loaded.backup_retention_days == defaults.backup_retention_days
     assert loaded.ai_assistant_enabled == defaults.ai_assistant_enabled
     assert loaded.ai_auto_apply == defaults.ai_auto_apply
+    assert loaded.ai_diff_notes_enabled == defaults.ai_diff_notes_enabled
 
 
 def test_save_and_load_roundtrip(tmp_path: Path) -> None:
@@ -42,6 +43,7 @@ def test_save_and_load_roundtrip(tmp_path: Path) -> None:
         backup_retention_days=14,
         ai_assistant_enabled=True,
         ai_auto_apply=True,
+        ai_diff_notes_enabled=True,
     )
 
     save_config(original, path=config_path)
@@ -68,6 +70,7 @@ def test_load_config_invalid_values_fallback(tmp_path: Path) -> None:
                 "backup_retention_days = -10",
                 'ai_assistant_enabled = "maybe"',
                 'ai_auto_apply = "\""',
+                'ai_diff_notes_enabled = "sure"',
                 "",
             ]
         ),
@@ -89,6 +92,7 @@ def test_load_config_invalid_values_fallback(tmp_path: Path) -> None:
     assert loaded.backup_retention_days == defaults.backup_retention_days
     assert loaded.ai_assistant_enabled == defaults.ai_assistant_enabled
     assert loaded.ai_auto_apply == defaults.ai_auto_apply
+    assert loaded.ai_diff_notes_enabled == defaults.ai_diff_notes_enabled
 
 
 def test_load_config_accepts_empty_exclude_list(tmp_path: Path) -> None:
@@ -109,6 +113,7 @@ def test_load_config_accepts_empty_exclude_list(tmp_path: Path) -> None:
                 "backup_retention_days = 30",
                 "ai_assistant_enabled = true",
                 "ai_auto_apply = true",
+                "ai_diff_notes_enabled = true",
                 "",
             ]
         ),
@@ -129,3 +134,4 @@ def test_load_config_accepts_empty_exclude_list(tmp_path: Path) -> None:
     assert loaded.backup_retention_days == 30
     assert loaded.ai_assistant_enabled is True
     assert loaded.ai_auto_apply is True
+    assert loaded.ai_diff_notes_enabled is True

--- a/tests/test_diff_applier_gui.py
+++ b/tests/test_diff_applier_gui.py
@@ -151,6 +151,7 @@ def test_settings_dialog_gathers_config(qt_app: Any, tmp_path: Path) -> None:
         backup_retention_days=4,
         ai_assistant_enabled=True,
         ai_auto_apply=False,
+        ai_diff_notes_enabled=False,
     )
 
     dialog = app_module.SettingsDialog(None, config=config)
@@ -170,6 +171,7 @@ def test_settings_dialog_gathers_config(qt_app: Any, tmp_path: Path) -> None:
     dialog.backup_retention_edit.setText("7")
     dialog.ai_assistant_check.setChecked(False)
     dialog.ai_auto_check.setChecked(True)
+    dialog.ai_notes_check.setChecked(True)
 
     updated = dialog._gather_config()
 
@@ -185,6 +187,7 @@ def test_settings_dialog_gathers_config(qt_app: Any, tmp_path: Path) -> None:
     assert updated.backup_retention_days == 7
     assert updated.ai_assistant_enabled is False
     assert updated.ai_auto_apply is True
+    assert updated.ai_diff_notes_enabled is True
 
 
 def test_main_window_applies_settings_dialog(
@@ -236,6 +239,7 @@ def test_main_window_applies_settings_dialog(
         log_backup_count=0,
         ai_assistant_enabled=False,
         ai_auto_apply=False,
+        ai_diff_notes_enabled=False,
     )
 
     window = app_module.MainWindow(app_config=original)
@@ -252,6 +256,7 @@ def test_main_window_applies_settings_dialog(
         log_backup_count=3,
         ai_assistant_enabled=True,
         ai_auto_apply=True,
+        ai_diff_notes_enabled=True,
     )
 
     class _FakeDialog:
@@ -273,6 +278,7 @@ def test_main_window_applies_settings_dialog(
     assert window.reports_enabled is new_config.write_reports
     assert window.ai_assistant_enabled is new_config.ai_assistant_enabled
     assert window.ai_auto_apply is new_config.ai_auto_apply
+    assert window.ai_notes_enabled is new_config.ai_diff_notes_enabled
     assert configured_invocations == [
         {
             "level": new_config.log_level,

--- a/tests/test_interactive_diff_formatting.py
+++ b/tests/test_interactive_diff_formatting.py
@@ -2,9 +2,29 @@
 
 from __future__ import annotations
 
+import pytest
 from unidiff import PatchSet
 
 from patch_gui.diff_formatting import format_diff_with_line_numbers
+
+try:
+    from patch_gui.interactive_diff import (
+        FileDiffEntry,
+        enrich_entry_with_ai_note,
+        set_diff_note_client,
+    )
+except ImportError as exc:  # pragma: no cover - optional dependency guard
+    message = repr(exc)
+    if "PySide6" in message or "libGL" in message:
+        pytest.skip("PySide6 non disponibile", allow_module_level=True)
+    raise
+
+
+@pytest.fixture(autouse=True)
+def _reset_diff_note_client() -> None:
+    set_diff_note_client(None)
+    yield
+    set_diff_note_client(None)
 
 
 def test_format_diff_with_line_numbers_includes_real_positions() -> None:
@@ -41,3 +61,74 @@ def test_format_diff_with_line_numbers_returns_fallback_for_binary() -> None:
     formatted = format_diff_with_line_numbers(patched_file, diff_text)
 
     assert formatted == diff_text
+
+
+def test_enrich_entry_with_ai_note_uses_client_and_strips_result() -> None:
+    class _FakeClient:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, str]] = []
+
+        def generate_note(self, *, file_label: str, diff_text: str) -> str:
+            self.calls.append((file_label, diff_text))
+            return "  Nota sintetica  \n"
+
+    client = _FakeClient()
+    set_diff_note_client(client)
+    entry = FileDiffEntry(
+        file_label="foo.py",
+        diff_text="-old\n+new\n",
+        annotated_diff_text="annotated",
+        additions=1,
+        deletions=1,
+    )
+
+    enriched = enrich_entry_with_ai_note(entry, ai_notes_enabled=True)
+
+    assert enriched.ai_note == "Nota sintetica"
+    assert client.calls == [("foo.py", "-old\n+new\n")]
+
+
+def test_enrich_entry_with_ai_note_returns_original_on_failure() -> None:
+    class _FailingClient:
+        def generate_note(self, *, file_label: str, diff_text: str) -> str:
+            raise RuntimeError("boom")
+
+    set_diff_note_client(_FailingClient())
+    entry = FileDiffEntry(
+        file_label="bar.txt",
+        diff_text="diff\n",
+        annotated_diff_text="annotated",
+        additions=0,
+        deletions=0,
+    )
+
+    result = enrich_entry_with_ai_note(entry, ai_notes_enabled=True)
+
+    assert result is entry
+    assert result.ai_note is None
+
+
+def test_enrich_entry_with_ai_note_skips_when_disabled() -> None:
+    class _CountingClient:
+        def __init__(self) -> None:
+            self.called = False
+
+        def generate_note(self, *, file_label: str, diff_text: str) -> str:
+            self.called = True
+            return "ignored"
+
+    client = _CountingClient()
+    set_diff_note_client(client)
+    entry = FileDiffEntry(
+        file_label="baz.py",
+        diff_text="diff\n",
+        annotated_diff_text="annotated",
+        additions=2,
+        deletions=0,
+    )
+
+    result = enrich_entry_with_ai_note(entry, ai_notes_enabled=False)
+
+    assert result is entry
+    assert result.ai_note is None
+    assert client.called is False


### PR DESCRIPTION
## Summary
- add AI-generated note support to interactive diff entries with optional shared client integration
- surface AI notes in the list UI and expose a preference toggle in the settings dialog
- extend configuration, CLI helpers, and tests to cover the new preference and AI note workflow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ccfa1958a08326a9b5461116616e31