### PR TITLE
Add config path support to CLI

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -80,6 +80,9 @@ Oltre a usare la GUI, puoi ispezionare e modificare le impostazioni persistenti 
 
 Se vuoi operare su un file alternativo (per test o ambienti portabili) aggiungi `--config-path /percorso/custom/settings.toml` dopo il nome del sottocomando.
 
+La stessa opzione può essere usata con `patch-gui apply` per applicare una
+configurazione personalizzata anche durante l'esecuzione del comando principale.
+
 ## Assistente AI (sperimentale)
 
 - L'assistente può essere abilitato o disabilitato sia dalla GUI (Preferenze → *Suggerisci automaticamente con l'assistente AI*) sia tramite CLI con `--ai-assistant` / `--no-ai-assistant`.

--- a/patch_gui/parser.py
+++ b/patch_gui/parser.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
 from typing import List, Optional, Sequence
 
 from ._version import __version__
@@ -48,6 +49,7 @@ def build_parser(
     parser: Optional[argparse.ArgumentParser] = None,
     *,
     config: AppConfig | None = None,
+    config_path: Path | None = None,
 ) -> argparse.ArgumentParser:
     """Create or enrich an ``ArgumentParser`` with CLI options."""
 
@@ -69,6 +71,14 @@ def build_parser(
         action="version",
         version=__version__,
         help=_("Show the version number and exit."),
+    )
+    parser.add_argument(
+        "--config-path",
+        type=Path,
+        default=config_path,
+        help=_(
+            "Override the configuration file path (default: use the standard location)."
+        ),
     )
     parser.add_argument(
         "patch",


### PR DESCRIPTION
## Summary
- allow passing --config-path when running `patch-gui apply` and validate the chosen file before loading configuration defaults
- load the configuration before building the main parser so defaults honour the selected file and report meaningful errors for invalid paths
- document the shared option in the CLI usage guide and cover custom path scenarios with new CLI tests

## Testing
- pytest tests/test_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68cd1ee0c7ac832691896fc95828c0df