### PR TITLE
Add configurable theme selection and palette builders

### DIFF
--- a/patch_gui/app.py
+++ b/patch_gui/app.py
@@ -21,7 +21,7 @@ from unidiff import PatchSet
 
 from .ai_candidate_selector import AISuggestion, rank_candidates
 from .ai_summaries import generate_session_summary
-from .config import AppConfig, load_config, save_config
+from .config import AppConfig, Theme, load_config, save_config
 from .filetypes import inspect_file_type
 from .highlighter import DiffHighlighter
 from .i18n import install_translators
@@ -883,6 +883,20 @@ class SettingsDialog(_QDialogBase):
             self.log_combo.setCurrentIndex(current_index)
         form.addRow(_("Livello log"), self.log_combo)
 
+        theme_labels = {
+            Theme.AUTO: _("Automatico"),
+            Theme.DARK: _("Scuro"),
+            Theme.LIGHT: _("Chiaro"),
+            Theme.HIGH_CONTRAST: _("Alto contrasto"),
+        }
+        self.theme_combo = QtWidgets.QComboBox()
+        for theme in Theme:
+            self.theme_combo.addItem(theme_labels[theme], theme)
+        theme_index = self.theme_combo.findData(self._original_config.theme)
+        if theme_index >= 0:
+            self.theme_combo.setCurrentIndex(theme_index)
+        form.addRow(_("Tema"), self.theme_combo)
+
         self.dry_run_check = QtWidgets.QCheckBox(
             _("Esegui sempre in dry-run inizialmente")
         )
@@ -964,6 +978,12 @@ class SettingsDialog(_QDialogBase):
         else:
             log_file = self._original_config.log_file
 
+        theme_data = self.theme_combo.currentData()
+        if isinstance(theme_data, Theme):
+            theme_choice = theme_data
+        else:
+            theme_choice = self._original_config.theme
+
         log_max_bytes = self._parse_non_negative_int(
             self.log_max_edit.text(), self._original_config.log_max_bytes
         )
@@ -980,6 +1000,7 @@ class SettingsDialog(_QDialogBase):
             exclude_dirs=excludes,
             backup_base=backup_base,
             log_level=log_level,
+            theme=theme_choice,
             dry_run_default=self.dry_run_check.isChecked(),
             write_reports=self.reports_check.isChecked(),
             log_file=log_file,
@@ -1668,6 +1689,7 @@ class MainWindow(_QMainWindowBase):
         if dialog.result_config is None:
             return
         self.app_config = dialog.result_config
+        apply_modern_theme(self.app_config.theme, QtWidgets.QApplication.instance())
         configure_logging(
             level=self.app_config.log_level,
             log_file=self.app_config.log_file,
@@ -2300,7 +2322,7 @@ def main() -> None:
     )
     _apply_platform_workarounds()
     app = QtWidgets.QApplication(sys.argv)
-    apply_modern_theme(app)
+    apply_modern_theme(app_config.theme, app)
     app.setApplicationName(APP_NAME)
     translators = install_translators(app)
     setattr(app, "_installed_translators", translators)

--- a/patch_gui/theme.py
+++ b/patch_gui/theme.py
@@ -4,67 +4,227 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import Mapping, MutableMapping, TYPE_CHECKING
 
-from PySide6 import QtCore, QtGui, QtWidgets
-
+from .config import Theme
 from .platform import running_on_windows_native, running_under_wsl
 
+if TYPE_CHECKING:  # pragma: no cover - hints for type checkers only
+    from PySide6 import QtCore, QtGui, QtWidgets
+else:  # pragma: no cover - optional dependency
+    try:
+        from PySide6 import QtCore, QtGui, QtWidgets
+    except Exception:  # pragma: no cover - bindings missing at runtime
+        QtCore = QtGui = QtWidgets = None  # type: ignore[assignment]
 
-_ACCENT_COLOR = QtGui.QColor("#3d7dca")
-_ACCENT_DARK = QtGui.QColor("#2f5a94")
-_BACKGROUND_DARK = QtGui.QColor("#1f1f28")
-_BACKGROUND_ELEVATED = QtGui.QColor("#27293a")
-_BACKGROUND_INPUT = QtGui.QColor("#252535")
-_BORDER_COLOR = QtGui.QColor("#3d3d52")
-_BORDER_FOCUS = QtGui.QColor("#4d8fe3")
-_TEXT_PRIMARY = QtGui.QColor("#f2f2f5")
-_TEXT_SECONDARY = QtGui.QColor("#c7cad4")
-_TEXT_DISABLED = QtGui.QColor("#7a7d8a")
-_SELECTION_BG = _ACCENT_COLOR
-_SELECTION_FG = QtGui.QColor("#ffffff")
 
 _ICON_DIR = Path(__file__).with_name("icons")
 _SPIN_UP_ICON = (_ICON_DIR / "spin_up.svg").resolve().as_posix()
 _SPIN_DOWN_ICON = (_ICON_DIR / "spin_down.svg").resolve().as_posix()
+_RESOURCE_DIR = Path(__file__).resolve().parent / "resources"
 
 
-def _build_palette() -> QtGui.QPalette:
+_BASE_TOKENS: Mapping[str, str] = {
+    "accent": "#3d7dca",
+    "accent_hover": "#4d8fe3",
+    "accent_pressed": "#2f5a94",
+    "background_window": "#1f1f28",
+    "background_surface": "#27293a",
+    "background_input": "#252535",
+    "background_input_focus": "#2f3043",
+    "background_disabled": "#2c2c3b",
+    "border": "#3d3d52",
+    "border_focus": "#4d8fe3",
+    "border_disabled": "#2a2a3a",
+    "text_primary": "#f2f2f5",
+    "text_secondary": "#c7cad4",
+    "text_disabled": "#7a7d8a",
+    "selection_bg": "#3d7dca",
+    "selection_fg": "#ffffff",
+    "tooltip_bg": "#27293a",
+    "tooltip_fg": "#f2f2f5",
+    "tooltip_border": "#3d3d52",
+    "button_disabled_bg": "#2c2c3b",
+    "button_disabled_border": "#2a2a3a",
+    "tree_alternate_bg": "#2c2c3b",
+    "header_bg": "#2c2c3b",
+    "header_text": "#c7cad4",
+    "splitter_handle_bg": "#2c2c3b",
+    "progress_chunk": "#3d7dca",
+    "status_bg": "#27293a",
+    "scrollbar_bg": "#27293a",
+    "scrollbar_handle": "#3d7dca",
+    "scrollbar_handle_hover": "#2f5a94",
+}
+
+
+_THEME_TOKEN_OVERRIDES: Mapping[Theme, MutableMapping[str, str]] = {
+    Theme.DARK: {},
+    Theme.LIGHT: {
+        "background_window": "#f5f7fa",
+        "background_surface": "#ffffff",
+        "background_input": "#f0f2f7",
+        "background_input_focus": "#e6ebf5",
+        "background_disabled": "#e0e7f1",
+        "border": "#c5d0e0",
+        "border_focus": "#3d7dca",
+        "border_disabled": "#d1d9e6",
+        "text_primary": "#1f2937",
+        "text_secondary": "#4b5563",
+        "text_disabled": "#9ca3af",
+        "selection_bg": "#3d7dca",
+        "selection_fg": "#ffffff",
+        "tooltip_bg": "#ffffff",
+        "tooltip_fg": "#1f2937",
+        "tooltip_border": "#c5d0e0",
+        "button_disabled_bg": "#e0e7f1",
+        "button_disabled_border": "#d1d9e6",
+        "tree_alternate_bg": "#eef2fb",
+        "header_bg": "#eef2fb",
+        "header_text": "#4b5563",
+        "splitter_handle_bg": "#d1d9e6",
+        "progress_chunk": "#3d7dca",
+        "status_bg": "#eef2fb",
+        "scrollbar_bg": "#e5e9f2",
+        "scrollbar_handle": "#c5d0e0",
+        "scrollbar_handle_hover": "#a7b4c8",
+    },
+    Theme.HIGH_CONTRAST: {
+        "accent": "#ffd500",
+        "accent_hover": "#ffea66",
+        "accent_pressed": "#caa700",
+        "background_window": "#000000",
+        "background_surface": "#000000",
+        "background_input": "#111111",
+        "background_input_focus": "#222222",
+        "background_disabled": "#1a1a1a",
+        "border": "#ffffff",
+        "border_focus": "#ffd500",
+        "border_disabled": "#666666",
+        "text_primary": "#ffffff",
+        "text_secondary": "#f0f0f0",
+        "text_disabled": "#aaaaaa",
+        "selection_bg": "#ffd500",
+        "selection_fg": "#000000",
+        "tooltip_bg": "#000000",
+        "tooltip_fg": "#ffffff",
+        "tooltip_border": "#ffffff",
+        "button_disabled_bg": "#1a1a1a",
+        "button_disabled_border": "#333333",
+        "tree_alternate_bg": "#111111",
+        "header_bg": "#111111",
+        "header_text": "#ffffff",
+        "splitter_handle_bg": "#333333",
+        "progress_chunk": "#ffd500",
+        "status_bg": "#111111",
+        "scrollbar_bg": "#111111",
+        "scrollbar_handle": "#666666",
+        "scrollbar_handle_hover": "#999999",
+    },
+}
+
+
+def _resource_url(name: str) -> str:
+    path = (_RESOURCE_DIR / name).resolve()
+    return path.as_posix()
+
+
+def _resolve_tokens(theme: Theme) -> dict[str, str]:
+    base = dict(_BASE_TOKENS)
+    overrides = _THEME_TOKEN_OVERRIDES.get(theme)
+    if overrides:
+        base.update(overrides)
+    return base
+
+
+def resolve_theme_choice(
+    theme: Theme, app: "QtWidgets.QApplication | None" = None
+) -> Theme:
+    """Resolve ``Theme.AUTO`` into a concrete theme."""
+
+    if theme is not Theme.AUTO:
+        return theme
+    if QtGui is None or QtWidgets is None or app is None:
+        return Theme.DARK
+    palette = app.palette()
+    window = palette.color(QtGui.QPalette.ColorRole.Window)
+    return Theme.LIGHT if window.lightness() > 128 else Theme.DARK
+
+
+def build_palette(theme: Theme) -> "QtGui.QPalette | None":
+    """Build a :class:`~PySide6.QtGui.QPalette` for ``theme``."""
+
+    if QtGui is None:
+        return None
+    resolved = theme if theme is not Theme.AUTO else Theme.DARK
+    tokens = _resolve_tokens(resolved)
     palette = QtGui.QPalette()
 
-    palette.setColor(QtGui.QPalette.ColorRole.Window, _BACKGROUND_DARK)
-    palette.setColor(QtGui.QPalette.ColorRole.WindowText, _TEXT_PRIMARY)
-    palette.setColor(QtGui.QPalette.ColorRole.Base, _BACKGROUND_INPUT)
-    palette.setColor(QtGui.QPalette.ColorRole.AlternateBase, _BACKGROUND_ELEVATED)
-    palette.setColor(QtGui.QPalette.ColorRole.ToolTipBase, _BACKGROUND_ELEVATED)
-    palette.setColor(QtGui.QPalette.ColorRole.ToolTipText, _TEXT_PRIMARY)
-    palette.setColor(QtGui.QPalette.ColorRole.Text, _TEXT_PRIMARY)
-    palette.setColor(QtGui.QPalette.ColorRole.Button, _BACKGROUND_ELEVATED)
-    palette.setColor(QtGui.QPalette.ColorRole.ButtonText, _TEXT_PRIMARY)
-    palette.setColor(QtGui.QPalette.ColorRole.BrightText, QtCore.Qt.GlobalColor.red)
-    palette.setColor(QtGui.QPalette.ColorRole.Link, _ACCENT_COLOR)
-    palette.setColor(QtGui.QPalette.ColorRole.Highlight, _SELECTION_BG)
-    palette.setColor(QtGui.QPalette.ColorRole.HighlightedText, _SELECTION_FG)
+    palette.setColor(
+        QtGui.QPalette.ColorRole.Window, QtGui.QColor(tokens["background_window"])
+    )
+    palette.setColor(
+        QtGui.QPalette.ColorRole.WindowText, QtGui.QColor(tokens["text_primary"])
+    )
+    palette.setColor(
+        QtGui.QPalette.ColorRole.Base, QtGui.QColor(tokens["background_input"])
+    )
+    palette.setColor(
+        QtGui.QPalette.ColorRole.AlternateBase,
+        QtGui.QColor(tokens["tree_alternate_bg"]),
+    )
+    palette.setColor(
+        QtGui.QPalette.ColorRole.ToolTipBase, QtGui.QColor(tokens["tooltip_bg"])
+    )
+    palette.setColor(
+        QtGui.QPalette.ColorRole.ToolTipText, QtGui.QColor(tokens["tooltip_fg"])
+    )
+    palette.setColor(QtGui.QPalette.ColorRole.Text, QtGui.QColor(tokens["text_primary"]))
+    palette.setColor(
+        QtGui.QPalette.ColorRole.Button, QtGui.QColor(tokens["background_surface"])
+    )
+    palette.setColor(
+        QtGui.QPalette.ColorRole.ButtonText, QtGui.QColor(tokens["text_primary"])
+    )
+    palette.setColor(QtGui.QPalette.ColorRole.BrightText, QtGui.QColor("#ff0000"))
+    palette.setColor(QtGui.QPalette.ColorRole.Link, QtGui.QColor(tokens["accent"]))
+    palette.setColor(
+        QtGui.QPalette.ColorRole.Highlight, QtGui.QColor(tokens["selection_bg"])
+    )
+    palette.setColor(
+        QtGui.QPalette.ColorRole.HighlightedText,
+        QtGui.QColor(tokens["selection_fg"]),
+    )
 
+    disabled_group = QtGui.QPalette.ColorGroup.Disabled
     palette.setColor(
-        QtGui.QPalette.ColorGroup.Disabled,
-        QtGui.QPalette.ColorRole.Text,
-        _TEXT_DISABLED,
+        disabled_group, QtGui.QPalette.ColorRole.Text, QtGui.QColor(tokens["text_disabled"])
     )
     palette.setColor(
-        QtGui.QPalette.ColorGroup.Disabled,
+        disabled_group,
         QtGui.QPalette.ColorRole.ButtonText,
-        _TEXT_DISABLED,
+        QtGui.QColor(tokens["text_disabled"]),
     )
     palette.setColor(
-        QtGui.QPalette.ColorGroup.Disabled,
+        disabled_group,
         QtGui.QPalette.ColorRole.WindowText,
-        _TEXT_DISABLED,
+        QtGui.QColor(tokens["text_disabled"]),
+    )
+    palette.setColor(
+        disabled_group, QtGui.QPalette.ColorRole.Base, QtGui.QColor(tokens["background_disabled"])
+    )
+    palette.setColor(
+        disabled_group,
+        QtGui.QPalette.ColorRole.Button,
+        QtGui.QColor(tokens["button_disabled_bg"]),
     )
 
     return palette
 
 
-def _resolve_default_font(app: QtWidgets.QApplication) -> QtGui.QFont:
+def _resolve_default_font(app: "QtWidgets.QApplication") -> "QtGui.QFont | None":
+    if QtGui is None:
+        return None
     if running_on_windows_native():
         font = QtGui.QFont("Segoe UI")
         if font.pointSize() <= 0:
@@ -77,7 +237,6 @@ def _resolve_default_font(app: QtWidgets.QApplication) -> QtGui.QFont:
             font = QtGui.QFont(general_font)
         else:
             font = QtGui.QFont(app.font())
-
         if font.pointSize() <= 0:
             font.setPointSize(10)
     font.setHintingPreference(QtGui.QFont.HintingPreference.PreferFullHinting)
@@ -87,15 +246,11 @@ def _resolve_default_font(app: QtWidgets.QApplication) -> QtGui.QFont:
     return font
 
 
-_RESOURCE_DIR = Path(__file__).resolve().parent / "resources"
+def build_stylesheet(theme: Theme) -> str:
+    """Return the Qt stylesheet string for ``theme``."""
 
-
-def _resource_url(name: str) -> str:
-    path = (_RESOURCE_DIR / name).resolve()
-    return path.as_posix()
-
-
-def _build_stylesheet() -> str:
+    resolved = theme if theme is not Theme.AUTO else Theme.DARK
+    tokens = _resolve_tokens(resolved)
     branch_closed_icon = _resource_url("tree_branch_closed.svg")
     branch_open_icon = _resource_url("tree_branch_open.svg")
 
@@ -106,12 +261,13 @@ def _build_stylesheet() -> str:
         "    border: 1px solid %s;"
         "    border-radius: 6px;"
         "    padding: 6px;"
-        "}" % (_TEXT_PRIMARY.name(), _BACKGROUND_ELEVATED.name(), _BORDER_COLOR.name())
+        "}"
+        % (tokens["tooltip_fg"], tokens["tooltip_bg"], tokens["tooltip_border"])
         + "\n"
         "QMainWindow {"
         "    background-color: %s;"
         "    color: %s;"
-        "}" % (_BACKGROUND_DARK.name(), _TEXT_PRIMARY.name()) + "\n"
+        "}" % (tokens["background_window"], tokens["text_primary"]) + "\n"
         "QWidget {"
         "    color: %s;"
         "    background-color: %s;"
@@ -119,13 +275,14 @@ def _build_stylesheet() -> str:
         "    selection-color: %s;"
         "}"
         % (
-            _TEXT_PRIMARY.name(),
-            _BACKGROUND_DARK.name(),
-            _SELECTION_BG.name(),
-            _SELECTION_FG.name(),
+            tokens["text_primary"],
+            tokens["background_window"],
+            tokens["selection_bg"],
+            tokens["selection_fg"],
         )
         + "\n"
-        "QLabel { color: %s; }" % _TEXT_PRIMARY.name() + "\n"
+        "QLabel { color: %s; }" % tokens["text_primary"]
+        + "\n"
         "QPushButton {"
         "    background-color: %s;"
         "    border: 1px solid %s;"
@@ -134,28 +291,30 @@ def _build_stylesheet() -> str:
         "    color: %s;"
         "}"
         % (
-            _BACKGROUND_ELEVATED.name(),
-            _BORDER_COLOR.name(),
-            _TEXT_PRIMARY.name(),
+            tokens["background_surface"],
+            tokens["border"],
+            tokens["text_primary"],
         )
         + "\n"
         "QPushButton:hover {"
         "    background-color: %s;"
         "    border-color: %s;"
-        "}" % (_ACCENT_COLOR.lighter(125).name(), _ACCENT_COLOR.name()) + "\n"
+        "}" % (tokens["accent_hover"], tokens["accent"])
+        + "\n"
         "QPushButton:pressed {"
         "    background-color: %s;"
         "    border-color: %s;"
-        "}" % (_ACCENT_DARK.name(), _ACCENT_DARK.darker(115).name()) + "\n"
+        "}" % (tokens["accent_pressed"], tokens["accent_pressed"])
+        + "\n"
         "QPushButton:disabled {"
         "    color: %s;"
         "    background-color: %s;"
         "    border-color: %s;"
         "}"
         % (
-            _TEXT_DISABLED.name(),
-            _BACKGROUND_ELEVATED.darker(110).name(),
-            _BACKGROUND_ELEVATED.darker(125).name(),
+            tokens["text_disabled"],
+            tokens["button_disabled_bg"],
+            tokens["button_disabled_border"],
         )
         + "\n"
         "QLineEdit, QPlainTextEdit, QTextEdit, QComboBox, QSpinBox, QDoubleSpinBox {"
@@ -166,19 +325,22 @@ def _build_stylesheet() -> str:
         "    color: %s;"
         "}"
         % (
-            _BACKGROUND_INPUT.name(),
-            _BORDER_COLOR.name(),
-            _TEXT_PRIMARY.name(),
+            tokens["background_input"],
+            tokens["border"],
+            tokens["text_primary"],
         )
         + "\n"
         "QSpinBox, QDoubleSpinBox {"
         "    padding-right: 32px;"
-        "}" + "\n"
+        "}"
+        + "\n"
         "QLineEdit:focus, QPlainTextEdit:focus, QTextEdit:focus, QComboBox:focus,"
         " QSpinBox:focus, QDoubleSpinBox:focus {"
         "    border: 1px solid %s;"
         "    background-color: %s;"
-        "}" % (_BORDER_FOCUS.name(), _BACKGROUND_ELEVATED.name()) + "\n"
+        "}"
+        % (tokens["border_focus"], tokens["background_input_focus"])
+        + "\n"
         "QSpinBox::up-button, QDoubleSpinBox::up-button {"
         "    subcontrol-origin: border;"
         "    subcontrol-position: top right;"
@@ -191,9 +353,9 @@ def _build_stylesheet() -> str:
         "    margin: 0;"
         "}"
         % (
-            _BORDER_COLOR.name(),
-            _BORDER_COLOR.name(),
-            _BACKGROUND_ELEVATED.name(),
+            tokens["border"],
+            tokens["border"],
+            tokens["background_surface"],
         )
         + "\n"
         "QSpinBox::down-button, QDoubleSpinBox::down-button {"
@@ -208,47 +370,53 @@ def _build_stylesheet() -> str:
         "    margin: 0;"
         "}"
         % (
-            _BORDER_COLOR.name(),
-            _BORDER_COLOR.name(),
-            _BACKGROUND_ELEVATED.name(),
+            tokens["border"],
+            tokens["border"],
+            tokens["background_surface"],
         )
         + "\n"
         "QSpinBox::up-button:hover, QDoubleSpinBox::up-button:hover,"
         " QSpinBox::down-button:hover, QDoubleSpinBox::down-button:hover {"
         "    background-color: %s;"
         "    border-color: %s;"
-        "}" % (_ACCENT_COLOR.lighter(130).name(), _ACCENT_COLOR.name()) + "\n"
+        "}" % (tokens["accent_hover"], tokens["accent"])
+        + "\n"
         "QSpinBox::up-button:pressed, QDoubleSpinBox::up-button:pressed,"
         " QSpinBox::down-button:pressed, QDoubleSpinBox::down-button:pressed {"
         "    background-color: %s;"
         "    border-color: %s;"
-        "}" % (_ACCENT_DARK.name(), _ACCENT_DARK.darker(115).name()) + "\n"
+        "}" % (tokens["accent_pressed"], tokens["accent_pressed"])
+        + "\n"
         "QSpinBox::up-button:disabled, QDoubleSpinBox::up-button:disabled,"
         " QSpinBox::down-button:disabled, QDoubleSpinBox::down-button:disabled {"
         "    background-color: %s;"
         "    border-color: %s;"
         "}"
         % (
-            _BACKGROUND_ELEVATED.darker(110).name(),
-            _BACKGROUND_ELEVATED.darker(125).name(),
+            tokens["button_disabled_bg"],
+            tokens["button_disabled_border"],
         )
         + "\n"
         "QSpinBox::up-arrow, QDoubleSpinBox::up-arrow {"
         '    image: url("%s");'
         "    width: 12px;"
         "    height: 12px;"
-        "}" % (_SPIN_UP_ICON,) + "\n"
+        "}" % (_SPIN_UP_ICON,)
+        + "\n"
         "QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {"
         '    image: url("%s");'
         "    width: 12px;"
         "    height: 12px;"
-        "}" % (_SPIN_DOWN_ICON,) + "\n"
+        "}" % (_SPIN_DOWN_ICON,)
+        + "\n"
         "QSpinBox::up-arrow:disabled, QDoubleSpinBox::up-arrow:disabled {"
         '    image: url("%s");'
-        "}" % (_SPIN_UP_ICON,) + "\n"
+        "}" % (_SPIN_UP_ICON,)
+        + "\n"
         "QSpinBox::down-arrow:disabled, QDoubleSpinBox::down-arrow:disabled {"
         '    image: url("%s");'
-        "}" % (_SPIN_DOWN_ICON,) + "\n"
+        "}" % (_SPIN_DOWN_ICON,)
+        + "\n"
         "QTreeWidget, QTreeView, QListWidget, QListView {"
         "    background-color: %s;"
         "    border: 1px solid %s;"
@@ -256,9 +424,9 @@ def _build_stylesheet() -> str:
         "    alternate-background-color: %s;"
         "}"
         % (
-            _BACKGROUND_ELEVATED.name(),
-            _BORDER_COLOR.name(),
-            _BACKGROUND_INPUT.name(),
+            tokens["background_surface"],
+            tokens["border"],
+            tokens["tree_alternate_bg"],
         )
         + "\n"
         "QTreeView::branch:has-children:!has-siblings:closed,"
@@ -267,14 +435,16 @@ def _build_stylesheet() -> str:
         '    image: url("%s");'
         "    padding: 6px;"
         "    margin: 0px;"
-        "}" % (branch_closed_icon,) + "\n"
+        "}" % (branch_closed_icon,)
+        + "\n"
         "QTreeView::branch:has-children:!has-siblings:open,"
         "QTreeView::branch:has-children:!has-siblings:open:hover,"
         "QTreeView::branch:has-children:!has-siblings:open:pressed {"
         '    image: url("%s");'
         "    padding: 6px;"
         "    margin: 0px;"
-        "}" % (branch_open_icon,) + "\n"
+        "}" % (branch_open_icon,)
+        + "\n"
         "QHeaderView::section {"
         "    background-color: %s;"
         "    color: %s;"
@@ -283,9 +453,9 @@ def _build_stylesheet() -> str:
         "    border-right: 1px solid %s;"
         "}"
         % (
-            _BACKGROUND_INPUT.name(),
-            _TEXT_SECONDARY.name(),
-            _BORDER_COLOR.name(),
+            tokens["header_bg"],
+            tokens["header_text"],
+            tokens["border"],
         )
         + "\n"
         "QSplitter::handle {"
@@ -293,14 +463,18 @@ def _build_stylesheet() -> str:
         "    border: 1px solid %s;"
         "    margin: 4px;"
         "    border-radius: 4px;"
-        "}" % (_BACKGROUND_INPUT.name(), _BORDER_COLOR.name()) + "\n"
+        "}"
+        % (tokens["splitter_handle_bg"], tokens["border"])
+        + "\n"
         "QSplitter::handle:hover {"
         "    background: %s;"
         "    border-color: %s;"
-        "}" % (_ACCENT_COLOR.name(), _ACCENT_COLOR.darker(120).name()) + "\n"
+        "}" % (tokens["accent"], tokens["accent"])
+        + "\n"
         "QSplitter::handle:pressed {"
         "    background: %s;"
-        "}" % (_ACCENT_DARK.name(),) + "\n"
+        "}" % (tokens["accent_pressed"],)
+        + "\n"
         "QProgressBar {"
         "    border: 1px solid %s;"
         "    border-radius: 8px;"
@@ -310,61 +484,65 @@ def _build_stylesheet() -> str:
         "    padding: 2px;"
         "}"
         % (
-            _BORDER_COLOR.name(),
-            _BACKGROUND_ELEVATED.name(),
-            _TEXT_PRIMARY.name(),
+            tokens["border"],
+            tokens["background_surface"],
+            tokens["text_primary"],
         )
         + "\n"
         "QProgressBar::chunk {"
         "    background-color: %s;"
         "    border-radius: 6px;"
-        "}" % (_ACCENT_COLOR.name(),) + "\n"
+        "}" % (tokens["progress_chunk"],)
+        + "\n"
         "QScrollBar:vertical {"
         "    background: %s;"
         "    width: 14px;"
         "    margin: 4px 2px 4px 2px;"
         "    border-radius: 6px;"
-        "}" % (_BACKGROUND_ELEVATED.name(),) + "\n"
+        "}" % (tokens["scrollbar_bg"],)
+        + "\n"
         "QScrollBar::handle:vertical {"
         "    background: %s;"
         "    min-height: 24px;"
         "    border-radius: 6px;"
-        "}" % (_ACCENT_COLOR.name(),) + "\n"
+        "}" % (tokens["scrollbar_handle"],)
+        + "\n"
         "QScrollBar::handle:vertical:hover {"
         "    background: %s;"
-        "}" % (_ACCENT_DARK.name(),) + "\n"
+        "}" % (tokens["scrollbar_handle_hover"],)
+        + "\n"
         "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {"
         "    background: none;"
-        "}" + "\n"
+        "}"
+        + "\n"
         "QStatusBar {"
         "    background: %s;"
         "    color: %s;"
-        "}" % (_BACKGROUND_ELEVATED.name(), _TEXT_PRIMARY.name()) + "\n"
+        "}" % (tokens["status_bg"], tokens["text_primary"])
+        + "\n"
         "QGroupBox {"
         "    border: 1px solid %s;"
         "    border-radius: 8px;"
         "    margin-top: 16px;"
         "    padding: 10px;"
-        "}" % (_BORDER_COLOR.name(),) + "\n"
+        "}"
+        % (tokens["border"],)
+        + "\n"
         "QGroupBox::title {"
         "    subcontrol-origin: margin;"
         "    subcontrol-position: top left;"
         "    padding: 0 6px;"
         "    color: %s;"
-        "}" % (_TEXT_SECONDARY.name(),)
+        "}" % (tokens["text_secondary"],)
     )
 
 
-def apply_modern_theme(app: QtWidgets.QApplication) -> None:
-    """Apply a modern dark theme to ``app`` while remaining WSL-friendly."""
+def apply_modern_theme(theme: Theme, app: "QtWidgets.QApplication | None") -> None:
+    """Apply the selected theme to ``app`` while remaining WSL-friendly."""
 
-    if app is None:
+    if app is None or QtWidgets is None:
         return
 
-    # ``Fusion`` provides a predictable baseline but we allow power users to
-    # override it via the standard ``QT_STYLE_OVERRIDE`` variable. Keeping the
-    # existing style is especially important for WSL sessions where users may
-    # prefer the Windows host look & feel.
     style_override = os.getenv("QT_STYLE_OVERRIDE")
     if style_override:
         app.setStyle(style_override)
@@ -376,6 +554,22 @@ def apply_modern_theme(app: QtWidgets.QApplication) -> None:
         if fusion:
             app.setStyle(fusion)
 
-    app.setPalette(_build_palette())
-    app.setFont(_resolve_default_font(app))
-    app.setStyleSheet(_build_stylesheet())
+    resolved = resolve_theme_choice(theme, app)
+
+    palette = build_palette(resolved)
+    if palette is not None:
+        app.setPalette(palette)
+
+    font = _resolve_default_font(app)
+    if font is not None:
+        app.setFont(font)
+
+    app.setStyleSheet(build_stylesheet(resolved))
+
+
+__all__ = [
+    "apply_modern_theme",
+    "build_palette",
+    "build_stylesheet",
+    "resolve_theme_choice",
+]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 import patch_gui.config as config_module
-from patch_gui.config import AppConfig, load_config, save_config
+from patch_gui.config import AppConfig, Theme, load_config, save_config
 
 
 def test_load_config_returns_defaults_when_missing(tmp_path: Path) -> None:
@@ -24,6 +24,7 @@ def test_load_config_returns_defaults_when_missing(tmp_path: Path) -> None:
     assert loaded.backup_retention_days == defaults.backup_retention_days
     assert loaded.ai_assistant_enabled == defaults.ai_assistant_enabled
     assert loaded.ai_auto_apply == defaults.ai_auto_apply
+    assert loaded.theme == defaults.theme
 
 
 def test_save_and_load_roundtrip(tmp_path: Path) -> None:
@@ -35,6 +36,7 @@ def test_save_and_load_roundtrip(tmp_path: Path) -> None:
         exclude_dirs=("one", "two"),
         backup_base=custom_backup,
         log_level="debug",
+        theme=Theme.LIGHT,
         dry_run_default=False,
         write_reports=False,
         log_file=tmp_path / "custom.log",
@@ -83,6 +85,7 @@ def test_load_config_invalid_values_fallback(tmp_path: Path) -> None:
                 'exclude_dirs = ""',
                 'backup_base = "   "',
                 "log_level = 123",
+                'theme = "super"',
                 'dry_run_default = "maybe"',
                 'write_reports = "sometimes"',
                 'log_file = "   "',
@@ -112,6 +115,7 @@ def test_load_config_invalid_values_fallback(tmp_path: Path) -> None:
     assert loaded.backup_retention_days == defaults.backup_retention_days
     assert loaded.ai_assistant_enabled == defaults.ai_assistant_enabled
     assert loaded.ai_auto_apply == defaults.ai_auto_apply
+    assert loaded.theme == defaults.theme
 
 
 def test_load_config_accepts_empty_exclude_list(tmp_path: Path) -> None:
@@ -152,3 +156,4 @@ def test_load_config_accepts_empty_exclude_list(tmp_path: Path) -> None:
     assert loaded.backup_retention_days == 30
     assert loaded.ai_assistant_enabled is True
     assert loaded.ai_auto_apply is True
+    assert loaded.theme == AppConfig().theme

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from patch_gui import theme as theme_module
+from patch_gui.config import Theme
+
+try:  # pragma: no cover - optional dependency
+    from PySide6 import QtGui as _QtGui
+    from PySide6 import QtWidgets as _QtWidgets
+except Exception as exc:  # pragma: no cover - bindings missing at runtime
+    QtGui: Any | None = None
+    QtWidgets: Any | None = None
+    _QT_IMPORT_ERROR: Exception | None = exc
+else:  # pragma: no cover - executed when bindings are available
+    QtGui = _QtGui
+    QtWidgets = _QtWidgets
+    _QT_IMPORT_ERROR = None
+
+
+@pytest.fixture()
+def themed_app() -> Any:
+    if QtWidgets is None:
+        pytest.skip(f"PySide6 non disponibile: {_QT_IMPORT_ERROR}")
+    assert QtGui is not None
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    original_palette = QtGui.QPalette(app.palette())
+    original_stylesheet = app.styleSheet()
+    original_style_name = app.style().objectName()
+    yield app
+    app.setPalette(original_palette)
+    app.setStyleSheet(original_stylesheet)
+    if original_style_name:
+        app.setStyle(original_style_name)
+
+
+@pytest.mark.skipif(QtWidgets is None, reason="PySide6 non disponibile")
+def test_build_palette_high_contrast_uses_tokens() -> None:
+    assert QtGui is not None
+    palette = theme_module.build_palette(Theme.HIGH_CONTRAST)
+    assert palette is not None
+    window_color = palette.color(QtGui.QPalette.ColorRole.Window).name().lower()
+    highlight_color = palette.color(
+        QtGui.QPalette.ColorRole.Highlight
+    ).name().lower()
+    assert window_color == "#000000"
+    assert highlight_color == "#ffd500"
+
+
+@pytest.mark.skipif(QtWidgets is None, reason="PySide6 non disponibile")
+def test_apply_modern_theme_updates_palette_and_stylesheet(themed_app: Any) -> None:
+    assert QtGui is not None
+    theme_module.apply_modern_theme(Theme.LIGHT, themed_app)
+    palette = themed_app.palette()
+    window_color = palette.color(QtGui.QPalette.ColorRole.Window).name().lower()
+    assert window_color == "#f5f7fa"
+    stylesheet = themed_app.styleSheet()
+    assert "#f5f7fa" in stylesheet
+
+
+def test_apply_modern_theme_gracefully_handles_missing_qt(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(theme_module, "QtWidgets", None)
+    monkeypatch.setattr(theme_module, "QtGui", None)
+    theme_module.apply_modern_theme(Theme.DARK, None)
+    assert theme_module.build_palette(Theme.DARK) is None
+    assert theme_module.resolve_theme_choice(Theme.AUTO, None) is Theme.DARK


### PR DESCRIPTION
## Summary
- add a Theme enum to AppConfig with serialization helpers and TOML persistence
- refactor theme helpers to build palettes and stylesheets from shared tokens per theme
- expose theme selection in the settings dialog and refresh the running app when changed
- add configuration and UI regression tests covering new theme behaviour and Qt fallbacks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd2cbe1268832691a532b6224e86f1