### PR TITLE
Use atomic writes when saving config

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 
+import patch_gui.config as config_module
 from patch_gui.config import AppConfig, load_config, save_config
 
 
@@ -48,6 +49,28 @@ def test_save_and_load_roundtrip(tmp_path: Path) -> None:
     loaded = load_config(path=config_path)
 
     assert loaded == original
+
+
+def test_save_config_atomic_replace_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "settings.toml"
+    original = AppConfig(threshold=0.9)
+    save_config(original, path=config_path)
+
+    attempted = AppConfig(threshold=0.5)
+
+    def failing_replace(src: object, dst: object) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(config_module.os, "replace", failing_replace)
+
+    with pytest.raises(RuntimeError):
+        save_config(attempted, path=config_path)
+
+    loaded = load_config(path=config_path)
+    assert loaded == original
+    assert {path for path in config_path.parent.iterdir()} == {config_path}
 
 
 def test_load_config_invalid_values_fallback(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- write configuration files to a temporary location and atomically replace the target
- ensure temporary files are cleaned up when replacements fail
- add a regression test exercising a simulated replace failure during save

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd1eb7a7cc8326aadadcec4521bb68