### PR TITLE
Support config-driven dry-run defaults in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ git diff | patch-gui apply --root . --backup ~/diff_backups -
 utili:
 
 - `--dry-run`: simula l'esecuzione senza modificare i file.
+- `--apply`: forza l'applicazione reale anche se la configurazione predefinisce il
+  dry-run.
 - `--threshold`: regola la tolleranza fuzzy (default `0.85`).
 - `--backup`: directory personalizzata per backup e report.
 - `--report-json` / `--report-txt`: percorsi espliciti per i report.

--- a/patch_gui/parser.py
+++ b/patch_gui/parser.py
@@ -89,12 +89,27 @@ def build_parser(
             "Override the configuration file path (default: use the standard location)."
         ),
     )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help=_("Simulate the execution without modifying files or creating backups."),
-    )
     resolved_config = config or load_config(config_path)
+
+    dry_run_group = parser.add_mutually_exclusive_group()
+    dry_run_group.add_argument(
+        "--dry-run",
+        dest="dry_run",
+        action="store_true",
+        help=_(
+            "Simulate the execution without modifying files or creating backups. "
+            "Overrides the configured default when provided."
+        ),
+    )
+    dry_run_group.add_argument(
+        "--apply",
+        dest="dry_run",
+        action="store_false",
+        help=_(
+            "Apply changes even if the configuration defaults to dry runs."
+        ),
+    )
+    parser.set_defaults(dry_run=resolved_config.dry_run_default)
     parser.add_argument(
         "--threshold",
         type=threshold_value,


### PR DESCRIPTION
## Summary
- align the CLI dry-run option with the persisted configuration and add an --apply override
- expand CLI tests to cover config-driven dry-run defaults and the new override flag
- document the new CLI flag in the README

## Testing
- pytest tests/test_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68cd2125ce5c8326bd00bbcadab499ce