### PR TITLE
Include typing marker in package data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ include = ["patch_gui*"]
 
 [tool.setuptools.package-data]
 "patch_gui" = [
+    "py.typed",
     "translations/*.ts",
     "translations/*.qm",
     "resources/*.svg",

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import patch_gui
+
+
+def test_package_includes_typing_marker() -> None:
+    package_paths = list(patch_gui.__path__)
+    assert package_paths
+    package_dir = Path(package_paths[0]).resolve()
+    assert (package_dir / "py.typed").is_file()


### PR DESCRIPTION
## Summary
- add the `py.typed` marker file to the project and ship it via setuptools package data
- add a regression test to ensure the typing marker is bundled with the installed package

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cd1eb25ed88326bccc865bd77b3b4b