### PR TITLE
Adjust CLI report flags to follow configuration

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -56,6 +56,8 @@ Questa guida passo‑passo descrive il workflow tipico per applicare una patch c
 - La soglia fuzzy più alta aumenta la precisione ma potrebbe non trovare patch leggermente disallineate.
 - I file binari vengono ignorati automaticamente.
 - Per diff molto grandi l'analisi può richiedere tempo; attendi il completamento prima di chiudere la finestra.
+- La creazione dei report JSON/TXT della sessione segue la configurazione salvata, ma può essere forzata dalla CLI con `--report`
+  o disattivata con `--no-report` secondo le necessità.
 
 Per una panoramica delle opzioni tecniche e delle dipendenze consulta il [README](README.md).
 

--- a/patch_gui/parser.py
+++ b/patch_gui/parser.py
@@ -120,6 +120,7 @@ def build_parser(
         % REPORT_TXT,
     )
     report_group = parser.add_mutually_exclusive_group()
+    report_group.set_defaults(write_reports=resolved_config.write_reports)
     report_group.add_argument(
         "--report",
         dest="write_reports",
@@ -130,9 +131,8 @@ def build_parser(
         "--no-report",
         dest="write_reports",
         action="store_false",
-        help=_("Do not create JSON/TXT report files."),
+        help=_("Do not create JSON/TXT report files (overrides the configuration)."),
     )
-    parser.set_defaults(write_reports=resolved_config.write_reports)
     parser.add_argument(
         "--summary-format",
         action="append",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1002,7 +1002,7 @@ def test_run_cli_can_override_config_report_default(
 
     captured: dict[str, object] = {}
 
-    monkeypatch.setattr(cli, "load_config", lambda: config)
+    monkeypatch.setattr(cli, "load_config", lambda path=None: config)
 
     def fake_load_patch(source: str, *, encoding: str | None = None) -> PatchSet:
         captured["source"] = source
@@ -1033,6 +1033,25 @@ def test_run_cli_can_override_config_report_default(
 
     assert exit_code == 0
     assert captured["write_report_files"] is True
+
+
+@pytest.mark.parametrize("config_value", [True, False])
+def test_build_parser_uses_config_write_reports_default(config_value: bool) -> None:
+    config = AppConfig(write_reports=config_value)
+
+    parser_obj = parser.build_parser(config=config)
+    args = parser_obj.parse_args(["--root", ".", "patch.diff"])
+
+    assert args.write_reports is config_value
+
+
+def test_build_parser_report_flag_can_enable_reports() -> None:
+    config = AppConfig(write_reports=False)
+
+    parser_obj = parser.build_parser(config=config)
+    args = parser_obj.parse_args(["--root", ".", "--report", "patch.diff"])
+
+    assert args.write_reports is True
 
 
 def test_run_cli_respects_config_path_override(


### PR DESCRIPTION
## Summary
- update the CLI parser so the `--report`/`--no-report` flags honour the configuration defaults
- cover the new behaviour with targeted CLI tests and documentation tweaks

## Testing
- pytest tests/test_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68cd2120cf808326a2500d8e7ddde38b