### PR TITLE
Add CLI config-path support

### DIFF
--- a/patch_gui/cli.py
+++ b/patch_gui/cli.py
@@ -70,9 +70,16 @@ _CONFIG_KEYS = (
 def run_cli(argv: Sequence[str] | None = None) -> int:
     """Parse ``argv`` and execute the CLI workflow."""
 
-    config = load_config()
-    parser = build_parser(config=config)
-    args = parser.parse_args(list(argv) if argv is not None else None)
+    argument_list = list(argv) if argv is not None else sys.argv[1:]
+
+    bootstrap_parser = argparse.ArgumentParser(add_help=False)
+    bootstrap_parser.add_argument("--config-path", type=Path, default=None)
+    bootstrap_args, _remaining = bootstrap_parser.parse_known_args(argument_list)
+    config_path = bootstrap_args.config_path
+
+    config = load_config(config_path)
+    parser = build_parser(config=config, config_path=config_path)
+    args = parser.parse_args(argument_list)
 
     raw_summary_formats = list(args.summary_format) if args.summary_format else None
     if raw_summary_formats and "none" in raw_summary_formats:

--- a/patch_gui/parser.py
+++ b/patch_gui/parser.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
 from typing import List, Optional, Sequence
 
 from ._version import __version__
@@ -48,6 +49,7 @@ def build_parser(
     parser: Optional[argparse.ArgumentParser] = None,
     *,
     config: AppConfig | None = None,
+    config_path: Path | None = None,
 ) -> argparse.ArgumentParser:
     """Create or enrich an ``ArgumentParser`` with CLI options."""
 
@@ -80,11 +82,19 @@ def build_parser(
         help=_("Project root where the patch should be applied."),
     )
     parser.add_argument(
+        "--config-path",
+        type=Path,
+        default=None,
+        help=_(
+            "Override the configuration file path (default: use the standard location)."
+        ),
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help=_("Simulate the execution without modifying files or creating backups."),
     )
-    resolved_config = config or load_config()
+    resolved_config = config or load_config(config_path)
     parser.add_argument(
         "--threshold",
         type=threshold_value,


### PR DESCRIPTION
## Summary
- add a --config-path option to the apply CLI parser and load configuration overrides from that path
- ensure the CLI bootstraps parsing with the requested config path before building the full parser
- cover the new behaviour with tests that exercise run_cli using temporary configuration files

## Testing
- pytest tests/test_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68cd1eb481dc8326a85761cd4c82c70a