### PR TITLE
Enhance conflict assistant with AI fallback

### DIFF
--- a/patch_gui/ai_conflict_helper.py
+++ b/patch_gui/ai_conflict_helper.py
@@ -2,9 +2,27 @@
 
 from __future__ import annotations
 
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
 from dataclasses import dataclass
 from difflib import unified_diff
 from typing import Sequence
+
+
+logger = logging.getLogger(__name__)
+
+
+AI_CONFLICT_ENDPOINT_ENV = "PATCH_GUI_AI_CONFLICT_ENDPOINT"
+AI_CONFLICT_TOKEN_ENV = "PATCH_GUI_AI_CONFLICT_TOKEN"
+AI_SHARED_ENDPOINT_ENV = "PATCH_GUI_AI_ENDPOINT"
+AI_SHARED_TOKEN_ENV = "PATCH_GUI_AI_TOKEN"
+
+_DEFAULT_TIMEOUT = 15.0
+_MAX_CONTEXT_CHARS = 6000
+_MAX_DIFF_CHARS = 8000
 
 
 @dataclass
@@ -15,6 +33,17 @@ class ConflictSuggestion:
     patch: str | None = None
     source: str = "heuristic"
     confidence: float | None = None
+
+
+class AIConflictAssistantError(RuntimeError):
+    """Raised when the remote assistant cannot provide a suggestion."""
+
+
+def _trim_text(value: str, limit: int) -> str:
+    if len(value) <= limit:
+        return value
+    ellipsis = "…"
+    return value[: max(0, limit - len(ellipsis))] + ellipsis
 
 
 def _build_patch(
@@ -37,7 +66,10 @@ def _build_patch(
     if header:
         result.append(header)
     result.extend(diff_lines)
-    return "\n".join(result).strip() or None
+    diff_text = "\n".join(result).strip()
+    if not diff_text:
+        return None
+    return _trim_text(diff_text, _MAX_DIFF_CHARS)
 
 
 def _extract_context(
@@ -51,7 +83,115 @@ def _extract_context(
     start = max(0, idx - window)
     end = min(len(file_context), idx + len(before_text) + window)
     snippet = file_context[start:end]
-    return snippet.strip() or None
+    trimmed = snippet.strip()
+    if not trimmed:
+        return None
+    return _trim_text(trimmed, _MAX_CONTEXT_CHARS)
+
+
+def _call_ai_service(payload: dict[str, object]) -> dict[str, object]:
+    endpoint = os.getenv(AI_CONFLICT_ENDPOINT_ENV) or os.getenv(AI_SHARED_ENDPOINT_ENV)
+    if not endpoint:
+        raise AIConflictAssistantError(
+            "AI conflict endpoint not configured (set PATCH_GUI_AI_CONFLICT_ENDPOINT)."
+        )
+
+    token = os.getenv(AI_CONFLICT_TOKEN_ENV) or os.getenv(AI_SHARED_TOKEN_ENV)
+    data = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(endpoint, data=data, method="POST")
+    request.add_header("Content-Type", "application/json")
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+
+    try:
+        with urllib.request.urlopen(request, timeout=_DEFAULT_TIMEOUT) as response:
+            body = response.read()
+            charset = response.headers.get_content_charset("utf-8")
+    except urllib.error.HTTPError as exc:  # pragma: no cover - network error paths
+        raise AIConflictAssistantError(f"HTTP error {exc.code}: {exc.reason}") from exc
+    except urllib.error.URLError as exc:  # pragma: no cover - network error paths
+        raise AIConflictAssistantError(str(exc)) from exc
+
+    try:
+        decoded = body.decode(charset or "utf-8")
+    except UnicodeDecodeError as exc:  # pragma: no cover - rare decoding errors
+        raise AIConflictAssistantError("Cannot decode AI response") from exc
+
+    try:
+        parsed = json.loads(decoded)
+    except json.JSONDecodeError as exc:
+        raise AIConflictAssistantError("Invalid JSON from AI endpoint") from exc
+
+    if not isinstance(parsed, dict):
+        raise AIConflictAssistantError("AI response must be a JSON object")
+
+    return parsed
+
+
+def _parse_ai_response(response: dict[str, object]) -> ConflictSuggestion:
+    raw_message = response.get("message") or response.get("assistant_message")
+    raw_patch = response.get("patch") or response.get("diff")
+    if raw_message is None and raw_patch is None:
+        raise AIConflictAssistantError("AI response missing 'message' or 'patch'")
+
+    message = str(raw_message).strip() if raw_message is not None else ""
+    patch = str(raw_patch).strip() if raw_patch is not None else None
+    source = str(response.get("source") or "assistant")
+    raw_confidence = response.get("confidence")
+    confidence: float | None
+    if raw_confidence is None:
+        confidence = None
+    else:
+        try:
+            confidence = float(raw_confidence)
+        except (TypeError, ValueError) as exc:
+            raise AIConflictAssistantError("Invalid confidence value from AI response") from exc
+
+    if patch:
+        patch = _trim_text(patch, _MAX_DIFF_CHARS)
+
+    if not message:
+        message = "Suggerimento generato automaticamente dall'assistente AI."
+
+    return ConflictSuggestion(
+        message=message,
+        patch=patch or None,
+        source=source,
+        confidence=confidence,
+    )
+
+
+def _maybe_request_ai(
+    *,
+    file_context: str,
+    hunk_header: str,
+    before_lines: Sequence[str],
+    after_lines: Sequence[str],
+    failure_reason: str,
+    original_diff: str,
+) -> ConflictSuggestion | None:
+    endpoint = os.getenv(AI_CONFLICT_ENDPOINT_ENV) or os.getenv(AI_SHARED_ENDPOINT_ENV)
+    if not endpoint:
+        return None
+
+    payload = {
+        "task": "conflict-resolution",
+        "hunk_header": hunk_header,
+        "before": list(before_lines),
+        "after": list(after_lines),
+        "failure_reason": failure_reason,
+        "original_diff": _trim_text(original_diff, _MAX_DIFF_CHARS),
+        "file_context": _trim_text(file_context, _MAX_CONTEXT_CHARS),
+    }
+
+    try:
+        response = _call_ai_service(payload)
+        suggestion = _parse_ai_response(response)
+        suggestion.source = suggestion.source or "assistant"
+        return suggestion
+    except AIConflictAssistantError as exc:
+        logger.warning("AI conflict assistant unavailable: %s", exc)
+        return None
 
 
 def generate_conflict_suggestion(
@@ -63,19 +203,24 @@ def generate_conflict_suggestion(
     failure_reason: str,
     original_diff: str,
 ) -> ConflictSuggestion | None:
-    """Return textual guidance and a patch snippet to resolve a failed hunk.
-
-    The implementation relies on lightweight heuristics so that the feature works
-    without network access.  The generated message explains why the assistant was
-    triggered and offers a compact diff that can be copied into the target file
-    manually.
-    """
+    """Return textual guidance and a patch snippet to resolve a failed hunk."""
 
     before_text = "".join(before_lines)
     after_text = "".join(after_lines)
 
     if not (before_text or after_text or original_diff.strip()):
         return None
+
+    ai_suggestion = _maybe_request_ai(
+        file_context=file_context,
+        hunk_header=hunk_header,
+        before_lines=before_lines,
+        after_lines=after_lines,
+        failure_reason=failure_reason,
+        original_diff=original_diff,
+    )
+    if ai_suggestion is not None:
+        return ai_suggestion
 
     failure_reason = failure_reason.strip()
 

--- a/patch_gui/cli.py
+++ b/patch_gui/cli.py
@@ -82,7 +82,10 @@ def run_cli(argv: Sequence[str] | None = None) -> int:
     bootstrap_args, _remaining = bootstrap_parser.parse_known_args(argument_list)
     config_path = bootstrap_args.config_path
 
-    config = load_config(config_path)
+    if config_path is None:
+        config = load_config()
+    else:
+        config = load_config(config_path)
     parser = build_parser(config=config, config_path=config_path)
     args = parser.parse_args(argument_list)
 

--- a/patch_gui/patcher.py
+++ b/patch_gui/patcher.py
@@ -450,6 +450,8 @@ def apply_hunks(
             return
         decision.assistant_message = suggestion.message
         decision.assistant_patch = suggestion.patch
+        decision.ai_source = suggestion.source
+        decision.ai_confidence = suggestion.confidence
         if suggestion.message:
             logger.debug(
                 "Suggerimento preliminare per hunk %s: %s",

--- a/tests/test_ai_conflict_helper.py
+++ b/tests/test_ai_conflict_helper.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from patch_gui import ai_conflict_helper
+from patch_gui.ai_conflict_helper import (
+    AI_CONFLICT_ENDPOINT_ENV,
+    AI_SHARED_ENDPOINT_ENV,
+    ConflictSuggestion,
+    generate_conflict_suggestion,
+)
+
+
+def _build_args() -> dict[str, Any]:
+    return {
+        "file_context": "// sample file context\nconst value = 1;\n",
+        "hunk_header": "@@ -1,2 +1,6 @@",
+        "before_lines": ["const value = 1;\n"],
+        "after_lines": ["const value = 2;\n"],
+        "failure_reason": "Unexpected hunk found",
+        "original_diff": "@@ -1 +1 @@\n-const value = 1;\n+const value = 2;\n",
+    }
+
+
+def test_generate_conflict_suggestion_heuristic(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(AI_CONFLICT_ENDPOINT_ENV, raising=False)
+    monkeypatch.delenv(AI_SHARED_ENDPOINT_ENV, raising=False)
+
+    suggestion = generate_conflict_suggestion(**_build_args())
+
+    assert suggestion is not None
+    assert isinstance(suggestion, ConflictSuggestion)
+    assert suggestion.source == "heuristic"
+    assert "Suggerimento assistente" in suggestion.message
+    assert suggestion.patch is not None
+
+
+class _DummyResponse:
+    def __init__(self, payload: dict[str, Any]):
+        self._body = json.dumps(payload).encode("utf-8")
+        self.headers = SimpleNamespace(get_content_charset=lambda default=None: "utf-8")
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> "_DummyResponse":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+
+def test_generate_conflict_suggestion_ai(monkeypatch: pytest.MonkeyPatch) -> None:
+    called_payload: dict[str, Any] = {}
+
+    def fake_urlopen(request: Any, timeout: float = 0.0) -> _DummyResponse:
+        nonlocal called_payload
+        called_payload = json.loads(request.data.decode("utf-8"))
+        return _DummyResponse(
+            {
+                "message": "AI suggerisce di aggiornare il blocco.",
+                "patch": "@@ -1 +1 @@\n-const value = 1;\n+const value = 2;\n",
+                "confidence": 0.87,
+                "source": "assistant",
+            }
+        )
+
+    monkeypatch.setenv(AI_CONFLICT_ENDPOINT_ENV, "https://example.invalid/ai")
+    monkeypatch.setattr(ai_conflict_helper.urllib.request, "urlopen", fake_urlopen)
+
+    suggestion = generate_conflict_suggestion(**_build_args())
+
+    assert suggestion is not None
+    assert suggestion.source == "assistant"
+    assert suggestion.confidence == pytest.approx(0.87)
+    assert "AI suggerisce" in suggestion.message
+    assert suggestion.patch is not None
+    assert called_payload["task"] == "conflict-resolution"
+    assert called_payload["before"] == ["const value = 1;\n"]
+


### PR DESCRIPTION
## Summary
- add optional AI-backed conflict suggestions when hunks fail to apply
- record assistant metadata on hunk decisions and keep CLI load_config compatible
- cover the new conflict helper behaviour with targeted unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd2168db448326867da057e02ddef0