### PR TITLE
Respect CLI report configuration defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ utili:
 - `--threshold`: regola la tolleranza fuzzy (default `0.85`).
 - `--backup`: directory personalizzata per backup e report.
 - `--report-json` / `--report-txt`: percorsi espliciti per i report.
+- `--report`: riabilita la generazione dei report se disattivata da configurazione.
 - `--no-report`: disattiva la generazione dei file di report.
 - `--summary-format`: controlla il riepilogo su stdout (`text`, `json`, `none`).
 - `--exclude-dir`: aggiunge cartelle all'elenco di esclusioni.

--- a/patch_gui/cli.py
+++ b/patch_gui/cli.py
@@ -90,7 +90,7 @@ def run_cli(argv: Sequence[str] | None = None) -> int:
         summary_formats = ["text"]
         summary_controlled = False
 
-    if args.no_report and (
+    if not args.write_reports and (
         (args.report_json is not REPORT_JSON_UNSET and args.report_json is not None)
         or (args.report_txt is not REPORT_TXT_UNSET and args.report_txt is not None)
     ):
@@ -163,7 +163,7 @@ def run_cli(argv: Sequence[str] | None = None) -> int:
             auto_accept=args.auto_accept,
             report_json=report_json_arg,
             report_txt=report_txt_arg,
-            write_report_files=not args.no_report,
+            write_report_files=bool(args.write_reports),
             write_report_json="json" in requested_report_formats,
             write_report_txt="text" in requested_report_formats,
             exclude_dirs=exclude_dirs,
@@ -196,7 +196,9 @@ def run_cli(argv: Sequence[str] | None = None) -> int:
                     _("Reports saved to: {details}").format(details=", ".join(details))
                 )
             else:
-                print(_("Reports disabled (--no-report)"))
+                print(
+                    _("Reports disabled (--no-report or configuration default)")
+                )
 
     emitted_text = False
     for fmt in summary_formats:
@@ -229,7 +231,9 @@ def run_cli(argv: Sequence[str] | None = None) -> int:
                     ", ".join(details),
                 )
             else:
-                logger.info(_("Reports disabled (--no-report)"))
+                logger.info(
+                    _("Reports disabled (--no-report or configuration default)")
+                )
 
     return 0 if session_completed(session) else 1
 

--- a/patch_gui/parser.py
+++ b/patch_gui/parser.py
@@ -109,11 +109,22 @@ def build_parser(
         help=_("Path of the generated text report; defaults to '<backup>/%s'.")
         % REPORT_TXT,
     )
-    parser.add_argument(
-        "--no-report",
+    report_group = parser.add_mutually_exclusive_group()
+    report_group.add_argument(
+        "--report",
+        dest="write_reports",
         action="store_true",
+        help=_(
+            "Create JSON/TXT report files even if disabled in the configuration."
+        ),
+    )
+    report_group.add_argument(
+        "--no-report",
+        dest="write_reports",
+        action="store_false",
         help=_("Do not create JSON/TXT report files."),
     )
+    parser.set_defaults(write_reports=bool(resolved_config.write_reports))
     parser.add_argument(
         "--summary-format",
         action="append",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -207,6 +207,20 @@ def test_build_parser_uses_config_defaults(tmp_path: Path) -> None:
     assert expected_snippet.replace(" ", "") in normalized_help
 
 
+def test_build_parser_uses_config_report_defaults(tmp_path: Path) -> None:
+    config = AppConfig(write_reports=False)
+
+    parser_obj = parser.build_parser(config=config)
+
+    args = parser_obj.parse_args(["--root", str(tmp_path), "patch.diff"])
+    assert args.write_reports is False
+
+    args_with_override = parser_obj.parse_args(
+        ["--root", str(tmp_path), "--report", "patch.diff"]
+    )
+    assert args_with_override.write_reports is True
+
+
 def test_apply_patchset_dry_run(tmp_path: Path) -> None:
     project = _create_project(tmp_path)
 
@@ -966,6 +980,7 @@ def test_run_cli_uses_config_defaults(
         captured["exclude_dirs"] = kwargs.get("exclude_dirs")
         captured["backup_base"] = kwargs.get("backup_base")
         captured["config"] = kwargs.get("config")
+        captured["write_report_files"] = kwargs.get("write_report_files")
         return _create_dummy_session(tmp_path)
 
     monkeypatch.setattr(cli, "load_patch", fake_load_patch)
@@ -986,6 +1001,84 @@ def test_run_cli_uses_config_defaults(
     assert captured["exclude_dirs"] == config.exclude_dirs
     assert captured["backup_base"] is None
     assert captured["config"] is config
+    assert captured["write_report_files"] is True
+
+
+def test_run_cli_respects_config_report_default(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    project = _create_project(tmp_path)
+    patch_path = tmp_path / "reports-default.diff"
+    patch_path.write_text(SAMPLE_DIFF, encoding="utf-8")
+
+    config = AppConfig(write_reports=False)
+
+    monkeypatch.setattr(cli, "load_config", lambda: config)
+
+    def fake_load_patch(source: str, *, encoding: str | None = None) -> PatchSet:
+        return PatchSet(SAMPLE_DIFF)
+
+    captured: dict[str, object] = {}
+
+    def fake_apply_patchset(
+        patch: PatchSet,
+        project_root: Path,
+        **kwargs: object,
+    ) -> _DummySession:
+        captured["write_report_files"] = kwargs.get("write_report_files")
+        return _create_dummy_session(tmp_path)
+
+    monkeypatch.setattr(cli, "load_patch", fake_load_patch)
+    monkeypatch.setattr(cli, "apply_patchset", fake_apply_patchset)
+    monkeypatch.setattr(cli, "session_completed", lambda session: True)
+
+    exit_code = cli.run_cli([
+        "--root",
+        str(project),
+        str(patch_path),
+    ])
+
+    assert exit_code == 0
+    assert captured["write_report_files"] is False
+
+
+def test_run_cli_report_flag_overrides_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    project = _create_project(tmp_path)
+    patch_path = tmp_path / "reports-override.diff"
+    patch_path.write_text(SAMPLE_DIFF, encoding="utf-8")
+
+    config = AppConfig(write_reports=False)
+
+    monkeypatch.setattr(cli, "load_config", lambda: config)
+
+    def fake_load_patch(source: str, *, encoding: str | None = None) -> PatchSet:
+        return PatchSet(SAMPLE_DIFF)
+
+    captured: dict[str, object] = {}
+
+    def fake_apply_patchset(
+        patch: PatchSet,
+        project_root: Path,
+        **kwargs: object,
+    ) -> _DummySession:
+        captured["write_report_files"] = kwargs.get("write_report_files")
+        return _create_dummy_session(tmp_path)
+
+    monkeypatch.setattr(cli, "load_patch", fake_load_patch)
+    monkeypatch.setattr(cli, "apply_patchset", fake_apply_patchset)
+    monkeypatch.setattr(cli, "session_completed", lambda session: True)
+
+    exit_code = cli.run_cli([
+        "--root",
+        str(project),
+        "--report",
+        str(patch_path),
+    ])
+
+    assert exit_code == 0
+    assert captured["write_report_files"] is True
 
 
 def test_run_cli_configures_requested_log_level(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- tie the CLI report toggle defaults to the configuration and add an explicit `--report` flag
- update the CLI workflow to consume the parsed boolean and adjust reporting messages
- cover the new behaviour with regression tests and refresh the README documentation

## Testing
- pytest tests/test_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68cd1ecbe8f08326b99a7ef05849d347