### PR TITLE
Add theme manager with palette switching and theme-aware widgets

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -61,6 +61,18 @@ Questa guida passo‑passo descrive il workflow tipico per applicare una patch c
 
 Per una panoramica delle opzioni tecniche e delle dipendenze consulta il [README](README.md).
 
+## Checklist QA manuale: cambio tema
+
+Esegui questa breve verifica ogni volta che vengono modificati i temi o il relativo codice:
+
+1. Avvia l'applicazione e apri **Preferenze…** dal menu *Impostazioni*.
+2. Cambia il valore del menu *Tema* da *Tema scuro* a *Tema chiaro* e conferma con **OK**.
+3. Verifica che:
+   - i colori di sfondo, pulsanti e testi si aggiornino immediatamente;
+   - l'evidenziazione del diff (sia nell'editor principale sia nel riquadro dell'anteprima interattiva) utilizzi nuove tinte coerenti;
+   - le icone generate (es. **Carica diff**, **Analizza diff**) vengano rigenerate con la nuova palette.
+4. Riapri le **Preferenze…**, ripristina *Tema scuro* e controlla che tutti gli elementi tornino alle tinte originali.
+
 ## Suggerimento CLI: includere directory normalmente escluse
 
 Quando usi la modalità `patch-gui apply`, per impostazione predefinita vengono ignorate directory come `.git`, `.venv`, `node_modules` e `.diff_backups`. Se devi patchare file posizionati lì dentro:

--- a/patch_gui/config.py
+++ b/patch_gui/config.py
@@ -47,6 +47,7 @@ _DEFAULT_BACKUP_RETENTION_DAYS = 0
 _DEFAULT_AI_ASSISTANT = False
 _DEFAULT_AI_AUTO_APPLY = False
 _DEFAULT_AI_DIFF_NOTES = False
+_DEFAULT_THEME = "dark"
 
 
 def _default_log_file() -> Path:
@@ -92,6 +93,7 @@ class AppConfig:
     ai_assistant_enabled: bool = _DEFAULT_AI_ASSISTANT
     ai_auto_apply: bool = _DEFAULT_AI_AUTO_APPLY
     ai_diff_notes_enabled: bool = _DEFAULT_AI_DIFF_NOTES
+    theme: str = _DEFAULT_THEME
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any]) -> "AppConfig":
@@ -124,6 +126,7 @@ class AppConfig:
         ai_diff_notes = _coerce_bool(
             data.get("ai_diff_notes_enabled"), base.ai_diff_notes_enabled
         )
+        theme = _coerce_theme(data.get("theme"), base.theme)
 
         return cls(
             threshold=threshold,
@@ -139,6 +142,7 @@ class AppConfig:
             ai_assistant_enabled=ai_enabled,
             ai_auto_apply=ai_auto_apply,
             ai_diff_notes_enabled=ai_diff_notes,
+            theme=theme,
         )
 
     def to_mapping(self) -> MutableMapping[str, Any]:
@@ -158,6 +162,7 @@ class AppConfig:
             "ai_assistant_enabled": bool(self.ai_assistant_enabled),
             "ai_auto_apply": bool(self.ai_auto_apply),
             "ai_diff_notes_enabled": bool(self.ai_diff_notes_enabled),
+            "theme": str(self.theme),
         }
 
 
@@ -227,6 +232,7 @@ def save_config(config: AppConfig, path: Path | None = None) -> Path:
     ai_assistant_repr = json.dumps(mapping["ai_assistant_enabled"])
     ai_auto_apply_repr = json.dumps(mapping["ai_auto_apply"])
     ai_diff_notes_repr = json.dumps(mapping["ai_diff_notes_enabled"])
+    theme_repr = json.dumps(mapping["theme"])
 
     content_lines = [
         f"[{_CONFIG_SECTION}]",
@@ -243,6 +249,7 @@ def save_config(config: AppConfig, path: Path | None = None) -> Path:
         f"ai_assistant_enabled = {ai_assistant_repr}",
         f"ai_auto_apply = {ai_auto_apply_repr}",
         f"ai_diff_notes_enabled = {ai_diff_notes_repr}",
+        f"theme = {theme_repr}",
         "",
     ]
 
@@ -382,6 +389,13 @@ def _coerce_bool(value: Any, default: bool) -> bool:
             return True
         if normalized in {"false", "0", "no", "off"}:
             return False
+    return default
+
+
+def _coerce_theme(value: Any, default: str) -> str:
+    if isinstance(value, str):
+        candidate = value.strip().lower()
+        return candidate or default
     return default
 
 

--- a/patch_gui/highlighter.py
+++ b/patch_gui/highlighter.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 
 from PySide6 import QtGui
 
+from .theme import PaletteColors, theme_manager
+
 if TYPE_CHECKING:
     # ``PySide6`` exposes ``QSyntaxHighlighter`` as ``Any`` to type checkers.
     # Providing a lightweight stub in the ``TYPE_CHECKING`` branch gives mypy a
@@ -30,24 +32,34 @@ class DiffHighlighter(_QSyntaxHighlighter):
     def __init__(self, document: QtGui.QTextDocument) -> None:
         super().__init__(document)
         self._addition_format = QtGui.QTextCharFormat()
-        self._addition_format.setBackground(QtGui.QColor("#e6ffed"))
-        self._addition_format.setForeground(QtGui.QColor("#033a16"))
-
         self._removal_format = QtGui.QTextCharFormat()
-        self._removal_format.setBackground(QtGui.QColor("#ffeef0"))
-        self._removal_format.setForeground(QtGui.QColor("#86181d"))
-
         self._context_format = QtGui.QTextCharFormat()
-        self._context_format.setBackground(QtGui.QColor("#f6f8fa"))
-        self._context_format.setForeground(QtGui.QColor("#24292e"))
-
         self._header_format = QtGui.QTextCharFormat()
-        self._header_format.setBackground(QtGui.QColor("#dbe9ff"))
-        self._header_format.setForeground(QtGui.QColor("#032f62"))
         self._header_format.setFontWeight(QtGui.QFont.Weight.Bold)
 
         self._meta_format = QtGui.QTextCharFormat()
-        self._meta_format.setForeground(QtGui.QColor("#6a737d"))
+        self._theme_manager = theme_manager
+        self._apply_palette(self._theme_manager.colors)
+        self._theme_manager.paletteChanged.connect(self._on_theme_changed)
+
+    def _apply_palette(self, colors: PaletteColors) -> None:
+        self._addition_format.setBackground(colors.diff_add_bg)
+        self._addition_format.setForeground(colors.diff_add_fg)
+
+        self._removal_format.setBackground(colors.diff_remove_bg)
+        self._removal_format.setForeground(colors.diff_remove_fg)
+
+        self._context_format.setBackground(colors.diff_context_bg)
+        self._context_format.setForeground(colors.diff_context_fg)
+
+        self._header_format.setBackground(colors.diff_header_bg)
+        self._header_format.setForeground(colors.diff_header_fg)
+
+        self._meta_format.setForeground(colors.diff_meta_fg)
+
+    def _on_theme_changed(self, _: str) -> None:
+        self._apply_palette(self._theme_manager.colors)
+        self.rehighlight()
         self._meta_format.setFontItalic(True)
 
     def highlightBlock(self, text: str) -> None:  # noqa: N802 (Qt signature)

--- a/patch_gui/theme.py
+++ b/patch_gui/theme.py
@@ -2,66 +2,435 @@
 
 from __future__ import annotations
 
+import base64
 import os
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Mapping
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
 from .platform import running_on_windows_native, running_under_wsl
 
 
-_ACCENT_COLOR = QtGui.QColor("#3d7dca")
-_ACCENT_DARK = QtGui.QColor("#2f5a94")
-_BACKGROUND_DARK = QtGui.QColor("#1f1f28")
-_BACKGROUND_ELEVATED = QtGui.QColor("#27293a")
-_BACKGROUND_INPUT = QtGui.QColor("#252535")
-_BORDER_COLOR = QtGui.QColor("#3d3d52")
-_BORDER_FOCUS = QtGui.QColor("#4d8fe3")
-_TEXT_PRIMARY = QtGui.QColor("#f2f2f5")
-_TEXT_SECONDARY = QtGui.QColor("#c7cad4")
-_TEXT_DISABLED = QtGui.QColor("#7a7d8a")
-_SELECTION_BG = _ACCENT_COLOR
-_SELECTION_FG = QtGui.QColor("#ffffff")
+@dataclass(frozen=True)
+class PaletteColors:
+    """Container for the core colours exposed by a theme."""
 
-_ICON_DIR = Path(__file__).with_name("icons")
-_SPIN_UP_ICON = (_ICON_DIR / "spin_up.svg").resolve().as_posix()
-_SPIN_DOWN_ICON = (_ICON_DIR / "spin_down.svg").resolve().as_posix()
+    accent: QtGui.QColor
+    accent_dark: QtGui.QColor
+    background_window: QtGui.QColor
+    background_elevated: QtGui.QColor
+    background_input: QtGui.QColor
+    border: QtGui.QColor
+    border_focus: QtGui.QColor
+    text_primary: QtGui.QColor
+    text_secondary: QtGui.QColor
+    text_disabled: QtGui.QColor
+    selection_bg: QtGui.QColor
+    selection_fg: QtGui.QColor
+    tooltip_bg: QtGui.QColor
+    tooltip_text: QtGui.QColor
+    brand_base: QtGui.QColor
+    brand_surface: QtGui.QColor
+    brand_primary: QtGui.QColor
+    brand_accent: QtGui.QColor
+    brand_light: QtGui.QColor
+    diff_add_bg: QtGui.QColor
+    diff_add_fg: QtGui.QColor
+    diff_remove_bg: QtGui.QColor
+    diff_remove_fg: QtGui.QColor
+    diff_context_bg: QtGui.QColor
+    diff_context_fg: QtGui.QColor
+    diff_header_bg: QtGui.QColor
+    diff_header_fg: QtGui.QColor
+    diff_meta_fg: QtGui.QColor
 
 
-def _build_palette() -> QtGui.QPalette:
+@dataclass(frozen=True)
+class ThemeDefinition:
+    """Descriptor for an available theme option."""
+
+    key: str
+    label: str
+    colors: PaletteColors
+
+
+_RESOURCE_DIR = Path(__file__).resolve().parent / "resources"
+_DEFAULT_THEME_KEY = "dark"
+
+
+def _resource_url(name: str) -> str:
+    path = (_RESOURCE_DIR / name).resolve()
+    return path.as_posix()
+
+
+def _colour_name(color: QtGui.QColor) -> str:
+    return QtGui.QColor(color).name()
+
+
+def _encoded_arrow_svg(path_d: str, colour: QtGui.QColor) -> str:
+    svg = (
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        "<svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" "
+        "fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">"
+        f"  <path d=\"{path_d}\" fill=\"{_colour_name(colour)}\"/>"
+        "</svg>"
+    )
+    return base64.b64encode(svg.encode("utf-8")).decode("ascii")
+
+
+def _build_palette(colors: PaletteColors) -> QtGui.QPalette:
     palette = QtGui.QPalette()
 
-    palette.setColor(QtGui.QPalette.ColorRole.Window, _BACKGROUND_DARK)
-    palette.setColor(QtGui.QPalette.ColorRole.WindowText, _TEXT_PRIMARY)
-    palette.setColor(QtGui.QPalette.ColorRole.Base, _BACKGROUND_INPUT)
-    palette.setColor(QtGui.QPalette.ColorRole.AlternateBase, _BACKGROUND_ELEVATED)
-    palette.setColor(QtGui.QPalette.ColorRole.ToolTipBase, _BACKGROUND_ELEVATED)
-    palette.setColor(QtGui.QPalette.ColorRole.ToolTipText, _TEXT_PRIMARY)
-    palette.setColor(QtGui.QPalette.ColorRole.Text, _TEXT_PRIMARY)
-    palette.setColor(QtGui.QPalette.ColorRole.Button, _BACKGROUND_ELEVATED)
-    palette.setColor(QtGui.QPalette.ColorRole.ButtonText, _TEXT_PRIMARY)
+    palette.setColor(QtGui.QPalette.ColorRole.Window, colors.background_window)
+    palette.setColor(QtGui.QPalette.ColorRole.WindowText, colors.text_primary)
+    palette.setColor(QtGui.QPalette.ColorRole.Base, colors.background_input)
+    palette.setColor(
+        QtGui.QPalette.ColorRole.AlternateBase, colors.background_elevated
+    )
+    palette.setColor(QtGui.QPalette.ColorRole.ToolTipBase, colors.tooltip_bg)
+    palette.setColor(QtGui.QPalette.ColorRole.ToolTipText, colors.tooltip_text)
+    palette.setColor(QtGui.QPalette.ColorRole.Text, colors.text_primary)
+    palette.setColor(QtGui.QPalette.ColorRole.Button, colors.background_elevated)
+    palette.setColor(QtGui.QPalette.ColorRole.ButtonText, colors.text_primary)
     palette.setColor(QtGui.QPalette.ColorRole.BrightText, QtCore.Qt.GlobalColor.red)
-    palette.setColor(QtGui.QPalette.ColorRole.Link, _ACCENT_COLOR)
-    palette.setColor(QtGui.QPalette.ColorRole.Highlight, _SELECTION_BG)
-    palette.setColor(QtGui.QPalette.ColorRole.HighlightedText, _SELECTION_FG)
+    palette.setColor(QtGui.QPalette.ColorRole.Link, colors.accent)
+    palette.setColor(QtGui.QPalette.ColorRole.Highlight, colors.selection_bg)
+    palette.setColor(QtGui.QPalette.ColorRole.HighlightedText, colors.selection_fg)
 
     palette.setColor(
         QtGui.QPalette.ColorGroup.Disabled,
         QtGui.QPalette.ColorRole.Text,
-        _TEXT_DISABLED,
+        colors.text_disabled,
     )
     palette.setColor(
         QtGui.QPalette.ColorGroup.Disabled,
         QtGui.QPalette.ColorRole.ButtonText,
-        _TEXT_DISABLED,
+        colors.text_disabled,
     )
     palette.setColor(
         QtGui.QPalette.ColorGroup.Disabled,
         QtGui.QPalette.ColorRole.WindowText,
-        _TEXT_DISABLED,
+        colors.text_disabled,
     )
 
     return palette
+
+
+def _build_stylesheet(colors: PaletteColors) -> str:
+    branch_closed_icon = _resource_url("tree_branch_closed.svg")
+    branch_open_icon = _resource_url("tree_branch_open.svg")
+
+    accent_hover = QtGui.QColor(colors.accent).lighter(125)
+    accent_pressed = QtGui.QColor(colors.accent_dark).darker(115)
+    elevated_darker = QtGui.QColor(colors.background_elevated).darker(110)
+    elevated_darkest = QtGui.QColor(colors.background_elevated).darker(125)
+    border_subtle = QtGui.QColor(colors.border).darker(120)
+
+    spin_up_svg = _encoded_arrow_svg("M12 6l6 8H6z", colors.accent)
+    spin_down_svg = _encoded_arrow_svg("M12 18l-6-8h12z", colors.accent)
+    spin_up_disabled_svg = _encoded_arrow_svg("M12 6l6 8H6z", colors.text_disabled)
+    spin_down_disabled_svg = _encoded_arrow_svg(
+        "M12 18l-6-8h12z", colors.text_disabled
+    )
+
+    return (
+        "QToolTip {"
+        "    color: %s;"
+        "    background-color: %s;"
+        "    border: 1px solid %s;"
+        "    border-radius: 6px;"
+        "    padding: 6px;"
+        "}"
+        % (
+            colors.tooltip_text.name(),
+            colors.tooltip_bg.name(),
+            colors.border.name(),
+        )
+        + "\n"
+        "QMainWindow {"
+        "    background-color: %s;"
+        "    color: %s;"
+        "}"
+        % (colors.background_window.name(), colors.text_primary.name())
+        + "\n"
+        "QWidget {"
+        "    color: %s;"
+        "    background-color: %s;"
+        "    selection-background-color: %s;"
+        "    selection-color: %s;"
+        "}"
+        % (
+            colors.text_primary.name(),
+            colors.background_window.name(),
+            colors.selection_bg.name(),
+            colors.selection_fg.name(),
+        )
+        + "\n"
+        "QLabel { color: %s; }" % colors.text_primary.name()
+        + "\n"
+        "QPushButton {"
+        "    background-color: %s;"
+        "    border: 1px solid %s;"
+        "    border-radius: 8px;"
+        "    padding: 6px 14px;"
+        "    color: %s;"
+        "}"
+        % (
+            colors.background_elevated.name(),
+            colors.border.name(),
+            colors.text_primary.name(),
+        )
+        + "\n"
+        "QPushButton:hover {"
+        "    background-color: %s;"
+        "    border-color: %s;"
+        "}"
+        % (accent_hover.name(), colors.accent.name())
+        + "\n"
+        "QPushButton:pressed {"
+        "    background-color: %s;"
+        "    border-color: %s;"
+        "}"
+        % (colors.accent_dark.name(), accent_pressed.name())
+        + "\n"
+        "QPushButton:disabled {"
+        "    color: %s;"
+        "    background-color: %s;"
+        "    border-color: %s;"
+        "}"
+        % (
+            colors.text_disabled.name(),
+            elevated_darker.name(),
+            elevated_darkest.name(),
+        )
+        + "\n"
+        "QLineEdit, QPlainTextEdit, QTextEdit, QComboBox, QSpinBox, QDoubleSpinBox {"
+        "    background-color: %s;"
+        "    border: 1px solid %s;"
+        "    border-radius: 6px;"
+        "    padding: 6px 8px;"
+        "    color: %s;"
+        "}"
+        % (
+            colors.background_input.name(),
+            colors.border.name(),
+            colors.text_primary.name(),
+        )
+        + "\n"
+        "QSpinBox, QDoubleSpinBox {"
+        "    padding-right: 32px;"
+        "}"
+        + "\n"
+        "QLineEdit:focus, QPlainTextEdit:focus, QTextEdit:focus, QComboBox:focus,"
+        " QSpinBox:focus, QDoubleSpinBox:focus {"
+        "    border: 1px solid %s;"
+        "    background-color: %s;"
+        "}"
+        % (colors.border_focus.name(), colors.background_elevated.name())
+        + "\n"
+        "QSpinBox::up-button, QDoubleSpinBox::up-button {"
+        "    subcontrol-origin: border;"
+        "    subcontrol-position: top right;"
+        "    width: 26px;"
+        "    border-left: 1px solid %s;"
+        "    border-bottom: 1px solid %s;"
+        "    border-top-right-radius: 6px;"
+        "    background-color: %s;"
+        "    padding: 0;"
+        "    margin: 0;"
+        "}"
+        % (
+            colors.border.name(),
+            colors.border.name(),
+            colors.background_elevated.name(),
+        )
+        + "\n"
+        "QSpinBox::down-button, QDoubleSpinBox::down-button {"
+        "    subcontrol-origin: border;"
+        "    subcontrol-position: bottom right;"
+        "    width: 26px;"
+        "    border-left: 1px solid %s;"
+        "    border-top: 1px solid %s;"
+        "    border-bottom-right-radius: 6px;"
+        "    background-color: %s;"
+        "    padding: 0;"
+        "    margin: 0;"
+        "}"
+        % (
+            colors.border.name(),
+            colors.border.name(),
+            colors.background_elevated.name(),
+        )
+        + "\n"
+        "QSpinBox::up-button:hover, QDoubleSpinBox::up-button:hover,"
+        " QSpinBox::down-button:hover, QDoubleSpinBox::down-button:hover {"
+        "    background-color: %s;"
+        "    border-color: %s;"
+        "}"
+        % (accent_hover.name(), colors.accent.name())
+        + "\n"
+        "QSpinBox::up-button:pressed, QDoubleSpinBox::up-button:pressed,"
+        " QSpinBox::down-button:pressed, QDoubleSpinBox::down-button:pressed {"
+        "    background-color: %s;"
+        "    border-color: %s;"
+        "}"
+        % (colors.accent_dark.name(), accent_pressed.name())
+        + "\n"
+        "QSpinBox::up-button:disabled, QDoubleSpinBox::up-button:disabled,"
+        " QSpinBox::down-button:disabled, QDoubleSpinBox::down-button:disabled {"
+        "    background-color: %s;"
+        "    border-color: %s;"
+        "}"
+        % (elevated_darker.name(), elevated_darkest.name())
+        + "\n"
+        "QSpinBox::up-arrow, QDoubleSpinBox::up-arrow {"
+        f'    image: url("data:image/svg+xml;base64,{spin_up_svg}");'
+        "    width: 12px;"
+        "    height: 12px;"
+        "}"
+        + "\n"
+        "QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {"
+        f'    image: url("data:image/svg+xml;base64,{spin_down_svg}");'
+        "    width: 12px;"
+        "    height: 12px;"
+        "}"
+        + "\n"
+        "QSpinBox::up-arrow:disabled, QDoubleSpinBox::up-arrow:disabled {"
+        f'    image: url("data:image/svg+xml;base64,{spin_up_disabled_svg}");'
+        "}"
+        + "\n"
+        "QSpinBox::down-arrow:disabled, QDoubleSpinBox::down-arrow:disabled {"
+        f'    image: url("data:image/svg+xml;base64,{spin_down_disabled_svg}");'
+        "}"
+        + "\n"
+        "QTreeWidget, QTreeView, QListWidget, QListView {"
+        "    background-color: %s;"
+        "    border: 1px solid %s;"
+        "    border-radius: 8px;"
+        "    alternate-background-color: %s;"
+        "}"
+        % (
+            colors.background_elevated.name(),
+            colors.border.name(),
+            colors.background_input.name(),
+        )
+        + "\n"
+        "QTreeView::branch:has-children:!has-siblings:closed,"
+        "QTreeView::branch:has-children:!has-siblings:closed:hover,"
+        "QTreeView::branch:has-children:!has-siblings:closed:pressed {"
+        f'    image: url("{branch_closed_icon}");'
+        "    padding: 6px;"
+        "    margin: 0px;"
+        "}"
+        + "\n"
+        "QTreeView::branch:has-children:!has-siblings:open,"
+        "QTreeView::branch:has-children:!has-siblings:open:hover,"
+        "QTreeView::branch:has-children:!has-siblings:open:pressed {"
+        f'    image: url("{branch_open_icon}");'
+        "    padding: 6px;"
+        "    margin: 0px;"
+        "}"
+        + "\n"
+        "QHeaderView::section {"
+        "    background-color: %s;"
+        "    color: %s;"
+        "    padding: 6px;"
+        "    border: none;"
+        "    border-right: 1px solid %s;"
+        "}"
+        % (
+            colors.background_input.name(),
+            colors.text_secondary.name(),
+            colors.border.name(),
+        )
+        + "\n"
+        "QSplitter::handle {"
+        "    background: %s;"
+        "    border: 1px solid %s;"
+        "    margin: 4px;"
+        "    border-radius: 4px;"
+        "}"
+        % (colors.background_input.name(), colors.border.name())
+        + "\n"
+        "QSplitter::handle:hover {"
+        "    background: %s;"
+        "    border-color: %s;"
+        "}"
+        % (colors.accent.name(), colors.accent.darker(120).name())
+        + "\n"
+        "QSplitter::handle:pressed {"
+        "    background: %s;"
+        "}"
+        % (colors.accent_dark.name(),)
+        + "\n"
+        "QProgressBar {"
+        "    border: 1px solid %s;"
+        "    border-radius: 8px;"
+        "    background-color: %s;"
+        "    color: %s;"
+        "    text-align: center;"
+        "    padding: 2px;"
+        "}"
+        % (
+            colors.border.name(),
+            colors.background_elevated.name(),
+            colors.text_primary.name(),
+        )
+        + "\n"
+        "QProgressBar::chunk {"
+        "    background-color: %s;"
+        "    border-radius: 6px;"
+        "}"
+        % (colors.accent.name(),)
+        + "\n"
+        "QScrollBar:vertical {"
+        "    background: %s;"
+        "    width: 14px;"
+        "    margin: 4px 2px 4px 2px;"
+        "    border-radius: 6px;"
+        "}"
+        % (colors.background_elevated.name(),)
+        + "\n"
+        "QScrollBar::handle:vertical {"
+        "    background: %s;"
+        "    min-height: 24px;"
+        "    border-radius: 6px;"
+        "}"
+        % (colors.accent.name(),)
+        + "\n"
+        "QScrollBar::handle:vertical:hover {"
+        "    background: %s;"
+        "}"
+        % (colors.accent_dark.name(),)
+        + "\n"
+        "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {"
+        "    background: none;"
+        "}"
+        + "\n"
+        "QStatusBar {"
+        "    background: %s;"
+        "    color: %s;"
+        "}"
+        % (colors.background_elevated.name(), colors.text_primary.name())
+        + "\n"
+        "QGroupBox {"
+        "    border: 1px solid %s;"
+        "    border-radius: 8px;"
+        "    margin-top: 16px;"
+        "    padding: 10px;"
+        "}"
+        % (colors.border.name(),)
+        + "\n"
+        "QGroupBox::title {"
+        "    subcontrol-origin: margin;"
+        "    subcontrol-position: top left;"
+        "    padding: 0 6px;"
+        "    color: %s;"
+        "}"
+        % (colors.text_secondary.name(),)
+    )
 
 
 def _resolve_default_font(app: QtWidgets.QApplication) -> QtGui.QFont:
@@ -87,295 +456,175 @@ def _resolve_default_font(app: QtWidgets.QApplication) -> QtGui.QFont:
     return font
 
 
-_RESOURCE_DIR = Path(__file__).resolve().parent / "resources"
+_DARK_THEME = ThemeDefinition(
+    key="dark",
+    label="Dark",
+    colors=PaletteColors(
+        accent=QtGui.QColor("#3d7dca"),
+        accent_dark=QtGui.QColor("#2f5a94"),
+        background_window=QtGui.QColor("#1f1f28"),
+        background_elevated=QtGui.QColor("#27293a"),
+        background_input=QtGui.QColor("#252535"),
+        border=QtGui.QColor("#3d3d52"),
+        border_focus=QtGui.QColor("#4d8fe3"),
+        text_primary=QtGui.QColor("#f2f2f5"),
+        text_secondary=QtGui.QColor("#c7cad4"),
+        text_disabled=QtGui.QColor("#7a7d8a"),
+        selection_bg=QtGui.QColor("#3d7dca"),
+        selection_fg=QtGui.QColor("#ffffff"),
+        tooltip_bg=QtGui.QColor("#27293a"),
+        tooltip_text=QtGui.QColor("#f2f2f5"),
+        brand_base=QtGui.QColor("#0f172a"),
+        brand_surface=QtGui.QColor("#1f2b4d"),
+        brand_primary=QtGui.QColor("#4a7bd6"),
+        brand_accent=QtGui.QColor("#7aa2ff"),
+        brand_light=QtGui.QColor("#f1f5ff"),
+        diff_add_bg=QtGui.QColor("#e6ffed"),
+        diff_add_fg=QtGui.QColor("#033a16"),
+        diff_remove_bg=QtGui.QColor("#ffeef0"),
+        diff_remove_fg=QtGui.QColor("#86181d"),
+        diff_context_bg=QtGui.QColor("#f6f8fa"),
+        diff_context_fg=QtGui.QColor("#24292e"),
+        diff_header_bg=QtGui.QColor("#dbe9ff"),
+        diff_header_fg=QtGui.QColor("#032f62"),
+        diff_meta_fg=QtGui.QColor("#6a737d"),
+    ),
+)
+
+_LIGHT_THEME = ThemeDefinition(
+    key="light",
+    label="Light",
+    colors=PaletteColors(
+        accent=QtGui.QColor("#2563eb"),
+        accent_dark=QtGui.QColor("#1d4ed8"),
+        background_window=QtGui.QColor("#f3f4f6"),
+        background_elevated=QtGui.QColor("#ffffff"),
+        background_input=QtGui.QColor("#f9fafb"),
+        border=QtGui.QColor("#d1d5db"),
+        border_focus=QtGui.QColor("#2563eb"),
+        text_primary=QtGui.QColor("#1f2937"),
+        text_secondary=QtGui.QColor("#4b5563"),
+        text_disabled=QtGui.QColor("#9ca3af"),
+        selection_bg=QtGui.QColor("#2563eb"),
+        selection_fg=QtGui.QColor("#ffffff"),
+        tooltip_bg=QtGui.QColor("#111827"),
+        tooltip_text=QtGui.QColor("#f9fafb"),
+        brand_base=QtGui.QColor("#1f2937"),
+        brand_surface=QtGui.QColor("#2563eb"),
+        brand_primary=QtGui.QColor("#3b82f6"),
+        brand_accent=QtGui.QColor("#38bdf8"),
+        brand_light=QtGui.QColor("#eff6ff"),
+        diff_add_bg=QtGui.QColor("#dafbe1"),
+        diff_add_fg=QtGui.QColor("#0a3622"),
+        diff_remove_bg=QtGui.QColor("#ffebe9"),
+        diff_remove_fg=QtGui.QColor("#86181d"),
+        diff_context_bg=QtGui.QColor("#f6f8fa"),
+        diff_context_fg=QtGui.QColor("#24292e"),
+        diff_header_bg=QtGui.QColor("#dbe9ff"),
+        diff_header_fg=QtGui.QColor("#032f62"),
+        diff_meta_fg=QtGui.QColor("#57606a"),
+    ),
+)
+
+_THEMES: Mapping[str, ThemeDefinition] = {
+    _DARK_THEME.key: _DARK_THEME,
+    _LIGHT_THEME.key: _LIGHT_THEME,
+}
 
 
-def _resource_url(name: str) -> str:
-    path = (_RESOURCE_DIR / name).resolve()
-    return path.as_posix()
+class ThemeManager(QtCore.QObject):
+    """Manage theme application and notify widgets about palette changes."""
+
+    paletteChanged = QtCore.Signal(str)
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._themes: Mapping[str, ThemeDefinition] = _THEMES
+        self._current_key: str = _DEFAULT_THEME_KEY
+        self._app: QtWidgets.QApplication | None = None
+        self._current_palette: QtGui.QPalette = _build_palette(
+            self._themes[self._current_key].colors
+        )
+        self._style_configured = False
+
+    @property
+    def available_themes(self) -> tuple[ThemeDefinition, ...]:
+        return tuple(self._themes.values())
+
+    @property
+    def current_theme(self) -> ThemeDefinition:
+        return self._themes[self._current_key]
+
+    @property
+    def colors(self) -> PaletteColors:
+        return self.current_theme.colors
+
+    @property
+    def current_palette(self) -> QtGui.QPalette:
+        return QtGui.QPalette(self._current_palette)
+
+    def apply(
+        self, app: QtWidgets.QApplication, theme: str | None = None
+    ) -> None:
+        self._app = app
+        if theme:
+            self._current_key = self._normalize_key(theme)
+        self._apply_palette()
+
+    def set_theme(self, theme: str) -> None:
+        normalized = self._normalize_key(theme)
+        self._current_key = normalized
+        self._apply_palette()
+
+    def _normalize_key(self, theme: str) -> str:
+        key = (theme or "").strip().lower()
+        if key in self._themes:
+            return key
+        return _DEFAULT_THEME_KEY
+
+    def _ensure_base_style(self) -> None:
+        if self._app is None or self._style_configured:
+            return
+        style_override = os.getenv("QT_STYLE_OVERRIDE")
+        if style_override:
+            self._app.setStyle(style_override)
+        elif not running_under_wsl():
+            available_styles = {
+                name.lower(): name for name in QtWidgets.QStyleFactory.keys()
+            }
+            fusion = available_styles.get("fusion")
+            if fusion:
+                self._app.setStyle(fusion)
+        self._app.setFont(_resolve_default_font(self._app))
+        self._style_configured = True
+
+    def _apply_palette(self) -> None:
+        definition = self._themes[self._current_key]
+        self._current_palette = _build_palette(definition.colors)
+        self._ensure_base_style()
+        if self._app is not None:
+            self._app.setPalette(self._current_palette)
+            self._app.setStyleSheet(_build_stylesheet(definition.colors))
+        self.paletteChanged.emit(self._current_key)
 
 
-def _build_stylesheet() -> str:
-    branch_closed_icon = _resource_url("tree_branch_closed.svg")
-    branch_open_icon = _resource_url("tree_branch_open.svg")
-
-    return (
-        "QToolTip {"
-        "    color: %s;"
-        "    background-color: %s;"
-        "    border: 1px solid %s;"
-        "    border-radius: 6px;"
-        "    padding: 6px;"
-        "}" % (_TEXT_PRIMARY.name(), _BACKGROUND_ELEVATED.name(), _BORDER_COLOR.name())
-        + "\n"
-        "QMainWindow {"
-        "    background-color: %s;"
-        "    color: %s;"
-        "}" % (_BACKGROUND_DARK.name(), _TEXT_PRIMARY.name()) + "\n"
-        "QWidget {"
-        "    color: %s;"
-        "    background-color: %s;"
-        "    selection-background-color: %s;"
-        "    selection-color: %s;"
-        "}"
-        % (
-            _TEXT_PRIMARY.name(),
-            _BACKGROUND_DARK.name(),
-            _SELECTION_BG.name(),
-            _SELECTION_FG.name(),
-        )
-        + "\n"
-        "QLabel { color: %s; }" % _TEXT_PRIMARY.name() + "\n"
-        "QPushButton {"
-        "    background-color: %s;"
-        "    border: 1px solid %s;"
-        "    border-radius: 8px;"
-        "    padding: 6px 14px;"
-        "    color: %s;"
-        "}"
-        % (
-            _BACKGROUND_ELEVATED.name(),
-            _BORDER_COLOR.name(),
-            _TEXT_PRIMARY.name(),
-        )
-        + "\n"
-        "QPushButton:hover {"
-        "    background-color: %s;"
-        "    border-color: %s;"
-        "}" % (_ACCENT_COLOR.lighter(125).name(), _ACCENT_COLOR.name()) + "\n"
-        "QPushButton:pressed {"
-        "    background-color: %s;"
-        "    border-color: %s;"
-        "}" % (_ACCENT_DARK.name(), _ACCENT_DARK.darker(115).name()) + "\n"
-        "QPushButton:disabled {"
-        "    color: %s;"
-        "    background-color: %s;"
-        "    border-color: %s;"
-        "}"
-        % (
-            _TEXT_DISABLED.name(),
-            _BACKGROUND_ELEVATED.darker(110).name(),
-            _BACKGROUND_ELEVATED.darker(125).name(),
-        )
-        + "\n"
-        "QLineEdit, QPlainTextEdit, QTextEdit, QComboBox, QSpinBox, QDoubleSpinBox {"
-        "    background-color: %s;"
-        "    border: 1px solid %s;"
-        "    border-radius: 6px;"
-        "    padding: 6px 8px;"
-        "    color: %s;"
-        "}"
-        % (
-            _BACKGROUND_INPUT.name(),
-            _BORDER_COLOR.name(),
-            _TEXT_PRIMARY.name(),
-        )
-        + "\n"
-        "QSpinBox, QDoubleSpinBox {"
-        "    padding-right: 32px;"
-        "}" + "\n"
-        "QLineEdit:focus, QPlainTextEdit:focus, QTextEdit:focus, QComboBox:focus,"
-        " QSpinBox:focus, QDoubleSpinBox:focus {"
-        "    border: 1px solid %s;"
-        "    background-color: %s;"
-        "}" % (_BORDER_FOCUS.name(), _BACKGROUND_ELEVATED.name()) + "\n"
-        "QSpinBox::up-button, QDoubleSpinBox::up-button {"
-        "    subcontrol-origin: border;"
-        "    subcontrol-position: top right;"
-        "    width: 26px;"
-        "    border-left: 1px solid %s;"
-        "    border-bottom: 1px solid %s;"
-        "    border-top-right-radius: 6px;"
-        "    background-color: %s;"
-        "    padding: 0;"
-        "    margin: 0;"
-        "}"
-        % (
-            _BORDER_COLOR.name(),
-            _BORDER_COLOR.name(),
-            _BACKGROUND_ELEVATED.name(),
-        )
-        + "\n"
-        "QSpinBox::down-button, QDoubleSpinBox::down-button {"
-        "    subcontrol-origin: border;"
-        "    subcontrol-position: bottom right;"
-        "    width: 26px;"
-        "    border-left: 1px solid %s;"
-        "    border-top: 1px solid %s;"
-        "    border-bottom-right-radius: 6px;"
-        "    background-color: %s;"
-        "    padding: 0;"
-        "    margin: 0;"
-        "}"
-        % (
-            _BORDER_COLOR.name(),
-            _BORDER_COLOR.name(),
-            _BACKGROUND_ELEVATED.name(),
-        )
-        + "\n"
-        "QSpinBox::up-button:hover, QDoubleSpinBox::up-button:hover,"
-        " QSpinBox::down-button:hover, QDoubleSpinBox::down-button:hover {"
-        "    background-color: %s;"
-        "    border-color: %s;"
-        "}" % (_ACCENT_COLOR.lighter(130).name(), _ACCENT_COLOR.name()) + "\n"
-        "QSpinBox::up-button:pressed, QDoubleSpinBox::up-button:pressed,"
-        " QSpinBox::down-button:pressed, QDoubleSpinBox::down-button:pressed {"
-        "    background-color: %s;"
-        "    border-color: %s;"
-        "}" % (_ACCENT_DARK.name(), _ACCENT_DARK.darker(115).name()) + "\n"
-        "QSpinBox::up-button:disabled, QDoubleSpinBox::up-button:disabled,"
-        " QSpinBox::down-button:disabled, QDoubleSpinBox::down-button:disabled {"
-        "    background-color: %s;"
-        "    border-color: %s;"
-        "}"
-        % (
-            _BACKGROUND_ELEVATED.darker(110).name(),
-            _BACKGROUND_ELEVATED.darker(125).name(),
-        )
-        + "\n"
-        "QSpinBox::up-arrow, QDoubleSpinBox::up-arrow {"
-        '    image: url("%s");'
-        "    width: 12px;"
-        "    height: 12px;"
-        "}" % (_SPIN_UP_ICON,) + "\n"
-        "QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {"
-        '    image: url("%s");'
-        "    width: 12px;"
-        "    height: 12px;"
-        "}" % (_SPIN_DOWN_ICON,) + "\n"
-        "QSpinBox::up-arrow:disabled, QDoubleSpinBox::up-arrow:disabled {"
-        '    image: url("%s");'
-        "}" % (_SPIN_UP_ICON,) + "\n"
-        "QSpinBox::down-arrow:disabled, QDoubleSpinBox::down-arrow:disabled {"
-        '    image: url("%s");'
-        "}" % (_SPIN_DOWN_ICON,) + "\n"
-        "QTreeWidget, QTreeView, QListWidget, QListView {"
-        "    background-color: %s;"
-        "    border: 1px solid %s;"
-        "    border-radius: 8px;"
-        "    alternate-background-color: %s;"
-        "}"
-        % (
-            _BACKGROUND_ELEVATED.name(),
-            _BORDER_COLOR.name(),
-            _BACKGROUND_INPUT.name(),
-        )
-        + "\n"
-        "QTreeView::branch:has-children:!has-siblings:closed,"
-        "QTreeView::branch:has-children:!has-siblings:closed:hover,"
-        "QTreeView::branch:has-children:!has-siblings:closed:pressed {"
-        '    image: url("%s");'
-        "    padding: 6px;"
-        "    margin: 0px;"
-        "}" % (branch_closed_icon,) + "\n"
-        "QTreeView::branch:has-children:!has-siblings:open,"
-        "QTreeView::branch:has-children:!has-siblings:open:hover,"
-        "QTreeView::branch:has-children:!has-siblings:open:pressed {"
-        '    image: url("%s");'
-        "    padding: 6px;"
-        "    margin: 0px;"
-        "}" % (branch_open_icon,) + "\n"
-        "QHeaderView::section {"
-        "    background-color: %s;"
-        "    color: %s;"
-        "    padding: 6px;"
-        "    border: none;"
-        "    border-right: 1px solid %s;"
-        "}"
-        % (
-            _BACKGROUND_INPUT.name(),
-            _TEXT_SECONDARY.name(),
-            _BORDER_COLOR.name(),
-        )
-        + "\n"
-        "QSplitter::handle {"
-        "    background: %s;"
-        "    border: 1px solid %s;"
-        "    margin: 4px;"
-        "    border-radius: 4px;"
-        "}" % (_BACKGROUND_INPUT.name(), _BORDER_COLOR.name()) + "\n"
-        "QSplitter::handle:hover {"
-        "    background: %s;"
-        "    border-color: %s;"
-        "}" % (_ACCENT_COLOR.name(), _ACCENT_COLOR.darker(120).name()) + "\n"
-        "QSplitter::handle:pressed {"
-        "    background: %s;"
-        "}" % (_ACCENT_DARK.name(),) + "\n"
-        "QProgressBar {"
-        "    border: 1px solid %s;"
-        "    border-radius: 8px;"
-        "    background-color: %s;"
-        "    color: %s;"
-        "    text-align: center;"
-        "    padding: 2px;"
-        "}"
-        % (
-            _BORDER_COLOR.name(),
-            _BACKGROUND_ELEVATED.name(),
-            _TEXT_PRIMARY.name(),
-        )
-        + "\n"
-        "QProgressBar::chunk {"
-        "    background-color: %s;"
-        "    border-radius: 6px;"
-        "}" % (_ACCENT_COLOR.name(),) + "\n"
-        "QScrollBar:vertical {"
-        "    background: %s;"
-        "    width: 14px;"
-        "    margin: 4px 2px 4px 2px;"
-        "    border-radius: 6px;"
-        "}" % (_BACKGROUND_ELEVATED.name(),) + "\n"
-        "QScrollBar::handle:vertical {"
-        "    background: %s;"
-        "    min-height: 24px;"
-        "    border-radius: 6px;"
-        "}" % (_ACCENT_COLOR.name(),) + "\n"
-        "QScrollBar::handle:vertical:hover {"
-        "    background: %s;"
-        "}" % (_ACCENT_DARK.name(),) + "\n"
-        "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {"
-        "    background: none;"
-        "}" + "\n"
-        "QStatusBar {"
-        "    background: %s;"
-        "    color: %s;"
-        "}" % (_BACKGROUND_ELEVATED.name(), _TEXT_PRIMARY.name()) + "\n"
-        "QGroupBox {"
-        "    border: 1px solid %s;"
-        "    border-radius: 8px;"
-        "    margin-top: 16px;"
-        "    padding: 10px;"
-        "}" % (_BORDER_COLOR.name(),) + "\n"
-        "QGroupBox::title {"
-        "    subcontrol-origin: margin;"
-        "    subcontrol-position: top left;"
-        "    padding: 0 6px;"
-        "    color: %s;"
-        "}" % (_TEXT_SECONDARY.name(),)
-    )
+theme_manager = ThemeManager()
 
 
-def apply_modern_theme(app: QtWidgets.QApplication) -> None:
-    """Apply a modern dark theme to ``app`` while remaining WSL-friendly."""
+def apply_modern_theme(
+    app: QtWidgets.QApplication, *, theme: str | None = None
+) -> None:
+    """Apply the requested theme to ``app`` and configure base styling."""
 
     if app is None:
         return
+    theme_manager.apply(app, theme=theme)
 
-    # ``Fusion`` provides a predictable baseline but we allow power users to
-    # override it via the standard ``QT_STYLE_OVERRIDE`` variable. Keeping the
-    # existing style is especially important for WSL sessions where users may
-    # prefer the Windows host look & feel.
-    style_override = os.getenv("QT_STYLE_OVERRIDE")
-    if style_override:
-        app.setStyle(style_override)
-    elif not running_under_wsl():
-        available_styles = {
-            name.lower(): name for name in QtWidgets.QStyleFactory.keys()
-        }
-        fusion = available_styles.get("fusion")
-        if fusion:
-            app.setStyle(fusion)
 
-    app.setPalette(_build_palette())
-    app.setFont(_resolve_default_font(app))
-    app.setStyleSheet(_build_stylesheet())
+__all__ = [
+    "PaletteColors",
+    "ThemeDefinition",
+    "ThemeManager",
+    "apply_modern_theme",
+    "theme_manager",
+]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,6 +24,7 @@ def test_load_config_returns_defaults_when_missing(tmp_path: Path) -> None:
     assert loaded.backup_retention_days == defaults.backup_retention_days
     assert loaded.ai_assistant_enabled == defaults.ai_assistant_enabled
     assert loaded.ai_auto_apply == defaults.ai_auto_apply
+    assert loaded.theme == defaults.theme
 
 
 def test_save_and_load_roundtrip(tmp_path: Path) -> None:
@@ -43,6 +44,7 @@ def test_save_and_load_roundtrip(tmp_path: Path) -> None:
         backup_retention_days=14,
         ai_assistant_enabled=True,
         ai_auto_apply=True,
+        theme="light",
     )
 
     save_config(original, path=config_path)
@@ -91,6 +93,7 @@ def test_load_config_invalid_values_fallback(tmp_path: Path) -> None:
                 "backup_retention_days = -10",
                 'ai_assistant_enabled = "maybe"',
                 'ai_auto_apply = """',
+                'theme = 123',
                 "",
             ]
         ),
@@ -112,6 +115,7 @@ def test_load_config_invalid_values_fallback(tmp_path: Path) -> None:
     assert loaded.backup_retention_days == defaults.backup_retention_days
     assert loaded.ai_assistant_enabled == defaults.ai_assistant_enabled
     assert loaded.ai_auto_apply == defaults.ai_auto_apply
+    assert loaded.theme == defaults.theme
 
 
 def test_load_config_accepts_empty_exclude_list(tmp_path: Path) -> None:
@@ -132,6 +136,7 @@ def test_load_config_accepts_empty_exclude_list(tmp_path: Path) -> None:
                 "backup_retention_days = 30",
                 "ai_assistant_enabled = true",
                 "ai_auto_apply = true",
+                'theme = "light"',
                 "",
             ]
         ),
@@ -152,3 +157,4 @@ def test_load_config_accepts_empty_exclude_list(tmp_path: Path) -> None:
     assert loaded.backup_retention_days == 30
     assert loaded.ai_assistant_enabled is True
     assert loaded.ai_auto_apply is True
+    assert loaded.theme == "light"

--- a/tests/test_diff_applier_gui.py
+++ b/tests/test_diff_applier_gui.py
@@ -170,6 +170,9 @@ def test_settings_dialog_gathers_config(qt_app: Any, tmp_path: Path) -> None:
     dialog.backup_retention_edit.setText("7")
     dialog.ai_assistant_check.setChecked(False)
     dialog.ai_auto_check.setChecked(True)
+    theme_index = dialog.theme_combo.findData("light")
+    if theme_index >= 0:
+        dialog.theme_combo.setCurrentIndex(theme_index)
 
     updated = dialog._gather_config()
 
@@ -185,6 +188,7 @@ def test_settings_dialog_gathers_config(qt_app: Any, tmp_path: Path) -> None:
     assert updated.backup_retention_days == 7
     assert updated.ai_assistant_enabled is False
     assert updated.ai_auto_apply is True
+    assert updated.theme == "light"
 
 
 def test_main_window_applies_settings_dialog(
@@ -252,6 +256,7 @@ def test_main_window_applies_settings_dialog(
         log_backup_count=3,
         ai_assistant_enabled=True,
         ai_auto_apply=True,
+        theme="light",
     )
 
     class _FakeDialog:

--- a/tests/test_theme_manager.py
+++ b/tests/test_theme_manager.py
@@ -1,0 +1,83 @@
+import pytest
+
+try:
+    from patch_gui.theme import theme_manager
+    from patch_gui.interactive_diff import InteractiveDiffWidget
+except Exception as exc:  # pragma: no cover - optional dependency
+    theme_manager = None
+    InteractiveDiffWidget = None
+    _THEME_IMPORT_ERROR: Exception | None = exc
+else:
+    _THEME_IMPORT_ERROR = None
+
+try:  # pragma: no cover - environment-dependent
+    from PySide6 import QtWidgets as _QtWidgets
+except Exception as exc:  # pragma: no cover - optional dependency
+    QtWidgets = None
+    _QT_IMPORT_ERROR: Exception | None = exc
+else:  # pragma: no cover - exercised when bindings are available
+    QtWidgets = _QtWidgets
+    _QT_IMPORT_ERROR = None
+
+
+@pytest.fixture()
+def qt_app() -> object:
+    if QtWidgets is None:
+        pytest.skip(f"PySide6 non disponibile: {_QT_IMPORT_ERROR}")
+    if theme_manager is None:
+        pytest.skip(f"Qt non disponibile: {_THEME_IMPORT_ERROR}")
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    theme_manager.apply(app, theme="dark")
+    return app
+
+
+def test_theme_manager_switches_palettes(qt_app: object) -> None:
+    if QtWidgets is None or theme_manager is None:
+        pytest.skip(
+            f"PySide6 non disponibile: {_QT_IMPORT_ERROR or _THEME_IMPORT_ERROR}"
+        )
+    seen: list[str] = []
+
+    def _listener(key: str) -> None:
+        seen.append(key)
+
+    theme_manager.paletteChanged.connect(_listener)
+    try:
+        theme_manager.set_theme("light")
+        if isinstance(qt_app, QtWidgets.QApplication):
+            qt_app.processEvents()
+        assert theme_manager.current_theme.key == "light"
+        assert seen and seen[-1] == "light"
+
+        light_palette = theme_manager.current_palette
+        theme_manager.set_theme("dark")
+        if isinstance(qt_app, QtWidgets.QApplication):
+            qt_app.processEvents()
+        assert theme_manager.current_theme.key == "dark"
+        assert theme_manager.current_palette != light_palette
+    finally:
+        theme_manager.paletteChanged.disconnect(_listener)
+        theme_manager.set_theme("dark")
+        if isinstance(qt_app, QtWidgets.QApplication):
+            qt_app.processEvents()
+
+
+def test_interactive_diff_widget_updates_on_theme_change(qt_app: object) -> None:
+    if QtWidgets is None or theme_manager is None or InteractiveDiffWidget is None:
+        pytest.skip(
+            f"PySide6 non disponibile: {_QT_IMPORT_ERROR or _THEME_IMPORT_ERROR}"
+        )
+    widget = InteractiveDiffWidget()
+    initial_colors = widget._colors
+    theme_manager.set_theme("light")
+    if isinstance(qt_app, QtWidgets.QApplication):
+        qt_app.processEvents()
+    try:
+        assert widget._colors != initial_colors
+    finally:
+        widget.deleteLater()
+        theme_manager.set_theme("dark")
+        if isinstance(qt_app, QtWidgets.QApplication):
+            qt_app.processEvents()


### PR DESCRIPTION
## Summary
- introduce a reusable theme manager with light and dark palettes, generated assets, and palette broadcasting
- persist the chosen theme in the app config, expose it in the settings dialog, and refresh generated icons on palette changes
- refactor diff highlighting and interactive diff UI to consume the active palette and react to theme updates
- document the manual QA checklist for switching themes and add regression tests for palette behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cd2ccc7f148326af4a03aa65474ec0