### PR TITLE
Align CLI dry-run defaults with configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ git diff | patch-gui apply --root . --backup ~/diff_backups -
 `patch-gui apply` condivide le stesse euristiche della GUI. Le opzioni più
 utili:
 
-- `--dry-run`: simula l'esecuzione senza modificare i file.
+- `--dry-run` / `--apply`: simula l'esecuzione oppure forza
+  l'applicazione anche se la configurazione prevede il dry-run
+  (il default segue le impostazioni salvate).
 - `--threshold`: regola la tolleranza fuzzy (default `0.85`).
 - `--backup`: directory personalizzata per backup e report.
 - `--report-json` / `--report-txt`: percorsi espliciti per i report.

--- a/patch_gui/parser.py
+++ b/patch_gui/parser.py
@@ -79,12 +79,28 @@ def build_parser(
         required=True,
         help=_("Project root where the patch should be applied."),
     )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help=_("Simulate the execution without modifying files or creating backups."),
-    )
     resolved_config = config or load_config()
+    dry_run_group = parser.add_mutually_exclusive_group()
+    dry_run_group.add_argument(
+        "--dry-run",
+        dest="dry_run",
+        action="store_true",
+        help=(
+            _(
+                "Simulate the execution without modifying files or creating backups"
+                " (default follows the configuration)."
+            )
+        ),
+    )
+    dry_run_group.add_argument(
+        "--apply",
+        dest="dry_run",
+        action="store_false",
+        help=_(
+            "Apply changes even when dry-run mode is enabled in the configuration."
+        ),
+    )
+    parser.set_defaults(dry_run=resolved_config.dry_run_default)
     parser.add_argument(
         "--threshold",
         type=threshold_value,


### PR DESCRIPTION
## Summary
- default the CLI `--dry-run` option to the configured value and add a mutually exclusive `--apply` override
- document the paired flags in the README and ensure help output includes the new option
- cover configuration-driven dry-run behaviour and override flows in the CLI tests while updating existing scenarios

## Testing
- pytest tests/test_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68cd1ebbdc208326980cf3355bc9b6bb