### PR TITLE
Add asynchronous AI summary worker with caching

### DIFF
--- a/patch_gui/executor.py
+++ b/patch_gui/executor.py
@@ -16,7 +16,7 @@ from unidiff import PatchSet
 from unidiff.errors import UnidiffParseError
 
 from .ai_candidate_selector import AISuggestion, rank_candidates
-from .ai_summaries import generate_session_summary
+from .ai_summaries import compute_summary_cache_key, generate_session_summary
 from .config import AppConfig, load_config
 from .filetypes import inspect_file_type
 from .localization import gettext as _
@@ -239,6 +239,11 @@ def apply_patchset(
         exclude_dirs=resolved_excludes,
         started_at=started_at,
     )
+
+    try:
+        session.summary_cache_key = compute_summary_cache_key(str(patch))
+    except Exception:  # pragma: no cover - defensive guard for exotic PatchSet repr
+        session.summary_cache_key = None
 
     effective_interactive = interactive or auto_accept
 

--- a/patch_gui/patcher.py
+++ b/patch_gui/patcher.py
@@ -122,6 +122,11 @@ class ApplySession:
     report_txt_path: Optional[Path] = None
     ai_summary: Optional[str] = None
     file_summaries: dict[str, str] = field(default_factory=dict)
+    summary_cache_key: Optional[str] = None
+    summary_cache_hit: bool = False
+    summary_generated_at: Optional[float] = None
+    summary_cached_at: Optional[float] = None
+    summary_error: Optional[str] = None
 
     def to_json(self) -> dict[str, object]:
         return {
@@ -133,6 +138,11 @@ class ApplySession:
             "started_at": datetime.fromtimestamp(self.started_at).isoformat(),
             "ai_summary": self.ai_summary,
             "file_summaries": self.file_summaries,
+            "summary_cache_key": self.summary_cache_key,
+            "summary_cache_hit": self.summary_cache_hit,
+            "summary_generated_at": self.summary_generated_at,
+            "summary_cached_at": self.summary_cached_at,
+            "summary_error": self.summary_error,
             "files": [
                 {
                     "file": fr.relative_to_root,

--- a/tests/test_ai_summaries.py
+++ b/tests/test_ai_summaries.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from patch_gui import ai_summaries
+from patch_gui.ai_summaries import AISummaryHooks, compute_summary_cache_key
+from patch_gui.patcher import ApplySession
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache() -> None:
+    ai_summaries.clear_summary_cache()
+
+
+def _make_session(tmp_path: Path) -> ApplySession:
+    project_root = tmp_path / "project"
+    project_root.mkdir(exist_ok=True)
+    backup_dir = tmp_path / "backup"
+    backup_dir.mkdir(exist_ok=True)
+    return ApplySession(
+        project_root=project_root,
+        backup_dir=backup_dir,
+        dry_run=True,
+        threshold=0.7,
+        started_at=1234.5,
+    )
+
+
+def test_generate_session_summary_uses_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    session = _make_session(tmp_path)
+    session.summary_cache_key = compute_summary_cache_key("example diff")
+
+    events: list[Any] = []
+
+    def fake_call(
+        payload: dict[str, object],
+        *,
+        timeout: float | None = None,
+        hooks: AISummaryHooks | None = None,
+    ) -> dict[str, object]:
+        events.append(payload)
+        if hooks and hooks.on_request_start:
+            hooks.on_request_start()
+        if hooks and hooks.on_raw_chunk:
+            hooks.on_raw_chunk(b"chunk")
+        response = {"summary": "overall", "files": {"file.py": "detail"}}
+        if hooks and hooks.on_response:
+            hooks.on_response(response)
+        return response
+
+    monkeypatch.setattr(ai_summaries, "_call_summary_service", fake_call)
+
+    hooks = AISummaryHooks(
+        on_request_start=lambda: events.append("start"),
+        on_raw_chunk=lambda chunk: events.append(("chunk", bytes(chunk))),
+        on_response=lambda response: events.append(("response", dict(response))),
+    )
+
+    summary = ai_summaries.generate_session_summary(session, hooks=hooks)
+
+    assert summary is not None
+    assert session.summary_cache_hit is False
+    assert session.summary_generated_at is not None
+    assert events[1:] == ["start", ("chunk", b"chunk"), ("response", {"summary": "overall", "files": {"file.py": "detail"}})]
+
+    new_session = _make_session(tmp_path)
+    new_session.summary_cache_key = session.summary_cache_key
+
+    cached_summary = ai_summaries.generate_session_summary(new_session)
+
+    assert cached_summary is summary
+    assert new_session.summary_cache_hit is True
+    assert new_session.summary_cached_at is not None
+    # ``fake_call`` should only run once.
+    assert len(events) == 4
+
+
+def test_generate_session_summary_records_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    session = _make_session(tmp_path)
+    session.summary_cache_key = "abc"
+
+    def fake_call(
+        payload: dict[str, object],
+        *,
+        timeout: float | None = None,
+        hooks: AISummaryHooks | None = None,
+    ) -> dict[str, object]:
+        raise ai_summaries.AISummaryError("boom")
+
+    monkeypatch.setattr(ai_summaries, "_call_summary_service", fake_call)
+
+    result = ai_summaries.generate_session_summary(session, use_cache=False)
+
+    assert result is None
+    assert session.summary_error == "boom"


### PR DESCRIPTION
## Summary
- add caching, metadata and streaming hooks to the AI summary helpers
- introduce an AISummaryWorker that runs summaries asynchronously and updates the GUI once complete
- cache summaries per diff, surface status messages in the UI, and cover the behaviour with new tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cd2cd696cc8326a6f2be42fc68e869