### PR TITLE
Fix typing for manual resolver and clean imports

### DIFF
--- a/patch_gui/ai_candidate_selector.py
+++ b/patch_gui/ai_candidate_selector.py
@@ -9,7 +9,7 @@ import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from difflib import SequenceMatcher
-from typing import Iterable, Optional, Sequence
+from typing import Optional, Sequence
 
 from .patcher import HunkView
 
@@ -199,9 +199,7 @@ def _local_best_candidate(
         else:
             continue
 
-        explanation = (
-            "Local heuristic based on textual similarity."
-        )
+        explanation = "Local heuristic based on textual similarity."
         if best is None or score > best.confidence:
             best = AISuggestion(
                 candidate_index=index,
@@ -249,4 +247,3 @@ def rank_candidates(
     except AIAssistantError as exc:
         log.warning("AI assistant unavailable: %s", exc)
         return local_choice
-

--- a/patch_gui/ai_conflict_helper.py
+++ b/patch_gui/ai_conflict_helper.py
@@ -17,7 +17,9 @@ class ConflictSuggestion:
     confidence: float | None = None
 
 
-def _build_patch(before_lines: Sequence[str], after_lines: Sequence[str], header: str) -> str | None:
+def _build_patch(
+    before_lines: Sequence[str], after_lines: Sequence[str], header: str
+) -> str | None:
     """Return a minimal diff that the user can copy to apply manually."""
 
     diff_lines = list(
@@ -38,7 +40,9 @@ def _build_patch(before_lines: Sequence[str], after_lines: Sequence[str], header
     return "\n".join(result).strip() or None
 
 
-def _extract_context(file_context: str, before_text: str, window: int = 120) -> str | None:
+def _extract_context(
+    file_context: str, before_text: str, window: int = 120
+) -> str | None:
     if not file_context or not before_text:
         return None
     idx = file_context.find(before_text)
@@ -99,9 +103,13 @@ def generate_conflict_suggestion(
         message_lines.append("Contesto trovato nel file:")
         message_lines.append(context_excerpt)
 
-    patch_text = (original_diff.strip() or None) or _build_patch(before_lines, after_lines, hunk_header)
+    patch_text = (original_diff.strip() or None) or _build_patch(
+        before_lines, after_lines, hunk_header
+    )
     if patch_text:
-        message_lines.append("È possibile copiare il diff suggerito per applicarlo manualmente.")
+        message_lines.append(
+            "È possibile copiare il diff suggerito per applicarlo manualmente."
+        )
 
     message = "\n".join(message_lines)
 

--- a/patch_gui/ai_summaries.py
+++ b/patch_gui/ai_summaries.py
@@ -61,7 +61,9 @@ def _build_payload(session: ApplySession) -> dict[str, object]:
 
         file_payload: dict[str, object] = {
             "path": file_result.relative_to_root,
-            "absolute_path": str(file_result.file_path) if file_result.file_path else "",
+            "absolute_path": (
+                str(file_result.file_path) if file_result.file_path else ""
+            ),
             "file_type": file_result.file_type,
             "hunks_applied": file_result.hunks_applied,
             "hunks_total": file_result.hunks_total,

--- a/patch_gui/app.py
+++ b/patch_gui/app.py
@@ -697,7 +697,8 @@ class CandidateDialog(_QDialogBase):
                 )
             if assistant_patch:
                 patch_label = QtWidgets.QLabel(
-                    _("Diff suggerito – applicazione manuale:"))
+                    _("Diff suggerito – applicazione manuale:")
+                )
                 patch_label.setWordWrap(True)
                 suggestion_layout.addWidget(patch_label)
                 patch_edit = QtWidgets.QPlainTextEdit(assistant_patch)
@@ -751,9 +752,7 @@ class CandidateDialog(_QDialogBase):
             self.ai_label = QtWidgets.QLabel(suggestion_text)
             self.ai_label.setWordWrap(True)
             suggestion_layout.addWidget(self.ai_label, 1)
-            self.apply_ai_btn = QtWidgets.QPushButton(
-                _("Applica suggerimento")
-            )
+            self.apply_ai_btn = QtWidgets.QPushButton(_("Applica suggerimento"))
             self.apply_ai_btn.clicked.connect(self._apply_ai)
             suggestion_layout.addWidget(self.apply_ai_btn)
             layout.addWidget(suggestion_widget)
@@ -1016,9 +1015,7 @@ class SettingsDialog(_QDialogBase):
         self.ai_assistant_check = QtWidgets.QCheckBox(
             _("Suggerisci automaticamente con l'assistente AI")
         )
-        self.ai_assistant_check.setChecked(
-            self._original_config.ai_assistant_enabled
-        )
+        self.ai_assistant_check.setChecked(self._original_config.ai_assistant_enabled)
         form.addRow("", self.ai_assistant_check)
 
         self.ai_auto_check = QtWidgets.QCheckBox(
@@ -1030,9 +1027,7 @@ class SettingsDialog(_QDialogBase):
         self.ai_diff_notes_check = QtWidgets.QCheckBox(
             _("Mostra note AI nel diff interattivo")
         )
-        self.ai_diff_notes_check.setChecked(
-            self._original_config.ai_diff_notes_enabled
-        )
+        self.ai_diff_notes_check.setChecked(self._original_config.ai_diff_notes_enabled)
         form.addRow("", self.ai_diff_notes_check)
 
         self.buttons = QtWidgets.QDialogButtonBox(
@@ -2178,9 +2173,9 @@ class MainWindow(_QMainWindowBase):
                 "Operazione terminata. Report disabilitati nelle impostazioni."
             )
         if session.ai_summary:
-            completion_message += "\n\n" + _(
-                "Sintesi AI: {summary}"
-            ).format(summary=session.ai_summary)
+            completion_message += "\n\n" + _("Sintesi AI: {summary}").format(
+                summary=session.ai_summary
+            )
         QtWidgets.QMessageBox.information(
             self,
             _("Completato"),

--- a/patch_gui/executor.py
+++ b/patch_gui/executor.py
@@ -605,7 +605,9 @@ def _apply_file_patch(
     resolved_ai_assistant = (
         config.ai_assistant_enabled if ai_assistant is None else ai_assistant
     )
-    resolved_ai_auto = config.ai_auto_apply if ai_auto_select is None else ai_auto_select
+    resolved_ai_auto = (
+        config.ai_auto_apply if ai_auto_select is None else ai_auto_select
+    )
     if resolved_ai_auto:
         resolved_ai_assistant = True
 
@@ -846,9 +848,7 @@ def _cli_manual_resolver(
             )
         )
         if ai_hint.explanation:
-            print(
-                _("  Explanation: {text}").format(text=ai_hint.explanation)
-            )
+            print(_("  Explanation: {text}").format(text=ai_hint.explanation))
 
         if ai_auto_select:
             chosen_pos = ai_hint.position

--- a/patch_gui/interactive_diff.py
+++ b/patch_gui/interactive_diff.py
@@ -14,7 +14,6 @@ from .diff_formatting import format_diff_with_line_numbers
 from .interactive_diff_model import (
     FileDiffEntry,
     enrich_entry_with_ai_note,
-    set_diff_note_client,
 )
 
 
@@ -548,7 +547,9 @@ class InteractiveDiffWidget(QtWidgets.QWidget):  # type: ignore[misc]
                 cache[entry] = enriched
                 return enriched
 
-            self._original_entries = [_resolve(entry) for entry in self._original_entries]
+            self._original_entries = [
+                _resolve(entry) for entry in self._original_entries
+            ]
             for idx in range(self._list_widget.count()):
                 item = self._list_widget.item(idx)
                 entry = item.data(QtCore.Qt.ItemDataRole.UserRole)
@@ -581,7 +582,9 @@ class InteractiveDiffWidget(QtWidgets.QWidget):  # type: ignore[misc]
             item = self._list_widget.item(idx)
             entry = item.data(QtCore.Qt.ItemDataRole.UserRole)
             widget = self._list_widget.itemWidget(item)
-            if isinstance(entry, FileDiffEntry) and isinstance(widget, _DiffListItemWidget):
+            if isinstance(entry, FileDiffEntry) and isinstance(
+                widget, _DiffListItemWidget
+            ):
                 note = entry.ai_note if self._ai_notes_enabled else None
                 widget.set_ai_note(note)
 

--- a/patch_gui/interactive_diff_model.py
+++ b/patch_gui/interactive_diff_model.py
@@ -53,9 +53,7 @@ def set_diff_note_client(client: _DiffNoteClient | None) -> None:
     _ai_note_client = client
 
 
-def enrich_entry_with_ai_note(
-    entry: FileDiffEntry, *, enabled: bool
-) -> FileDiffEntry:
+def enrich_entry_with_ai_note(entry: FileDiffEntry, *, enabled: bool) -> FileDiffEntry:
     """Populate ``entry`` with an AI-generated note when possible."""
 
     if not enabled or _ai_note_client is None:

--- a/patch_gui/patcher.py
+++ b/patch_gui/patcher.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from difflib import SequenceMatcher
 from pathlib import Path
-from typing import Callable, Iterable, Iterator, Optional, Protocol, Sequence
+from typing import Iterable, Iterator, Optional, Protocol, Sequence
 
 from patch_gui.ai_conflict_helper import generate_conflict_suggestion
 from patch_gui.localization import gettext as _
@@ -223,9 +223,7 @@ class ApplySession:
                 )
             )
             if fr.ai_summary:
-                lines.append(
-                    _("  AI summary: {summary}").format(summary=fr.ai_summary)
-                )
+                lines.append(_("  AI summary: {summary}").format(summary=fr.ai_summary))
             for d in fr.decisions:
                 lines.append(
                     _("    Hunk {header} -> {strategy}").format(
@@ -283,16 +281,16 @@ class ApplySession:
                         )
                     else:
                         lines.append(
-                            _(
-                                "      AI suggestion ({origin}): pos {position}"
-                            ).format(
+                            _("      AI suggestion ({origin}): pos {position}").format(
                                 origin=origin,
                                 position=d.ai_recommendation,
                             )
                         )
                     if d.ai_explanation:
                         lines.append(
-                            _("        Explanation: {text}").format(text=d.ai_explanation)
+                            _("        Explanation: {text}").format(
+                                text=d.ai_explanation
+                            )
                         )
             lines.append("")
         return "\n".join(lines)
@@ -306,10 +304,19 @@ class HunkView:
     context_lines: list[str] = field(default_factory=list)
 
 
-ManualResolver = Callable[
-    ["HunkView", list[str], list[tuple[int, float]], HunkDecision, str, str],
-    Optional[int],
-]
+class ManualResolver(Protocol):
+    def __call__(
+        self,
+        hv: "HunkView",
+        lines: list[str],
+        candidates: list[tuple[int, float]],
+        decision: HunkDecision,
+        reason: str,
+        /,
+        *,
+        original_diff: str,
+    ) -> Optional[int]:
+        """Resolve an ambiguous hunk by picking a candidate position."""
 
 
 def build_hunk_view(hunk: _HunkLike) -> HunkView:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -67,7 +67,7 @@ def test_load_config_invalid_values_fallback(tmp_path: Path) -> None:
                 "log_backup_count = -5",
                 "backup_retention_days = -10",
                 'ai_assistant_enabled = "maybe"',
-                'ai_auto_apply = "\""',
+                'ai_auto_apply = """',
                 "",
             ]
         ),


### PR DESCRIPTION
## Summary
- define a `ManualResolver` protocol that allows the `original_diff` keyword argument
- drop unused imports that ruff flagged after the formatting pass
- apply project formatting updates from black

## Testing
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68cd0ada4d148326a5aa5a7ad080562a