### PR TITLE
Improve candidate selection dialog and matching fallbacks

### DIFF
--- a/patch_gui/binary_patch.py
+++ b/patch_gui/binary_patch.py
@@ -3,14 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Iterable, List, Mapping, Optional, Tuple
+from typing import Dict, Iterable, List, Mapping, Optional, Tuple, Literal
 
 import zlib
-
-try:  # pragma: no cover - optional typing import
-    from typing import Literal
-except ImportError:  # pragma: no cover - Python < 3.8 fallback
-    Literal = str  # type: ignore[misc,assignment]
 
 try:  # pragma: no cover - optional typing import
     from unidiff.patch import PatchedFile
@@ -106,9 +101,7 @@ class _BinaryHunk:
             ) from exc
         if len(data) != self.expected_size:
             raise BinaryPatchError(
-                _(
-                    "Binary %s hunk expected %d bytes after decompressing but got %d"
-                )
+                _("Binary %s hunk expected %d bytes after decompressing but got %d")
                 % (self.method, self.expected_size, len(data))
             )
         return data
@@ -169,7 +162,9 @@ def _normalize(value: Optional[str]) -> Optional[str]:
     return cleaned or None
 
 
-def _parse_binary_blocks(raw_text: str) -> Dict[Tuple[Optional[str], Optional[str]], BinaryPatchData]:
+def _parse_binary_blocks(
+    raw_text: str,
+) -> Dict[Tuple[Optional[str], Optional[str]], BinaryPatchData]:
     lines = raw_text.splitlines()
     mapping: Dict[Tuple[Optional[str], Optional[str]], BinaryPatchData] = {}
     current_key: Tuple[Optional[str], Optional[str]] | None = None
@@ -212,7 +207,11 @@ def _parse_binary_blocks(raw_text: str) -> Dict[Tuple[Optional[str], Optional[st
                         encoded.append(lines[idx])
                         idx += 1
                     hunks.append(
-                        _BinaryHunk(method=method, expected_size=expected_size, encoded_lines=tuple(encoded))
+                        _BinaryHunk(
+                            method=method,
+                            expected_size=expected_size,
+                            encoded_lines=tuple(encoded),
+                        )
                     )
                     while idx < total and not lines[idx]:
                         idx += 1

--- a/patch_gui/split_diff_view.py
+++ b/patch_gui/split_diff_view.py
@@ -93,9 +93,7 @@ class SplitDiffView(QtWidgets.QWidget):  # type: ignore[misc]
         self._scroll_area.setVisible(False)
         self._placeholder.setVisible(False)
 
-    def set_highlight_palette(
-        self, palette: DiffHighlightPalette | None
-    ) -> None:
+    def set_highlight_palette(self, palette: DiffHighlightPalette | None) -> None:
         self._highlighter_palette = palette
         self._header_highlighter.set_palette(palette or DEFAULT_DIFF_PALETTE)
         for widget in self._hunk_widgets:
@@ -211,16 +209,14 @@ class _HunkWidget(QtWidgets.QFrame):  # type: ignore[misc]
         self._button_group.setExclusive(True)
         self._button_group.addButton(self._apply_button, 1)
         self._button_group.addButton(self._skip_button, 0)
-        self._button_group.buttonClicked[int].connect(self._on_button_clicked)
+        self._button_group.idClicked.connect(self._on_button_clicked)
 
         self._columns = _HunkColumns(hunk.annotated_text, highlighter_palette)
         layout.addWidget(self._columns)
 
         self.set_applied(applied)
 
-    def set_highlight_palette(
-        self, palette: DiffHighlightPalette | None
-    ) -> None:
+    def set_highlight_palette(self, palette: DiffHighlightPalette | None) -> None:
         self._palette = palette
         self._columns.set_highlight_palette(palette)
 
@@ -279,9 +275,7 @@ class _HunkColumns(QtWidgets.QWidget):  # type: ignore[misc]
         self.left_editor.verticalScrollBar().valueChanged.connect(self._sync_right)
         self.right_editor.verticalScrollBar().valueChanged.connect(self._sync_left)
 
-    def set_highlight_palette(
-        self, palette: DiffHighlightPalette | None
-    ) -> None:
+    def set_highlight_palette(self, palette: DiffHighlightPalette | None) -> None:
         self._left_highlighter.set_palette(palette or DEFAULT_DIFF_PALETTE)
         self._right_highlighter.set_palette(palette or DEFAULT_DIFF_PALETTE)
 

--- a/scripts/release_automation.py
+++ b/scripts/release_automation.py
@@ -191,10 +191,10 @@ def prune_remote_branches(
         try:
             run_cmd(["git", "push", remote, "--delete", branch], dry_run=dry_run)
         except ReleaseError as error:
-            print(
-                "Impossibile completare l'eliminazione del branch "
-                f"{branch}: {error}"
+            message = (
+                f"Impossibile completare l'eliminazione del branch {branch}: {error}"
             )
+            print(message)
 
 
 def checkout_branch(branch: str, *, dry_run: bool) -> None:
@@ -413,8 +413,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         push_refs(args.remote, f"v{args.version}", dry_run=args.dry_run)
     else:
         print(
-            "[nota] Push saltato: lanciare manualmente '
-            f"git push {args.remote} master' e 'git push {args.remote} v{args.version}'"
+            "[nota] Push saltato: lanciare manualmente "
+            f"'git push {args.remote} master' e 'git push {args.remote} v{args.version}'"
         )
 
     print("==> Allineo develop al commit di release")


### PR DESCRIPTION
## Summary
- refactor the candidate disambiguation dialog to keep track of the inspected windows, refresh previews reliably, and honour AI suggestions only when valid
- keep diff search highlights in sync via the editor textChanged signal instead of an obsolete Qt event
- rework matching fallbacks to avoid missing rapidfuzz, reuse a single SequenceMatcher instance, and probe neighbouring anchor windows; tidy binary patch typing and release messaging

## Testing
- pytest
- ruff check patch_gui/app.py patch_gui/diff_search.py patch_gui/matching.py patch_gui/binary_patch.py patch_gui/split_diff_view.py scripts/release_automation.py
- mypy patch_gui/app.py patch_gui/diff_search.py patch_gui/matching.py patch_gui/binary_patch.py patch_gui/split_diff_view.py scripts/release_automation.py

------
https://chatgpt.com/codex/tasks/task_e_68cd57197ec8832680deee5e4692f773