### PR TITLE
Introduce pluggable matching strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ utili:
 - `--apply`: forza l'applicazione reale anche se la configurazione predefinisce il
   dry-run.
 - `--threshold`: regola la tolleranza fuzzy (default `0.85`).
+- `--rapidfuzz` / `--no-rapidfuzz`: abilita il matcher basato su `rapidfuzz`
+  (quando installato) oppure forza il fallback legacy `difflib`.
+- `--anchors` / `--no-anchors`: controlla l'uso delle ancore strutturali per
+  ridurre il numero di confronti nelle ricerche dei candidati.
 - `--backup`: directory personalizzata per backup e report.
 - `--config-path`: usa un file di configurazione alternativo per i default.
 - `--report-json` / `--report-txt`: percorsi espliciti per i report.

--- a/USAGE.md
+++ b/USAGE.md
@@ -40,6 +40,7 @@ Questa guida passo‑passo descrive il workflow tipico per applicare una patch c
 4. **Configura l'esecuzione**
    - La modalità **Dry‑run** è abilitata di default e consente di simulare l'applicazione senza modificare i file.
    - Imposta la **Soglia fuzzy** (es. `0.85`) per controllare la tolleranza nel matching del contesto. I valori validi sono maggiori di 0 e non superano 1.
+   - Le caselle di controllo *Rapidfuzz* e *Ancora* accanto alla soglia consentono di abilitare il matcher ottimizzato e le ancore strutturali anche dalla GUI (default: entrambe attive se `rapidfuzz` è disponibile).
 5. **Applica la patch**
    - Con Dry‑run attivo clicca **Applica patch** per vedere l'anteprima dei risultati.
    - Quando sei soddisfatto, disattiva Dry‑run e premi nuovamente **Applica patch** per modificare realmente i file.

--- a/patch_gui/ai_summaries.py
+++ b/patch_gui/ai_summaries.py
@@ -93,7 +93,16 @@ def _build_payload(session: ApplySession) -> dict[str, object]:
             }
             candidates = decision.candidates[:_MAX_CANDIDATES_PER_DECISION]
             if candidates:
-                entry["candidates"] = [list(candidate) for candidate in candidates]
+                entry["candidates"] = [
+                    {
+                        "position": candidate.position,
+                        "score": candidate.score,
+                        "metadata": dict(candidate.metadata),
+                    }
+                    for candidate in candidates
+                ]
+            if decision.matching_metadata:
+                entry["matching_metadata"] = dict(decision.matching_metadata)
             if decision.ai_explanation:
                 entry["ai_explanation"] = decision.ai_explanation
             decisions.append(entry)

--- a/patch_gui/app.py
+++ b/patch_gui/app.py
@@ -40,9 +40,11 @@ from .theme import apply_modern_theme
 from .logging_utils import configure_logging
 from .patcher import (
     ApplySession,
+    CandidateMatch,
     FileResult,
     HunkDecision,
     HunkView,
+    MatchingOptions,
     apply_hunks,
     backup_file,
     build_hunk_view as patcher_build_hunk_view,
@@ -543,7 +545,7 @@ class CandidateDialog(_QDialogBase):
         self,
         parent: QtWidgets.QWidget | None,
         file_text: str,
-        candidates: List[Tuple[int, float]],
+        candidates: List[CandidateMatch],
         hv: HunkView,
         *,
         ai_hint: AISuggestion | None = None,
@@ -558,6 +560,7 @@ class CandidateDialog(_QDialogBase):
         self.ai_hint: AISuggestion | None = ai_hint
         self.assistant_message = assistant_message
         self.assistant_patch = assistant_patch
+        self._candidates = candidates
 
         layout = QtWidgets.QVBoxLayout(self)
 
@@ -668,12 +671,17 @@ class CandidateDialog(_QDialogBase):
         left = QtWidgets.QWidget()
         left_layout = QtWidgets.QVBoxLayout(left)
         self.list: QtWidgets.QListWidget = QtWidgets.QListWidget()
-        for pos, score in candidates:
-            label = _("Linea {line} – similarità {score:.3f}").format(
-                line=pos + 1, score=score
+        for candidate in candidates:
+            anchor_note = ""
+            if candidate.metadata.get("derived_from_anchor"):
+                anchor_note = _(" – ancora")
+            label = _("Linea {line} – similarità {score:.3f}{anchor}").format(
+                line=candidate.position + 1,
+                score=candidate.score,
+                anchor=anchor_note,
             )
             item = QtWidgets.QListWidgetItem(label)
-            item.setData(QtCore.Qt.ItemDataRole.UserRole, pos)
+            item.setData(QtCore.Qt.ItemDataRole.UserRole, candidate.position)
             self.list.addItem(item)
         if self.ai_hint is not None:
             index = self.ai_hint.candidate_index - 1
@@ -714,7 +722,8 @@ class CandidateDialog(_QDialogBase):
             row = self.list.currentRow()
             if row < 0:
                 return
-            pos, _ = candidates[row]
+            candidate = candidates[row]
+            pos = candidate.position
             file_lines = file_text.splitlines(keepends=True)
             start = max(0, pos - 15)
             end = min(len(file_lines), pos + len(hv.before_lines) + 15)
@@ -833,6 +842,14 @@ class SettingsDialog(_QDialogBase):
         self.threshold_spin.setDecimals(2)
         self.threshold_spin.setValue(self._original_config.threshold)
         form.addRow(_("Soglia fuzzy"), self.threshold_spin)
+
+        self.rapidfuzz_check = QtWidgets.QCheckBox(_("Usa matcher rapidfuzz"))
+        self.rapidfuzz_check.setChecked(self._original_config.use_rapidfuzz_matcher)
+        form.addRow("", self.rapidfuzz_check)
+
+        self.anchors_check = QtWidgets.QCheckBox(_("Usa ancore strutturali"))
+        self.anchors_check.setChecked(self._original_config.use_structural_anchors)
+        form.addRow("", self.anchors_check)
 
         self.exclude_edit = QtWidgets.QLineEdit(
             ", ".join(self._original_config.exclude_dirs)
@@ -1023,6 +1040,8 @@ class SettingsDialog(_QDialogBase):
             ai_assistant_enabled=self.ai_assistant_check.isChecked(),
             ai_auto_apply=self.ai_auto_check.isChecked(),
             ai_diff_notes_enabled=self.ai_diff_notes_check.isChecked(),
+            use_rapidfuzz_matcher=self.rapidfuzz_check.isChecked(),
+            use_structural_anchors=self.anchors_check.isChecked(),
         )
 
     @staticmethod
@@ -1224,6 +1243,7 @@ class PatchApplyWorker(_QThreadBase):
             lines,
             pf,
             threshold=self.session.threshold,
+            matching_options=self.session.matching_options,
             manual_resolver=self._resolve_hunk_choice,
         )
 
@@ -1275,7 +1295,7 @@ class PatchApplyWorker(_QThreadBase):
         self,
         hv: HunkView,
         lines: List[str],
-        candidates: List[Tuple[int, float]],
+        candidates: List[CandidateMatch],
         ai_hint: AISuggestion | None,
         assistant_message: str | None,
         assistant_patch: str | None,
@@ -1293,7 +1313,7 @@ class PatchApplyWorker(_QThreadBase):
         self,
         hv: HunkView,
         lines: List[str],
-        candidates: List[Tuple[int, float]],
+        candidates: List[CandidateMatch],
         decision: HunkDecision,
         reason: str,
         original_diff: str,
@@ -1641,6 +1661,21 @@ class MainWindow(_QMainWindowBase):
         self.spin_thresh.setDecimals(2)
         self.spin_thresh.setValue(self.threshold)
         second.addWidget(self.spin_thresh)
+
+        second.addSpacing(12)
+        self.chk_rapidfuzz = QtWidgets.QCheckBox(_("Rapidfuzz"))
+        self.chk_rapidfuzz.setToolTip(
+            _("Abilita il matcher basato su rapidfuzz quando disponibile.")
+        )
+        self.chk_rapidfuzz.setChecked(self.app_config.use_rapidfuzz_matcher)
+        second.addWidget(self.chk_rapidfuzz)
+
+        self.chk_anchors = QtWidgets.QCheckBox(_("Ancore"))
+        self.chk_anchors.setToolTip(
+            _("Utilizza ancore strutturali per velocizzare la ricerca delle posizioni.")
+        )
+        self.chk_anchors.setChecked(self.app_config.use_structural_anchors)
+        second.addWidget(self.chk_anchors)
 
         second.addSpacing(20)
         second.addWidget(QtWidgets.QLabel(_("Ignora directory")))
@@ -2217,6 +2252,8 @@ class MainWindow(_QMainWindowBase):
         self.app_config.ai_assistant_enabled = self.ai_assistant_enabled
         self.app_config.ai_auto_apply = self.ai_auto_apply
         self.app_config.ai_diff_notes_enabled = self.ai_diff_notes_enabled
+        self.app_config.use_rapidfuzz_matcher = self.chk_rapidfuzz.isChecked()
+        self.app_config.use_structural_anchors = self.chk_anchors.isChecked()
         self.threshold = self.app_config.threshold
         self.exclude_dirs = self.app_config.exclude_dirs
         self.reports_enabled = self.app_config.write_reports
@@ -2414,6 +2451,8 @@ class MainWindow(_QMainWindowBase):
             widget.setEnabled(not busy)
         self.chk_dry.setEnabled(not busy)
         self.spin_thresh.setEnabled(not busy)
+        self.chk_rapidfuzz.setEnabled(not busy)
+        self.chk_anchors.setEnabled(not busy)
         self.text_diff.setReadOnly(busy)
 
     def apply_patch(self) -> None:
@@ -2472,6 +2511,10 @@ class MainWindow(_QMainWindowBase):
             threshold=thr,
             exclude_dirs=excludes,
             started_at=started_at,
+            matching_options=MatchingOptions(
+                use_rapidfuzz=self.chk_rapidfuzz.isChecked(),
+                enable_structural_anchors=self.chk_anchors.isChecked(),
+            ),
         )
         session.summary_diff_digest = compute_diff_digest(self.patch)
         worker = PatchApplyWorker(
@@ -2697,7 +2740,7 @@ class MainWindow(_QMainWindowBase):
     def _on_worker_request_hunk_choice(
         self,
         file_text: str,
-        candidates: List[Tuple[int, float]],
+        candidates: List[CandidateMatch],
         hv: HunkView,
         ai_hint: AISuggestion | None,
         assistant_message: str | None,
@@ -2787,6 +2830,7 @@ class MainWindow(_QMainWindowBase):
             lines,
             pf,
             threshold=session.threshold,
+            matching_options=session.matching_options,
             manual_resolver=self._dialog_hunk_choice,
         )
 
@@ -2804,7 +2848,7 @@ class MainWindow(_QMainWindowBase):
         self,
         hv: HunkView,
         lines: List[str],
-        candidates: List[Tuple[int, float]],
+        candidates: List[CandidateMatch],
         decision: HunkDecision,
         reason: str,
         original_diff: str,

--- a/patch_gui/cli.py
+++ b/patch_gui/cli.py
@@ -198,6 +198,8 @@ def run_cli(argv: Sequence[str] | None = None) -> int:
             Path(args.root),
             dry_run=args.dry_run,
             threshold=args.threshold,
+            use_rapidfuzz=args.use_rapidfuzz,
+            use_structural_anchors=args.use_structural_anchors,
             backup_base=backup_base,
             interactive=interactive,
             auto_accept=args.auto_accept,

--- a/patch_gui/config.py
+++ b/patch_gui/config.py
@@ -107,6 +107,8 @@ class AppConfig:
     ai_assistant_enabled: bool = _DEFAULT_AI_ASSISTANT
     ai_auto_apply: bool = _DEFAULT_AI_AUTO_APPLY
     ai_diff_notes_enabled: bool = _DEFAULT_AI_DIFF_NOTES
+    use_rapidfuzz_matcher: bool = True
+    use_structural_anchors: bool = True
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any]) -> "AppConfig":
@@ -140,6 +142,12 @@ class AppConfig:
         ai_diff_notes = _coerce_bool(
             data.get("ai_diff_notes_enabled"), base.ai_diff_notes_enabled
         )
+        use_rapidfuzz = _coerce_bool(
+            data.get("use_rapidfuzz_matcher"), base.use_rapidfuzz_matcher
+        )
+        use_anchors = _coerce_bool(
+            data.get("use_structural_anchors"), base.use_structural_anchors
+        )
 
         return cls(
             threshold=threshold,
@@ -156,6 +164,8 @@ class AppConfig:
             ai_assistant_enabled=ai_enabled,
             ai_auto_apply=ai_auto_apply,
             ai_diff_notes_enabled=ai_diff_notes,
+            use_rapidfuzz_matcher=use_rapidfuzz,
+            use_structural_anchors=use_anchors,
         )
 
     def to_mapping(self) -> MutableMapping[str, Any]:
@@ -176,6 +186,8 @@ class AppConfig:
             "ai_assistant_enabled": bool(self.ai_assistant_enabled),
             "ai_auto_apply": bool(self.ai_auto_apply),
             "ai_diff_notes_enabled": bool(self.ai_diff_notes_enabled),
+            "use_rapidfuzz_matcher": bool(self.use_rapidfuzz_matcher),
+            "use_structural_anchors": bool(self.use_structural_anchors),
         }
 
 

--- a/patch_gui/matching.py
+++ b/patch_gui/matching.py
@@ -1,0 +1,204 @@
+"""Candidate matching strategies for locating hunk positions in target files."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from difflib import SequenceMatcher
+from typing import Iterable, Mapping, MutableMapping, Sequence
+
+
+logger = logging.getLogger(__name__)
+
+
+try:  # pragma: no cover - exercised via runtime environment
+    from rapidfuzz.distance import Levenshtein  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    Levenshtein = None  # type: ignore
+
+
+@dataclass(slots=True, frozen=True)
+class CandidateMatch:
+    """Representation of a candidate position in the target file."""
+
+    position: int
+    score: float
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class MatchingOptions:
+    """Configuration toggles for the matching strategy."""
+
+    use_rapidfuzz: bool = True
+    enable_structural_anchors: bool = True
+    max_anchor_lines: int = 4
+
+
+@dataclass(slots=True)
+class MatchingResult:
+    """Return value for :func:`find_candidates`."""
+
+    candidates: list[CandidateMatch]
+    metadata: MutableMapping[str, object]
+
+
+def _select_anchor_offsets(before_lines: Sequence[str], max_anchor_lines: int) -> list[int]:
+    """Return offsets within ``before_lines`` that are good anchor candidates."""
+
+    offsets: list[int] = []
+    seen: dict[str, int] = {}
+    for line in before_lines:
+        seen[line] = seen.get(line, 0) + 1
+
+    for offset, raw_line in enumerate(before_lines):
+        line = raw_line.strip()
+        if not line:
+            continue
+        if seen[raw_line] > 1 and not (
+            line.endswith(":")
+            or line.startswith("def ")
+            or line.startswith("class ")
+            or line.startswith("if ")
+            or line.startswith("for ")
+            or line.startswith("while ")
+        ):
+            continue
+        offsets.append(offset)
+        if len(offsets) >= max_anchor_lines:
+            break
+    return offsets
+
+
+def _collect_anchor_positions(
+    file_lines: Sequence[str],
+    before_lines: Sequence[str],
+    offsets: Iterable[int],
+) -> tuple[set[int], int]:
+    """Return candidate start positions based on matching anchor lines."""
+
+    positions: set[int] = set()
+    hits = 0
+    if not offsets:
+        return positions, hits
+
+    line_index: dict[str, list[int]] = {}
+    for idx, line in enumerate(file_lines):
+        line_index.setdefault(line, []).append(idx)
+
+    window_len = len(before_lines)
+    for anchor_offset in offsets:
+        anchor_line = before_lines[anchor_offset]
+        indices = line_index.get(anchor_line)
+        if not indices:
+            continue
+        hits += 1
+        for index in indices:
+            start = index - anchor_offset
+            if start < 0:
+                continue
+            if start + window_len > len(file_lines):
+                continue
+            positions.add(start)
+    return positions, hits
+
+
+def _legacy_similarity(a: str, b: str) -> float:
+    """Fallback similarity score using :mod:`difflib`."""
+
+    return SequenceMatcher(None, a, b).ratio()
+
+
+def _rapidfuzz_similarity(a: str, b: str) -> float:
+    if Levenshtein is None:
+        return _legacy_similarity(a, b)
+    return float(Levenshtein.normalized_similarity(a, b))
+
+
+def find_candidates(
+    file_lines: Sequence[str],
+    before_lines: Sequence[str],
+    threshold: float,
+    options: MatchingOptions | None = None,
+) -> MatchingResult:
+    """Return candidate windows that meet ``threshold``.
+
+    The return value includes both the candidates and metadata describing
+    the work performed (number of windows scored, anchor usage, etc.).
+    """
+
+    opts = options or MatchingOptions()
+    metadata: MutableMapping[str, object] = {
+        "engine": "rapidfuzz" if opts.use_rapidfuzz and Levenshtein is not None else "difflib",
+        "anchor_hits": 0,
+        "total_windows": 0,
+        "scored_windows": 0,
+        "candidate_windows": 0,
+    }
+
+    if not before_lines:
+        logger.debug("Skipping candidate search: empty 'before' block")
+        return MatchingResult([], metadata)
+
+    window_len = len(before_lines)
+    if window_len == 0 or window_len > len(file_lines):
+        return MatchingResult([], metadata)
+
+    target_text = "".join(before_lines)
+    total_windows = len(file_lines) - window_len + 1
+    metadata["total_windows"] = max(total_windows, 0)
+
+    scorer = _rapidfuzz_similarity if opts.use_rapidfuzz else _legacy_similarity
+    if scorer is _rapidfuzz_similarity and Levenshtein is None:
+        metadata["engine"] = "difflib"
+    elif scorer is _rapidfuzz_similarity:
+        metadata["engine"] = "rapidfuzz"
+
+    candidate_positions: set[int] = set()
+    anchor_offsets: list[int] = []
+    anchor_positions: set[int] = set()
+    if opts.enable_structural_anchors and window_len > 1:
+        anchor_offsets = _select_anchor_offsets(before_lines, opts.max_anchor_lines)
+        positions, hits = _collect_anchor_positions(file_lines, before_lines, anchor_offsets)
+        candidate_positions |= positions
+        anchor_positions |= positions
+        metadata["anchor_hits"] = hits
+
+    if not candidate_positions:
+        candidate_positions = set(range(0, total_windows))
+    metadata["candidate_windows"] = len(candidate_positions)
+
+    ordered_positions = sorted(candidate_positions)
+    candidates: list[CandidateMatch] = []
+
+    # First check for exact matches to short-circuit fuzzy scoring when possible.
+    before_slice = list(before_lines)
+    for pos in ordered_positions:
+        if file_lines[pos : pos + window_len] == before_slice:
+            candidate = CandidateMatch(
+                position=pos,
+                score=1.0,
+                metadata={"exact": True, "derived_from_anchor": pos in anchor_positions},
+            )
+            logger.debug("Exact candidate found at position %d", pos)
+            return MatchingResult([candidate], metadata)
+
+    for pos in ordered_positions:
+        window_text = "".join(file_lines[pos : pos + window_len])
+        score = scorer(window_text, target_text)
+        metadata["scored_windows"] = int(metadata["scored_windows"]) + 1
+        if score >= threshold:
+            candidate_metadata: dict[str, object] = {"derived_from_anchor": pos in anchor_positions}
+            candidates.append(CandidateMatch(position=pos, score=score, metadata=candidate_metadata))
+
+    candidates.sort(key=lambda c: (-c.score, c.position))
+    return MatchingResult(candidates, metadata)
+
+
+__all__ = [
+    "CandidateMatch",
+    "MatchingOptions",
+    "MatchingResult",
+    "find_candidates",
+]
+

--- a/patch_gui/parser.py
+++ b/patch_gui/parser.py
@@ -115,6 +115,32 @@ def build_parser(
         help=_("Matching threshold (0-1) for fuzzy context alignment."),
     )
     parser.add_argument(
+        "--rapidfuzz",
+        dest="use_rapidfuzz",
+        action="store_true",
+        default=resolved_config.use_rapidfuzz_matcher,
+        help=_("Enable the rapidfuzz-based matcher when available."),
+    )
+    parser.add_argument(
+        "--no-rapidfuzz",
+        dest="use_rapidfuzz",
+        action="store_false",
+        help=_("Force the legacy difflib matcher even if rapidfuzz is installed."),
+    )
+    parser.add_argument(
+        "--no-anchors",
+        dest="use_structural_anchors",
+        action="store_false",
+        default=resolved_config.use_structural_anchors,
+        help=_("Disable structural anchors when searching for candidates."),
+    )
+    parser.add_argument(
+        "--anchors",
+        dest="use_structural_anchors",
+        action="store_true",
+        help=_("Enable structural anchors to speed up candidate search."),
+    )
+    parser.add_argument(
         "--backup",
         help=_('Base directory for backups and reports; defaults to "{path}".').format(
             path=display_path(resolved_config.backup_base)


### PR DESCRIPTION
## Summary
- add a patch_gui.matching module that encapsulates candidate scoring, anchor heuristics, and returns CandidateMatch metadata
- thread the new strategy through the patcher, executor, CLI/GUI, and AI flows so manual resolutions and reports keep richer candidate details
- document the rapidfuzz/anchor controls and extend regression tests for deterministic matching and anchor performance

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cd46889fbc8326bd81e103aeb1eabf