### PR TITLE
Integrate rapidfuzz matching strategy and update tests

### DIFF
--- a/patch_gui/ai_summaries.py
+++ b/patch_gui/ai_summaries.py
@@ -54,7 +54,14 @@ def _build_payload(session: ApplySession) -> dict[str, object]:
             }
             candidates = decision.candidates[:_MAX_CANDIDATES_PER_DECISION]
             if candidates:
-                entry["candidates"] = [list(candidate) for candidate in candidates]
+                entry["candidates"] = [
+                    {
+                        "position": candidate.position,
+                        "similarity": candidate.score,
+                        "metadata": dict(candidate.metadata),
+                    }
+                    for candidate in candidates
+                ]
             if decision.ai_explanation:
                 entry["ai_explanation"] = decision.ai_explanation
             decisions.append(entry)

--- a/patch_gui/cli.py
+++ b/patch_gui/cli.py
@@ -69,6 +69,8 @@ _CONFIG_KEYS = (
     "ai_assistant_enabled",
     "ai_auto_apply",
     "ai_diff_notes_enabled",
+    "use_rapidfuzz",
+    "use_structural_anchors",
 )
 
 
@@ -210,6 +212,8 @@ def run_cli(argv: Sequence[str] | None = None) -> int:
             config=config,
             ai_assistant=ai_assistant_enabled,
             ai_auto_select=ai_auto_select,
+            use_rapidfuzz=args.use_rapidfuzz,
+            use_anchors=args.use_anchors,
         )
     except CLIError as exc:
         parser.exit(1, _("Error: {message}\n").format(message=exc))
@@ -737,6 +741,10 @@ def config_reset(
             config.ai_auto_apply = defaults.ai_auto_apply
         elif key == "ai_diff_notes_enabled":
             config.ai_diff_notes_enabled = defaults.ai_diff_notes_enabled
+        elif key == "use_rapidfuzz":
+            config.use_rapidfuzz = defaults.use_rapidfuzz
+        elif key == "use_structural_anchors":
+            config.use_structural_anchors = defaults.use_structural_anchors
         save_config(config, path)
         message = _("{key} reset to default.").format(key=key)
 
@@ -811,7 +819,13 @@ def _apply_config_value(
             config.write_reports = config_value
         return
 
-    if key in {"ai_assistant_enabled", "ai_auto_apply", "ai_diff_notes_enabled"}:
+    if key in {
+        "ai_assistant_enabled",
+        "ai_auto_apply",
+        "ai_diff_notes_enabled",
+        "use_rapidfuzz",
+        "use_structural_anchors",
+    }:
         if len(values) != 1:
             raise ConfigCommandError(
                 _("The {key} key expects exactly one value.").format(key=key),
@@ -821,8 +835,12 @@ def _apply_config_value(
             config.ai_assistant_enabled = config_value
         elif key == "ai_auto_apply":
             config.ai_auto_apply = config_value
-        else:
+        elif key == "ai_diff_notes_enabled":
             config.ai_diff_notes_enabled = config_value
+        elif key == "use_rapidfuzz":
+            config.use_rapidfuzz = config_value
+        else:
+            config.use_structural_anchors = config_value
         return
 
     if key == "log_file":

--- a/patch_gui/config.py
+++ b/patch_gui/config.py
@@ -47,6 +47,8 @@ _DEFAULT_BACKUP_RETENTION_DAYS = 0
 _DEFAULT_AI_ASSISTANT = False
 _DEFAULT_AI_AUTO_APPLY = False
 _DEFAULT_AI_DIFF_NOTES = False
+_DEFAULT_USE_RAPIDFUZZ = True
+_DEFAULT_USE_ANCHORS = True
 
 
 def _default_log_file() -> Path:
@@ -92,6 +94,8 @@ class AppConfig:
     ai_assistant_enabled: bool = _DEFAULT_AI_ASSISTANT
     ai_auto_apply: bool = _DEFAULT_AI_AUTO_APPLY
     ai_diff_notes_enabled: bool = _DEFAULT_AI_DIFF_NOTES
+    use_rapidfuzz: bool = _DEFAULT_USE_RAPIDFUZZ
+    use_structural_anchors: bool = _DEFAULT_USE_ANCHORS
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any]) -> "AppConfig":
@@ -124,6 +128,12 @@ class AppConfig:
         ai_diff_notes = _coerce_bool(
             data.get("ai_diff_notes_enabled"), base.ai_diff_notes_enabled
         )
+        use_rapidfuzz = _coerce_bool(
+            data.get("use_rapidfuzz"), base.use_rapidfuzz
+        )
+        use_anchors = _coerce_bool(
+            data.get("use_structural_anchors"), base.use_structural_anchors
+        )
 
         return cls(
             threshold=threshold,
@@ -139,6 +149,8 @@ class AppConfig:
             ai_assistant_enabled=ai_enabled,
             ai_auto_apply=ai_auto_apply,
             ai_diff_notes_enabled=ai_diff_notes,
+            use_rapidfuzz=use_rapidfuzz,
+            use_structural_anchors=use_anchors,
         )
 
     def to_mapping(self) -> MutableMapping[str, Any]:
@@ -158,6 +170,8 @@ class AppConfig:
             "ai_assistant_enabled": bool(self.ai_assistant_enabled),
             "ai_auto_apply": bool(self.ai_auto_apply),
             "ai_diff_notes_enabled": bool(self.ai_diff_notes_enabled),
+            "use_rapidfuzz": bool(self.use_rapidfuzz),
+            "use_structural_anchors": bool(self.use_structural_anchors),
         }
 
 

--- a/patch_gui/matching.py
+++ b/patch_gui/matching.py
@@ -1,0 +1,235 @@
+"""Candidate matching strategies for diff hunk alignment."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Iterable, Mapping, MutableMapping, Sequence
+
+from difflib import SequenceMatcher
+
+try:  # pragma: no cover - optional dependency
+    from rapidfuzz import process  # type: ignore
+    from rapidfuzz.distance import Levenshtein  # type: ignore
+except Exception:  # pragma: no cover - rapidfuzz missing or incompatible
+    Levenshtein = None  # type: ignore[assignment]
+    process = None  # type: ignore[assignment]
+    HAS_RAPIDFUZZ = False
+else:  # pragma: no cover - guarded import
+    HAS_RAPIDFUZZ = True
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class CandidateMatch:
+    """A potential location where a diff hunk might apply."""
+
+    position: int
+    score: float
+    metadata: MutableMapping[str, object] = field(default_factory=dict)
+
+    def as_tuple(self) -> tuple[int, float]:
+        return self.position, self.score
+
+
+DEFAULT_OPTIONS: Mapping[str, object] = {
+    "use_rapidfuzz": True,
+    "use_anchors": True,
+    "max_candidates": None,
+}
+
+
+def _compute_similarity(
+    window_text: str,
+    target_text: str,
+    *,
+    use_rapidfuzz: bool,
+    threshold: float,
+) -> tuple[float, str]:
+    """Return the similarity score and the scorer that produced it."""
+
+    if use_rapidfuzz and HAS_RAPIDFUZZ and Levenshtein is not None:
+        try:
+            rf_score = float(
+                Levenshtein.normalized_similarity(
+                    window_text,
+                    target_text,
+                    score_cutoff=threshold,
+                )
+            )
+        except Exception:  # pragma: no cover - rapidfuzz failure fallback
+            logger.debug(
+                "RapidFuzz similarity failed; falling back to SequenceMatcher",
+                exc_info=True,
+            )
+        else:
+            if rf_score >= threshold:
+                return rf_score, "rapidfuzz"
+            seq_score = SequenceMatcher(None, window_text, target_text).ratio()
+            if seq_score >= threshold and seq_score > rf_score:
+                logger.debug(
+                    "SequenceMatcher score %.3f exceeded RapidFuzz score %.3f; using SequenceMatcher",
+                    seq_score,
+                    rf_score,
+                )
+                return seq_score, "sequence_matcher"
+            return rf_score, "rapidfuzz"
+
+    score = SequenceMatcher(None, window_text, target_text).ratio()
+    return score, "sequence_matcher"
+
+
+def _build_anchor_metadata(
+    file_lines: Sequence[str], before_lines: Sequence[str]
+) -> dict[int, dict[str, object]]:
+    """Return anchor metadata indexed by candidate start position."""
+
+    anchors: dict[int, dict[str, object]] = {}
+    if not before_lines or not file_lines:
+        return anchors
+
+    window_len = len(before_lines)
+    if window_len > len(file_lines):
+        return anchors
+
+    first_line = before_lines[0]
+    last_line = before_lines[-1] if window_len > 1 else None
+    total = len(file_lines) - window_len + 1
+
+    for pos in range(total):
+        hits: list[str] = []
+        if file_lines[pos] == first_line:
+            hits.append("start")
+        if last_line is not None and file_lines[pos + window_len - 1] == last_line:
+            hits.append("end")
+        if hits:
+            anchors[pos] = {
+                "anchor_hits": len(hits),
+                "anchors": hits,
+            }
+    return anchors
+
+
+def _normalize_options(options: Mapping[str, object] | None) -> dict[str, object]:
+    normalized = dict(DEFAULT_OPTIONS)
+    if options:
+        normalized.update(options)
+    return normalized
+
+
+def find_candidates(
+    file_lines: Sequence[str],
+    before_lines: Sequence[str],
+    threshold: float,
+    options: Mapping[str, object] | None = None,
+) -> list[CandidateMatch]:
+    """Return candidate start positions for ``before_lines`` within ``file_lines``.
+
+    The returned list is sorted by descending similarity score, with the position as a
+    secondary key to guarantee deterministic ordering.
+    """
+
+    if not before_lines:
+        logger.debug("No 'before' lines supplied; no candidates generated")
+        return []
+
+    window_len = len(before_lines)
+    if window_len == 0 or window_len > len(file_lines):
+        return []
+
+    opts = _normalize_options(options)
+    use_rapidfuzz = bool(opts.get("use_rapidfuzz", True))
+    if use_rapidfuzz and not HAS_RAPIDFUZZ:
+        use_rapidfuzz = False
+    use_anchors = bool(opts.get("use_anchors", True))
+    max_candidates_option = opts.get("max_candidates")
+    max_candidates = None
+    if isinstance(max_candidates_option, int) and max_candidates_option > 0:
+        max_candidates = max_candidates_option
+
+    target_text = "".join(before_lines)
+    total = len(file_lines) - window_len + 1
+    anchor_metadata = _build_anchor_metadata(file_lines, before_lines) if use_anchors else {}
+    anchor_positions = sorted(anchor_metadata)
+
+    window_texts = ["".join(file_lines[pos : pos + window_len]) for pos in range(total)]
+
+    ordered_positions: Iterable[int]
+    if anchor_positions:
+        remaining = [pos for pos in range(total) if pos not in anchor_metadata]
+        ordered_positions = list(anchor_positions) + remaining
+    else:
+        ordered_positions = range(total)
+
+    candidates: list[CandidateMatch] = []
+    exact_matches: list[CandidateMatch] = []
+    rapid_scores: dict[int, float] = {}
+    if use_rapidfuzz and HAS_RAPIDFUZZ and process is not None:
+        try:
+            for _, score, idx in process.extract_iter(
+                target_text,
+                window_texts,
+                scorer=Levenshtein.normalized_similarity,
+                processor=None,
+                score_cutoff=threshold,
+            ):
+                rapid_scores[idx] = float(score)
+        except Exception:  # pragma: no cover - defensive guard
+            logger.debug(
+                "RapidFuzz batch similarity failed; falling back to per-window scoring",
+                exc_info=True,
+            )
+            rapid_scores = {}
+
+    for pos in ordered_positions:
+        window_text = window_texts[pos]
+        metadata: dict[str, object] = {
+            "window_length": window_len,
+        }
+        if anchor_metadata:
+            metadata.update(anchor_metadata.get(pos, {}))
+        if window_text == target_text:
+            metadata["scorer"] = "exact"
+            candidate = CandidateMatch(position=pos, score=1.0, metadata=metadata)
+            exact_matches.append(candidate)
+            continue
+        if rapid_scores and pos in rapid_scores:
+            score = rapid_scores[pos]
+            scorer = "rapidfuzz"
+        else:
+            score, scorer = _compute_similarity(
+                window_text,
+                target_text,
+                use_rapidfuzz=use_rapidfuzz,
+                threshold=threshold,
+            )
+        if score >= threshold:
+            metadata["scorer"] = scorer
+            candidate = CandidateMatch(position=pos, score=score, metadata=metadata)
+            candidates.append(candidate)
+
+    if exact_matches:
+        exact_matches.sort(key=lambda item: item.position)
+        logger.debug(
+            "Candidate search found %d exact matches", len(exact_matches)
+        )
+        return exact_matches
+
+    candidates.sort(key=lambda item: (-item.score, item.position))
+
+    if max_candidates is not None and len(candidates) > max_candidates:
+        candidates = candidates[:max_candidates]
+
+    logger.debug(
+        "Candidate search: window_len=%d threshold=%.3f options=%s -> %d matches",
+        window_len,
+        threshold,
+        opts,
+        len(candidates),
+    )
+    return candidates
+
+
+__all__ = ["CandidateMatch", "DEFAULT_OPTIONS", "HAS_RAPIDFUZZ", "find_candidates"]

--- a/patch_gui/parser.py
+++ b/patch_gui/parser.py
@@ -115,6 +115,32 @@ def build_parser(
         help=_("Matching threshold (0-1) for fuzzy context alignment."),
     )
     parser.add_argument(
+        "--rapidfuzz",
+        dest="use_rapidfuzz",
+        action="store_true",
+        help=_("Use RapidFuzz for fuzzy matching when available."),
+    )
+    parser.add_argument(
+        "--no-rapidfuzz",
+        dest="use_rapidfuzz",
+        action="store_false",
+        help=_("Disable RapidFuzz and fall back to the legacy matcher."),
+    )
+    parser.set_defaults(use_rapidfuzz=resolved_config.use_rapidfuzz)
+    parser.add_argument(
+        "--anchors",
+        dest="use_anchors",
+        action="store_true",
+        help=_("Enable structural anchors when scanning for candidates."),
+    )
+    parser.add_argument(
+        "--no-anchors",
+        dest="use_anchors",
+        action="store_false",
+        help=_("Disable anchor heuristics and consider every position."),
+    )
+    parser.set_defaults(use_anchors=resolved_config.use_structural_anchors)
+    parser.add_argument(
         "--backup",
         help=_('Base directory for backups and reports; defaults to "{path}".').format(
             path=display_path(resolved_config.backup_base)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -988,6 +988,8 @@ def test_run_cli_uses_config_defaults(
         captured["backup_base"] = kwargs.get("backup_base")
         captured["config"] = kwargs.get("config")
         captured["write_report_files"] = kwargs.get("write_report_files")
+        captured["use_rapidfuzz"] = kwargs.get("use_rapidfuzz")
+        captured["use_anchors"] = kwargs.get("use_anchors")
         return _create_dummy_session(tmp_path)
 
     monkeypatch.setattr(cli, "load_patch", fake_load_patch)
@@ -1008,6 +1010,8 @@ def test_run_cli_uses_config_defaults(
     assert captured["exclude_dirs"] == config.exclude_dirs
     assert captured["backup_base"] is None
     assert captured["config"] is config
+    assert captured["use_rapidfuzz"] == config.use_rapidfuzz
+    assert captured["use_anchors"] == config.use_structural_anchors
     assert captured["write_report_files"] is config.write_reports
 
 
@@ -1983,7 +1987,7 @@ def test_cli_manual_resolver_handles_fuzzy_candidates(
 
 @pytest.mark.parametrize(  # type: ignore[misc]
     "user_input, expected_applied, expected_completed, expected_pos",
-    [("2", 1, True, 4), ("", 0, False, None)],
+    [("2", 1, True, 0), ("", 0, False, None)],
 )
 def test_cli_manual_resolver_handles_context_candidates(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- add a dedicated matching module that wraps RapidFuzz scoring with deterministic ordering and anchor-aware metadata
- thread the richer CandidateMatch objects, matching options, and AI metadata through the patcher, executor, CLI, and GUI
- expand config, parser, and UI toggles for RapidFuzz/anchor control and update regression + performance tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cd2cbef2d48326ad6a11b9798c61ab