### PR TITLE
Add theme manager and responsive palette support

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -98,3 +98,12 @@ Se vuoi operare su un file alternativo (per test o ambienti portabili) aggiungi 
 - Per applicare automaticamente il suggerimento migliore quando viene richiesta una scelta manuale usa la spunta *Applica il suggerimento AI senza chiedere* nella GUI o la flag `--ai-select` in CLI.
 - Il servizio AI utilizza l'endpoint configurato tramite la variabile d'ambiente `PATCH_GUI_AI_ENDPOINT` (opzionalmente con token `PATCH_GUI_AI_TOKEN`). Se non è disponibile, il programma ricade su una valutazione locale basata sulla similarità del testo.
 - Quando nessun candidato viene applicato automaticamente, CLI e GUI mostrano comunque un messaggio esplicativo e un diff copiabile per facilitare l'intervento manuale: le informazioni sono incluse anche nei report generati.
+
+## QA manuale: cambio tema
+
+1. Avvia l'applicazione e apri **Impostazioni → Preferenze…**.
+2. Nella sezione *Tema* alterna tra **Scuro** e **Chiaro** verificando che:
+   - lo sfondo generale della finestra e i testi cambino tonalità;
+   - le icone della toolbar e il pulsante **Carica diff** adottino i nuovi colori.
+3. Conferma un tema, riapri le preferenze e passa a **Alto contrasto**: gli editor diff (incluso il tab *Diff interattivo*) devono evidenziare aggiunte/rimozioni con tinte coerenti e facilmente leggibili.
+4. Ripristina l'opzione **Automatico**, salva e riavvia l'app: il tema selezionato in precedenza deve essere applicato all'avvio.

--- a/patch_gui/highlighter.py
+++ b/patch_gui/highlighter.py
@@ -124,6 +124,16 @@ class DiffHighlighter(_QSyntaxHighlighter):
         self._meta_format.setFontItalic(True)
         self.set_palette(palette or DEFAULT_DIFF_PALETTE)
 
+    def set_qpalette(self, palette: QtGui.QPalette | None) -> DiffHighlightPalette:
+        """Derive colours from ``palette`` and apply them."""
+
+        if palette is None:
+            applied = DEFAULT_DIFF_PALETTE
+        else:
+            applied = build_diff_highlight_palette(palette)
+        self.set_palette(applied)
+        return applied
+
     def set_palette(self, palette: DiffHighlightPalette) -> None:
         """Update the highlight colours used by the highlighter."""
 

--- a/tests/test_diff_applier_gui.py
+++ b/tests/test_diff_applier_gui.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 import pytest
 
 from patch_gui import diff_applier_gui
-from patch_gui.config import AppConfig
+from patch_gui.config import AppConfig, Theme
 from tests._pytest_typing import typed_fixture, typed_parametrize
 
 try:  # pragma: no cover - environment-dependent
@@ -170,6 +170,7 @@ def test_settings_dialog_gathers_config(qt_app: Any, tmp_path: Path) -> None:
     dialog.backup_retention_edit.setText("7")
     dialog.ai_assistant_check.setChecked(False)
     dialog.ai_auto_check.setChecked(True)
+    dialog.theme_buttons[Theme.LIGHT].setChecked(True)
 
     updated = dialog._gather_config()
 
@@ -178,6 +179,7 @@ def test_settings_dialog_gathers_config(qt_app: Any, tmp_path: Path) -> None:
     assert updated.backup_base == new_backup
     assert updated.log_level == "debug"
     assert updated.dry_run_default is False
+    assert updated.theme is Theme.LIGHT
     assert updated.write_reports is False
     assert updated.log_file == new_log_file
     assert updated.log_max_bytes == 8192


### PR DESCRIPTION
## Summary
- add a ThemeManager with snapshot broadcasting and hook apply_modern_theme to it
- refresh the settings UI with theme toggle buttons and update app icons/brand colours when the palette changes
- make interactive diff and split diff views pull colours from the active palette and react to theme switches
- document a manual QA checklist and extend tests for theme selection

## Testing
- pytest tests/test_theme.py tests/test_diff_applier_gui.py tests/test_interactive_diff_widget.py

------
https://chatgpt.com/codex/tasks/task_e_68cd46989b4083269fb8bfc921727483