### PR TITLE
Add CLI restore command

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ Comandi aggiuntivi:
 - `patch-gui download-exe`: scarica l'eseguibile Windows dalla pagina delle
   release. Usa `--output` per impostare il percorso di destinazione e `--tag`
   per selezionare una release specifica.
+- `patch-gui restore`: elenca i timestamp disponibili e ripristina i file da un
+  backup creato in precedenza. Aggiungi `--timestamp <label>` per evitare il
+  prompt di selezione, `--yes`/`--force` per saltare la conferma e `--dry-run`
+  per verificare i file che verrebbero copiati senza toccare il progetto.
 - `patch-gui config`: visualizza o modifica la configurazione persistente.
   Esempi:
 
@@ -208,6 +212,13 @@ Struttura predefinita:
 - I report vengono generati anche nelle simulazioni (puoi disattivarli con
   `--no-report`).
 - La retention configurabile rimuove automaticamente i backup più vecchi.
+
+Per ripristinare rapidamente un backup senza aprire la GUI puoi usare
+`patch-gui restore --root <percorso>`: il comando elenca i timestamp disponibili
+nella cartella `.diff_backups` del progetto (o nella directory configurata)
+copiando i file selezionati. Le opzioni `--timestamp`, `--yes` e `--dry-run`
+permettono di automatizzare il workflow o di eseguire una prova senza
+modifiche.
 
 ## Configurazione persistente
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -48,6 +48,8 @@ Questa guida passo‑passo descrive il workflow tipico per applicare una patch c
      (anche in dry‑run, se non disattivati) per documentare l'esito della simulazione.
 8. **Ripristina da backup**
    - Usa il pulsante **Ripristina da backup…** e seleziona il timestamp desiderato per ripristinare i file originali.
+   - In alternativa esegui `patch-gui restore --root /percorso/del/progetto` dalla CLI per elencare i backup disponibili; puoi
+     combinare `--timestamp`, `--yes`/`--force` e `--dry-run` per automatizzare il ripristino o simulare l'operazione.
 
 ## Suggerimenti utili
 

--- a/patch_gui/diff_applier_gui.py
+++ b/patch_gui/diff_applier_gui.py
@@ -64,6 +64,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args[0] == "download-exe":
         return cli.run_download_exe(args[1:])
 
+    if args[0] == "restore":
+        return cli.run_restore(args[1:])
+
     if any(opt in {"-h", "--help"} for opt in args):
         _print_help()
         return 0
@@ -126,7 +129,7 @@ def _print_help() -> None:
     parser.add_argument(
         "command",
         nargs="?",
-        choices=["gui", "apply", "config", "download-exe"],
+        choices=["gui", "apply", "config", "download-exe", "restore"],
         help=_tr("Command to execute (default: gui)."),
     )
     parser.print_help()
@@ -136,6 +139,8 @@ def _print_help() -> None:
     cli.build_config_parser().print_help()
     print(_tr("\nExecutable download command:"), file=sys.stdout)
     cli.build_download_parser().print_help()
+    print(_tr("\nRestore command:"), file=sys.stdout)
+    cli.build_restore_parser().print_help()
 
 
 def _ensure_translator() -> None:


### PR DESCRIPTION
## Summary
- add a `patch-gui restore` command that lists backup sessions, prompts for a selection, and supports non-interactive flags plus dry-run previews
- wire the new command into the dispatcher and document its usage in README/USAGE
- cover the workflow with interactive and non-interactive tests that build temporary backup directories

## Testing
- pytest tests/test_cli.py::test_run_restore_interactive tests/test_cli.py::test_run_restore_non_interactive

------
https://chatgpt.com/codex/tasks/task_e_68cd1ee76ff083268d41136f61054aca