### PR TITLE
Add asynchronous AI summary handling and caching

### DIFF
--- a/patch_gui/app.py
+++ b/patch_gui/app.py
@@ -20,7 +20,12 @@ from PySide6.QtWidgets import QDialog, QMainWindow
 from unidiff import PatchSet
 
 from .ai_candidate_selector import AISuggestion, rank_candidates
-from .ai_summaries import generate_session_summary
+from .ai_summaries import (
+    AISummary,
+    AISummaryHooks,
+    compute_diff_digest,
+    generate_session_summary,
+)
 from .config import AppConfig, Theme, load_config, save_config
 from .filetypes import inspect_file_type
 from .highlighter import DiffHighlighter
@@ -1341,6 +1346,82 @@ class PatchApplyWorker(_QThreadBase):
         return pos
 
 
+class AISummaryWorker(_QThreadBase):
+    progress = QtCore.Signal(str)
+    partial_update = QtCore.Signal(object)
+    completed = QtCore.Signal(object, object)
+    failed = QtCore.Signal(object, str)
+    cancelled = QtCore.Signal(object)
+
+    def __init__(self, session: ApplySession, *, timeout: float | None = None) -> None:
+        super().__init__()
+        self.session = session
+        self._timeout = timeout
+        self._cancel_event = threading.Event()
+        self._cache_hit: bool | None = None
+
+    def cancel(self) -> None:
+        self._cancel_event.set()
+
+    def _handle_start(self, payload: dict[str, object]) -> None:
+        if self._cancel_event.is_set():
+            return
+        message = _("Richiesta sintesi AI in corso…")
+        self.progress.emit(message)
+
+    def _handle_chunk(self, chunk: dict[str, object]) -> None:
+        if self._cancel_event.is_set():
+            return
+        self.partial_update.emit(chunk)
+
+    def _handle_cached(self, summary: AISummary) -> None:
+        if self._cancel_event.is_set():
+            return
+        self._cache_hit = True
+        message = _("Sintesi AI recuperata dalla cache.")
+        self.progress.emit(message)
+
+    def _handle_complete(self, summary: AISummary, cached: bool) -> None:
+        if self._cancel_event.is_set():
+            return
+        self._cache_hit = cached
+        if cached:
+            return
+        message = _("Sintesi AI generata.")
+        self.progress.emit(message)
+
+    def run(self) -> None:  # pragma: no cover - thread orchestration
+        if self._cancel_event.is_set():
+            self.cancelled.emit(self.session)
+            return
+
+        hooks = AISummaryHooks(
+            on_start=self._handle_start,
+            on_chunk=self._handle_chunk,
+            on_complete=self._handle_complete,
+            on_cached=self._handle_cached,
+        )
+
+        kwargs: dict[str, object] = {"hooks": hooks}
+        if self._timeout is not None:
+            kwargs["timeout"] = float(self._timeout)
+
+        try:
+            summary = generate_session_summary(self.session, **kwargs)
+        except Exception as exc:  # pragma: no cover - defensive guard
+            if self._cancel_event.is_set():
+                self.cancelled.emit(self.session)
+            else:
+                self.failed.emit(self.session, str(exc))
+            return
+
+        if self._cancel_event.is_set():
+            self.cancelled.emit(self.session)
+            return
+
+        self.completed.emit(self.session, summary)
+
+
 class MainWindow(_QMainWindowBase):
     def __init__(self, *, app_config: AppConfig | None = None) -> None:
         super().__init__()
@@ -1367,6 +1448,8 @@ class MainWindow(_QMainWindowBase):
         self.ai_diff_notes_enabled: bool = self.app_config.ai_diff_notes_enabled
         self._qt_log_handler: Optional[GuiLogHandler] = None
         self._current_worker: Optional[PatchApplyWorker] = None
+        self._summary_worker: Optional[AISummaryWorker] = None
+        self._pending_summary_session: Optional[ApplySession] = None
         self._log_messages: List[str] = []
 
         central = QtWidgets.QWidget()
@@ -2045,6 +2128,7 @@ class MainWindow(_QMainWindowBase):
             exclude_dirs=excludes,
             started_at=started_at,
         )
+        session.summary_diff_digest = compute_diff_digest(self.patch)
         worker = PatchApplyWorker(
             self.patch,
             session,
@@ -2084,23 +2168,115 @@ class MainWindow(_QMainWindowBase):
         self, session: ApplySession
     ) -> None:  # pragma: no cover - UI feedback
         self._current_worker = None
-        summary = generate_session_summary(session)
-        if summary is not None:
-            session.ai_summary = summary.overall
-            session.file_summaries = summary.per_file
-            if summary.per_file:
-                for fr in session.results:
-                    candidate_keys = [fr.relative_to_root, str(fr.file_path)]
-                    for key in candidate_keys:
-                        if key and key in summary.per_file:
-                            fr.ai_summary = summary.per_file[key]
-                            break
+        self._pending_summary_session = session
+        self._start_summary_worker(session)
+
+    @_qt_slot(str)
+    def _on_worker_error(self, message: str) -> None:  # pragma: no cover - UI feedback
+        logger.error(_("Errore durante l'applicazione della patch: %s"), message)
+        self._set_busy(False)
+        self._current_worker = None
+        self.progress_bar.setVisible(False)
+        self.progress_bar.setToolTip("")
+        QtWidgets.QMessageBox.critical(self, _("Errore"), message)
+        self.statusBar().showMessage(_("Errore durante l'applicazione della patch"))
+
+    def _start_summary_worker(self, session: ApplySession) -> None:
+        if self._summary_worker is not None and self._summary_worker.isRunning():
+            self._summary_worker.cancel()
+        worker = AISummaryWorker(session)
+        worker.progress.connect(self._on_summary_progress)
+        worker.partial_update.connect(self._on_summary_partial_update)
+        worker.completed.connect(self._on_summary_completed)
+        worker.failed.connect(self._on_summary_failed)
+        worker.cancelled.connect(self._on_summary_cancelled)
+        worker.finished.connect(worker.deleteLater)
+        self._summary_worker = worker
+        message = _("Generazione sintesi AI in corso…")
+        self.progress_bar.setRange(0, 0)
+        self.progress_bar.setValue(0)
+        self.progress_bar.setVisible(True)
+        self.progress_bar.setToolTip(message)
+        self.statusBar().showMessage(message)
+        worker.start()
+
+    @_qt_slot(str)
+    def _on_summary_progress(self, message: str) -> None:
+        if not message:
+            return
+        self._append_log_message(message)
+        self.statusBar().showMessage(message[:100])
+        self.progress_bar.setToolTip(message)
+
+    @_qt_slot(object)
+    def _on_summary_partial_update(self, payload: object) -> None:
+        logger.debug("Aggiornamento sintesi AI: %s", payload)
+
+    @_qt_slot(object, object)
+    def _on_summary_completed(
+        self, session: ApplySession, summary_obj: object
+    ) -> None:
+        self._summary_worker = None
+        summary = cast(Optional[AISummary], summary_obj)
+        self._merge_session_summary(session, summary)
+        self._pending_summary_session = None
+        self._finalize_session(session)
+
+    @_qt_slot(object, str)
+    def _on_summary_failed(self, session: ApplySession, message: str) -> None:
+        self._summary_worker = None
+        session.summary_error = message or _("Errore durante la generazione della sintesi AI")
+        logger.warning("Sintesi AI fallita: %s", session.summary_error)
+        self._pending_summary_session = None
+        self._finalize_session(session)
+
+    @_qt_slot(object)
+    def _on_summary_cancelled(self, session: ApplySession) -> None:
+        self._summary_worker = None
+        if not session.summary_error:
+            session.summary_error = _("Sintesi AI annullata")
+        logger.info("Sintesi AI annullata")
+        self._pending_summary_session = None
+        self._finalize_session(session)
+
+    def _merge_session_summary(
+        self, session: ApplySession, summary: Optional[AISummary]
+    ) -> None:
+        if summary is None:
+            return
+        session.ai_summary = summary.overall
+        session.file_summaries = summary.per_file
+        if summary.per_file:
+            for fr in session.results:
+                fr.ai_summary = None
+                candidate_keys = [fr.relative_to_root, str(fr.file_path)]
+                for key in candidate_keys:
+                    if key and key in summary.per_file:
+                        fr.ai_summary = summary.per_file[key]
+                        break
+
+    def _finalize_session(self, session: ApplySession) -> None:
         write_session_reports(
             session,
             report_json=None,
             report_txt=None,
             enable_reports=self.app_config.write_reports,
         )
+
+        if session.summary_cache_hit is True:
+            cache_message = _("Sintesi AI recuperata dalla cache (chiave {key}).").format(
+                key=session.summary_cache_key or "-"
+            )
+            logger.info(cache_message)
+            self._append_log_message(cache_message)
+        elif session.summary_cache_hit is False:
+            duration = session.summary_duration or 0.0
+            generation_message = _("Sintesi AI generata in {seconds:.2f}s.").format(
+                seconds=duration
+            )
+            logger.info(generation_message)
+            self._append_log_message(generation_message)
+
         if session.ai_summary:
             text = _("Sintesi AI: {text}").format(text=session.ai_summary)
             logger.info(text)
@@ -2115,8 +2291,22 @@ class MainWindow(_QMainWindowBase):
                 )
                 logger.info(detail)
                 self._append_log_message(detail)
+
+        if session.summary_error:
+            error_message = _("Sintesi AI non disponibile: {error}").format(
+                error=session.summary_error
+            )
+            logger.info(error_message)
+            self._append_log_message(error_message)
+            QtWidgets.QMessageBox.warning(
+                self,
+                _("Sintesi AI non disponibile"),
+                error_message,
+            )
+
         logger.info(_("\n=== RISULTATO ===\n%s"), session.to_txt())
         self._set_busy(False)
+        self.progress_bar.setRange(0, 100)
         self.progress_bar.setValue(100)
         self.progress_bar.setVisible(False)
         self.progress_bar.setToolTip("")
@@ -2138,16 +2328,7 @@ class MainWindow(_QMainWindowBase):
             completion_message,
         )
         self.statusBar().showMessage(_("Operazione completata"))
-
-    @_qt_slot(str)
-    def _on_worker_error(self, message: str) -> None:  # pragma: no cover - UI feedback
-        logger.error(_("Errore durante l'applicazione della patch: %s"), message)
-        self._set_busy(False)
-        self._current_worker = None
-        self.progress_bar.setVisible(False)
-        self.progress_bar.setToolTip("")
-        QtWidgets.QMessageBox.critical(self, _("Errore"), message)
-        self.statusBar().showMessage(_("Errore durante l'applicazione della patch"))
+        self._pending_summary_session = None
 
     @_qt_slot(str, object)
     def _on_worker_request_file_choice(

--- a/patch_gui/executor.py
+++ b/patch_gui/executor.py
@@ -16,7 +16,7 @@ from unidiff import PatchSet
 from unidiff.errors import UnidiffParseError
 
 from .ai_candidate_selector import AISuggestion, rank_candidates
-from .ai_summaries import generate_session_summary
+from .ai_summaries import compute_diff_digest, generate_session_summary
 from .config import AppConfig, load_config
 from .filetypes import inspect_file_type
 from .localization import gettext as _
@@ -239,6 +239,7 @@ def apply_patchset(
         exclude_dirs=resolved_excludes,
         started_at=started_at,
     )
+    session.summary_diff_digest = compute_diff_digest(patch)
 
     effective_interactive = interactive or auto_accept
 

--- a/patch_gui/patcher.py
+++ b/patch_gui/patcher.py
@@ -125,6 +125,12 @@ class ApplySession:
     file_summaries: dict[str, str] = field(default_factory=dict)
     file_index: Optional[FileIndex] = None
     lookup_metrics: FileLookupMetrics = field(default_factory=FileLookupMetrics)
+    summary_diff_digest: Optional[str] = None
+    summary_cache_key: Optional[str] = None
+    summary_cache_hit: Optional[bool] = None
+    summary_generated_at: Optional[float] = None
+    summary_duration: Optional[float] = None
+    summary_error: Optional[str] = None
 
     def ensure_index(self) -> FileIndex:
         if self.file_index is None:
@@ -141,6 +147,12 @@ class ApplySession:
             "started_at": datetime.fromtimestamp(self.started_at).isoformat(),
             "ai_summary": self.ai_summary,
             "file_summaries": self.file_summaries,
+            "summary_diff_digest": self.summary_diff_digest,
+            "summary_cache_key": self.summary_cache_key,
+            "summary_cache_hit": self.summary_cache_hit,
+            "summary_generated_at": self.summary_generated_at,
+            "summary_duration": self.summary_duration,
+            "summary_error": self.summary_error,
             "files": [
                 {
                     "file": fr.relative_to_root,

--- a/tests/test_ai_summaries.py
+++ b/tests/test_ai_summaries.py
@@ -1,0 +1,147 @@
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from patch_gui.ai_summaries import AISummary, generate_session_summary
+from patch_gui.patcher import ApplySession
+
+try:  # pragma: no cover - optional dependency
+    from PySide6 import QtWidgets as _QtWidgets
+except Exception as exc:  # pragma: no cover - PySide6 missing in environment
+    QtWidgets: Any | None = None
+    _QT_IMPORT_ERROR: Exception | None = exc
+else:  # pragma: no cover - executed when bindings are available
+    QtWidgets = _QtWidgets
+    _QT_IMPORT_ERROR = None
+
+
+def _build_session(tmp_path: Path) -> ApplySession:
+    backup_dir = tmp_path / "backups"
+    backup_dir.mkdir(exist_ok=True)
+    session = ApplySession(
+        project_root=tmp_path,
+        backup_dir=backup_dir,
+        dry_run=True,
+        threshold=0.9,
+        started_at=1234.5,
+    )
+    return session
+
+
+def test_generate_session_summary_uses_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    import patch_gui.ai_summaries as summaries_module
+
+    monkeypatch.setattr(summaries_module, "_SUMMARY_CACHE", {})
+
+    calls: list[dict[str, object]] = []
+
+    def fake_call(payload: dict[str, object], *, timeout: float) -> dict[str, object]:
+        calls.append(payload)
+        return {
+            "summary": "Overall text",
+            "files": {"file.txt": "File level summary"},
+        }
+
+    monkeypatch.setattr(summaries_module, "_call_summary_service", fake_call)
+
+    session_a = _build_session(tmp_path)
+    session_a.summary_diff_digest = "digest"
+    summary_a = generate_session_summary(session_a)
+
+    assert summary_a is not None
+    assert summary_a.overall == "Overall text"
+    assert session_a.summary_cache_hit is False
+    assert session_a.summary_duration is not None
+    assert calls and calls[0]["project_root"] == str(tmp_path)
+
+    session_b = _build_session(tmp_path)
+    session_b.summary_diff_digest = "digest"
+    summary_b = generate_session_summary(session_b)
+
+    assert summary_b is not None
+    assert summary_b.overall == "Overall text"
+    assert session_b.summary_cache_hit is True
+    assert session_b.summary_duration == 0.0
+    assert len(calls) == 1
+
+
+@pytest.fixture()  # type: ignore[misc]
+def qt_app() -> Any:
+    if QtWidgets is None:  # pragma: no cover - PySide6 missing
+        pytest.skip(f"PySide6 non disponibile: {_QT_IMPORT_ERROR}")
+
+    assert QtWidgets is not None
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    return app
+
+
+def test_ai_summary_worker_non_blocking(
+    qt_app: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from patch_gui import app as app_module
+
+    session = _build_session(tmp_path)
+    session.summary_diff_digest = "digest"
+
+    start_event = threading.Event()
+    release_event = threading.Event()
+    done_event = threading.Event()
+    thread_name: dict[str, str] = {}
+    results: dict[str, Any] = {}
+    errors: dict[str, Any] = {}
+
+    def fake_generate(
+        session_arg: ApplySession,
+        *,
+        use_cache: bool = True,
+        timeout: float = 15.0,
+        hooks: Any | None = None,
+    ) -> AISummary:
+        thread_name["name"] = threading.current_thread().name
+        if hooks is not None and hooks.on_start is not None:
+            hooks.on_start({})
+        start_event.set()
+        release_event.wait(1.0)
+        summary = AISummary(overall="Completato", per_file={})
+        if hooks is not None and hooks.on_complete is not None:
+            hooks.on_complete(summary, False)
+        return summary
+
+    monkeypatch.setattr(app_module, "generate_session_summary", fake_generate)
+
+    worker = app_module.AISummaryWorker(session)
+
+    def handle_completed(session_arg: ApplySession, summary_obj: object) -> None:
+        results["summary"] = summary_obj
+        done_event.set()
+
+    def handle_failed(session_arg: ApplySession, message: str) -> None:
+        errors["message"] = message
+        done_event.set()
+
+    worker.completed.connect(handle_completed)
+    worker.failed.connect(handle_failed)
+    worker.start()
+
+    assert start_event.wait(1.0)
+    assert thread_name.get("name") and thread_name["name"] != threading.current_thread().name
+    assert "summary" not in results
+
+    release_event.set()
+
+    deadline = time.time() + 2.0
+    while not done_event.is_set() and time.time() < deadline:
+        qt_app.processEvents()
+        time.sleep(0.01)
+
+    worker.wait(1000)
+
+    assert done_event.is_set()
+    assert not errors
+    assert isinstance(results.get("summary"), AISummary)
+    assert results["summary"].overall == "Completato"


### PR DESCRIPTION
## Summary
- introduce cache-aware AI summary generation with digest helpers and streaming hooks
- add an AISummaryWorker to fetch summaries asynchronously and update the GUI when ready while preserving session metadata
- record cache metadata on ApplySession and cover the behaviour with new unit tests

## Testing
- pytest
- pytest tests/test_ai_summaries.py

------
https://chatgpt.com/codex/tasks/task_e_68cd331daf40832690a5840fd39ffc4d