### PR TITLE
Respect CLI report defaults from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ utili:
 - `--threshold`: regola la tolleranza fuzzy (default `0.85`).
 - `--backup`: directory personalizzata per backup e report.
 - `--report-json` / `--report-txt`: percorsi espliciti per i report.
-- `--no-report`: disattiva la generazione dei file di report.
+- `--report` / `--no-report`: forza l'abilitazione o la disattivazione dei file di
+  report (di default segue la configurazione salvata).
 - `--summary-format`: controlla il riepilogo su stdout (`text`, `json`, `none`).
 - `--exclude-dir`: aggiunge cartelle all'elenco di esclusioni.
 - `--no-default-exclude`: rimuove le esclusioni predefinite (es. `.git`,

--- a/patch_gui/cli.py
+++ b/patch_gui/cli.py
@@ -90,7 +90,7 @@ def run_cli(argv: Sequence[str] | None = None) -> int:
         summary_formats = ["text"]
         summary_controlled = False
 
-    if args.no_report and (
+    if (not args.write_reports) and (
         (args.report_json is not REPORT_JSON_UNSET and args.report_json is not None)
         or (args.report_txt is not REPORT_TXT_UNSET and args.report_txt is not None)
     ):
@@ -163,7 +163,7 @@ def run_cli(argv: Sequence[str] | None = None) -> int:
             auto_accept=args.auto_accept,
             report_json=report_json_arg,
             report_txt=report_txt_arg,
-            write_report_files=not args.no_report,
+            write_report_files=args.write_reports,
             write_report_json="json" in requested_report_formats,
             write_report_txt="text" in requested_report_formats,
             exclude_dirs=exclude_dirs,
@@ -196,7 +196,7 @@ def run_cli(argv: Sequence[str] | None = None) -> int:
                     _("Reports saved to: {details}").format(details=", ".join(details))
                 )
             else:
-                print(_("Reports disabled (--no-report)"))
+                print(_("Reports disabled (--no-report or configuration)"))
 
     emitted_text = False
     for fmt in summary_formats:
@@ -229,7 +229,7 @@ def run_cli(argv: Sequence[str] | None = None) -> int:
                     ", ".join(details),
                 )
             else:
-                logger.info(_("Reports disabled (--no-report)"))
+                logger.info(_("Reports disabled (--no-report or configuration)"))
 
     return 0 if session_completed(session) else 1
 

--- a/patch_gui/parser.py
+++ b/patch_gui/parser.py
@@ -109,11 +109,20 @@ def build_parser(
         help=_("Path of the generated text report; defaults to '<backup>/%s'.")
         % REPORT_TXT,
     )
-    parser.add_argument(
-        "--no-report",
+    report_group = parser.add_mutually_exclusive_group()
+    report_group.add_argument(
+        "--report",
+        dest="write_reports",
         action="store_true",
+        help=_("Generate JSON/TXT report files (overrides the configuration)."),
+    )
+    report_group.add_argument(
+        "--no-report",
+        dest="write_reports",
+        action="store_false",
         help=_("Do not create JSON/TXT report files."),
     )
+    parser.set_defaults(write_reports=resolved_config.write_reports)
     parser.add_argument(
         "--summary-format",
         action="append",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -946,6 +946,7 @@ def test_run_cli_uses_config_defaults(
         exclude_dirs=("foo", "bar"),
         backup_base=tmp_path / "custom-backups",
         log_level="debug",
+        write_reports=False,
     )
 
     captured: dict[str, object] = {}
@@ -966,6 +967,7 @@ def test_run_cli_uses_config_defaults(
         captured["exclude_dirs"] = kwargs.get("exclude_dirs")
         captured["backup_base"] = kwargs.get("backup_base")
         captured["config"] = kwargs.get("config")
+        captured["write_report_files"] = kwargs.get("write_report_files")
         return _create_dummy_session(tmp_path)
 
     monkeypatch.setattr(cli, "load_patch", fake_load_patch)
@@ -986,6 +988,51 @@ def test_run_cli_uses_config_defaults(
     assert captured["exclude_dirs"] == config.exclude_dirs
     assert captured["backup_base"] is None
     assert captured["config"] is config
+    assert captured["write_report_files"] is config.write_reports
+
+
+def test_run_cli_can_override_config_report_default(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    project = _create_project(tmp_path)
+    patch_path = tmp_path / "config.diff"
+    patch_path.write_text(SAMPLE_DIFF, encoding="utf-8")
+
+    config = AppConfig(write_reports=False)
+
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(cli, "load_config", lambda: config)
+
+    def fake_load_patch(source: str, *, encoding: str | None = None) -> PatchSet:
+        captured["source"] = source
+        captured["encoding"] = encoding
+        return PatchSet(SAMPLE_DIFF)
+
+    def fake_apply_patchset(
+        patch: PatchSet,
+        project_root: Path,
+        **kwargs: object,
+    ) -> _DummySession:
+        captured["write_report_files"] = kwargs.get("write_report_files")
+        return _create_dummy_session(tmp_path)
+
+    monkeypatch.setattr(cli, "load_patch", fake_load_patch)
+    monkeypatch.setattr(cli, "apply_patchset", fake_apply_patchset)
+    monkeypatch.setattr(cli, "session_completed", lambda session: True)
+
+    exit_code = cli.run_cli(
+        [
+            "--root",
+            str(project),
+            "--dry-run",
+            "--report",
+            str(patch_path),
+        ]
+    )
+
+    assert exit_code == 0
+    assert captured["write_report_files"] is True
 
 
 def test_run_cli_configures_requested_log_level(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- update the CLI parser to share `--report`/`--no-report` toggles that default to the saved configuration
- have `run_cli` use the parsed report preference directly while keeping the rest of the workflow unchanged
- extend CLI tests and docs to cover config-driven report defaults and the new override flag

## Testing
- pytest tests/test_cli.py::test_run_cli_uses_config_defaults tests/test_cli.py::test_run_cli_can_override_config_report_default

------
https://chatgpt.com/codex/tasks/task_e_68cd1ec627788326b5ab944a6c2466a6