### PR TITLE
Fix mypy issues in AI conflict helper and tests

### DIFF
--- a/patch_gui/cli.py
+++ b/patch_gui/cli.py
@@ -86,9 +86,9 @@ def run_cli(argv: Sequence[str] | None = None) -> int:
         if config_path.exists() and config_path.is_dir():
             bootstrap_parser.exit(
                 1,
-                _(
-                    "Error: configuration path {path} points to a directory.\n"
-                ).format(path=display_path(config_path)),
+                _("Error: configuration path {path} points to a directory.\n").format(
+                    path=display_path(config_path)
+                ),
             )
 
     if config_path is None:
@@ -300,9 +300,7 @@ def run_download_exe(argv: Sequence[str] | None = None) -> int:
     return 0
 
 
-def build_restore_parser(
-    *, config: AppConfig | None = None
-) -> argparse.ArgumentParser:
+def build_restore_parser(*, config: AppConfig | None = None) -> argparse.ArgumentParser:
     """Return an ``ArgumentParser`` configured for the ``restore`` command."""
 
     resolved_config = config or load_config()
@@ -366,10 +364,14 @@ def run_restore(argv: Sequence[str] | None = None) -> int:
     try:
         root = Path(args.root).expanduser().resolve()
     except OSError as exc:
-        parser.exit(1, _("Error: failed to resolve project root: {error}\n").format(error=exc))
+        parser.exit(
+            1, _("Error: failed to resolve project root: {error}\n").format(error=exc)
+        )
 
     if not root.exists() or not root.is_dir():
-        parser.exit(1, _("Error: invalid project root: {path}\n").format(path=args.root))
+        parser.exit(
+            1, _("Error: invalid project root: {path}\n").format(path=args.root)
+        )
 
     backup_base: Path
     if args.backup_base is not None:
@@ -442,9 +444,7 @@ def run_restore(argv: Sequence[str] | None = None) -> int:
         if args.non_interactive:
             parser.exit(
                 1,
-                _(
-                    "Error: --yes is required when running in non-interactive mode.\n"
-                ),
+                _("Error: --yes is required when running in non-interactive mode.\n"),
             )
         confirmed = _prompt_for_confirmation(chosen_session.name)
         if not confirmed:

--- a/patch_gui/config.py
+++ b/patch_gui/config.py
@@ -65,6 +65,7 @@ __all__ = [
     "DEFAULT_LOG_BACKUP_COUNT",
     "DEFAULT_LOG_FILE",
     "DEFAULT_LOG_MAX_BYTES",
+    "os",
     "default_config_dir",
     "default_config_path",
     "load_config",

--- a/patch_gui/logging_utils.py
+++ b/patch_gui/logging_utils.py
@@ -133,4 +133,3 @@ def configure_logging(
 
     root_logger.addHandler(file_handler)
     return file_path
-

--- a/patch_gui/parser.py
+++ b/patch_gui/parser.py
@@ -105,9 +105,7 @@ def build_parser(
         "--apply",
         dest="dry_run",
         action="store_false",
-        help=_(
-            "Apply changes even if the configuration defaults to dry runs."
-        ),
+        help=_("Apply changes even if the configuration defaults to dry runs."),
     )
     parser.set_defaults(dry_run=resolved_config.dry_run_default)
     parser.add_argument(

--- a/scripts/release_automation.py
+++ b/scripts/release_automation.py
@@ -109,7 +109,9 @@ def ensure_clean_worktree(*, dry_run: bool) -> None:
     if dry_run:
         print("[dry-run] Salto controllo stato working tree")
         return
-    status = run_cmd(["git", "status", "--porcelain"], dry_run=False, capture_output=True)
+    status = run_cmd(
+        ["git", "status", "--porcelain"], dry_run=False, capture_output=True
+    )
     if status:
         raise ReleaseError("La working tree contiene modifiche non committate")
 
@@ -213,7 +215,9 @@ def update_changelog(version: str, *, dry_run: bool) -> None:
     try:
         start = next(i for i, line in enumerate(lines) if line.strip() == header)
     except StopIteration as exc:  # pragma: no cover - difesa extra
-        raise ReleaseError("Sezione [Non rilasciato] non trovata nel changelog") from exc
+        raise ReleaseError(
+            "Sezione [Non rilasciato] non trovata nel changelog"
+        ) from exc
 
     end = len(lines)
     for idx in range(start + 1, len(lines)):
@@ -223,7 +227,9 @@ def update_changelog(version: str, *, dry_run: bool) -> None:
 
     block = normalize_block(lines[start + 1 : end])
     if not block:
-        raise ReleaseError("La sezione [Non rilasciato] è vuota: aggiungi le note prima del rilascio")
+        raise ReleaseError(
+            "La sezione [Non rilasciato] è vuota: aggiungi le note prima del rilascio"
+        )
 
     release_header = f"## [{version}] - {_dt.date.today().isoformat()}"
     new_lines: list[str] = []
@@ -253,7 +259,10 @@ def commit(message: str, *, dry_run: bool) -> None:
 
 
 def tag_version(version: str, *, dry_run: bool) -> None:
-    run_cmd(["git", "tag", "-a", f"v{version}", "-m", f"Patch GUI {version}"], dry_run=dry_run)
+    run_cmd(
+        ["git", "tag", "-a", f"v{version}", "-m", f"Patch GUI {version}"],
+        dry_run=dry_run,
+    )
 
 
 def push_refs(*refs: str, dry_run: bool) -> None:
@@ -272,10 +281,18 @@ def run_checks(*, dry_run: bool) -> None:
     dist_dir = REPO_ROOT / "dist"
     artifacts = sorted(dist_dir.glob("*")) if dist_dir.exists() else []
     if artifacts:
-        twine_args = [sys.executable, "-m", "twine", "check", *(str(a.relative_to(REPO_ROOT)) for a in artifacts)]
+        twine_args = [
+            sys.executable,
+            "-m",
+            "twine",
+            "check",
+            *(str(a.relative_to(REPO_ROOT)) for a in artifacts),
+        ]
         commands.append(twine_args)
     else:
-        print("Nessun artifact in dist/ – salto twine check finché non vengono generati")
+        print(
+            "Nessun artifact in dist/ – salto twine check finché non vengono generati"
+        )
 
     for cmd in commands:
         if shutil.which(cmd[0] if os.path.sep in cmd[0] else cmd[0]) is None:
@@ -317,7 +334,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         print("[avviso] Controlli disattivati con --skip-checks")
 
     print("==> Commit di release")
-    stage_files([PYPROJECT_PATH, VERSION_MODULE_PATH, CHANGELOG_PATH], dry_run=args.dry_run)
+    stage_files(
+        [PYPROJECT_PATH, VERSION_MODULE_PATH, CHANGELOG_PATH], dry_run=args.dry_run
+    )
     commit(f"chore: release {args.version}", dry_run=args.dry_run)
 
     print("==> Creazione tag")
@@ -328,7 +347,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         push_refs("master", dry_run=args.dry_run)
         push_refs(f"v{args.version}", dry_run=args.dry_run)
     else:
-        print("[nota] Push saltato: lanciare manualmente 'git push origin master' e 'git push origin v{args.version}'")
+        print(
+            "[nota] Push saltato: lanciare manualmente 'git push origin master' e 'git push origin v{args.version}'"
+        )
 
     print("==> Allineo develop al commit di release")
     checkout_branch("develop", dry_run=args.dry_run)
@@ -339,11 +360,16 @@ def main(argv: Sequence[str] | None = None) -> int:
         update_pyproject(args.next_dev_version, dry_run=args.dry_run)
         update_version_module(args.next_dev_version, dry_run=args.dry_run)
         stage_files([PYPROJECT_PATH, VERSION_MODULE_PATH], dry_run=args.dry_run)
-        commit(f"chore: start development cycle {args.next_dev_version}", dry_run=args.dry_run)
+        commit(
+            f"chore: start development cycle {args.next_dev_version}",
+            dry_run=args.dry_run,
+        )
         if args.push:
             push_refs("develop", dry_run=args.dry_run)
         else:
-            print("[nota] Esegui 'git push origin develop' per aggiornare il branch remoto")
+            print(
+                "[nota] Esegui 'git push origin develop' per aggiornare il branch remoto"
+            )
     else:
         if args.push:
             push_refs("develop", dry_run=args.dry_run)

--- a/tests/test_ai_conflict_helper.py
+++ b/tests/test_ai_conflict_helper.py
@@ -26,7 +26,9 @@ def _build_args() -> dict[str, Any]:
     }
 
 
-def test_generate_conflict_suggestion_heuristic(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_generate_conflict_suggestion_heuristic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.delenv(AI_CONFLICT_ENDPOINT_ENV, raising=False)
     monkeypatch.delenv(AI_SHARED_ENDPOINT_ENV, raising=False)
 
@@ -81,4 +83,3 @@ def test_generate_conflict_suggestion_ai(monkeypatch: pytest.MonkeyPatch) -> Non
     assert suggestion.patch is not None
     assert called_payload["task"] == "conflict-resolution"
     assert called_payload["before"] == ["const value = 1;\n"]
-

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1097,7 +1097,7 @@ def test_run_cli_can_override_config_report_default(
     assert captured["write_report_files"] is True
 
 
-@pytest.mark.parametrize("config_value", [True, False])
+@typed_parametrize("config_value", [True, False])
 def test_build_parser_uses_config_write_reports_default(config_value: bool) -> None:
     config = AppConfig(write_reports=config_value)
 

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import json
+from email.message import Message
 from pathlib import Path
 from typing import Any, List
 from urllib.error import HTTPError
@@ -122,7 +123,7 @@ def test_download_latest_release_exe_wraps_http_error(tmp_path: Path) -> None:
     download_url = "https://example.test/patch-gui.exe"
     release_response = _FakeResponse(_release_payload(download_url))
     http_error = HTTPError(
-        download_url, 404, "Not Found", hdrs=None, fp=io.BytesIO(b"missing")
+        download_url, 404, "Not Found", hdrs=Message(), fp=io.BytesIO(b"missing")
     )
     requests: list[str] = []
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -141,15 +141,17 @@ def test_run_cli_respects_log_configuration(
     monkeypatch.setattr("patch_gui.cli.apply_patchset", _fake_apply_patchset)
     monkeypatch.setattr("patch_gui.cli.session_completed", lambda session: True)
 
-    result = run_cli([
-        "dummy.patch",
-        "--root",
-        str(tmp_path),
-        "--summary-format",
-        "none",
-        "--log-level",
-        "info",
-    ])
+    result = run_cli(
+        [
+            "dummy.patch",
+            "--root",
+            str(tmp_path),
+            "--summary-format",
+            "none",
+            "--log-level",
+            "info",
+        ]
+    )
 
     assert result == 0
 


### PR DESCRIPTION
## Summary
- export the AI conflict helper symbols and validate confidence parsing to satisfy mypy
- expose the configuration module's os attribute and tighten test typing helpers
- ensure HTTPError is constructed with headers to keep tests type-safe

## Testing
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68cd297e16608326bcc0d978da326b0c