### PR TITLE
Fix matching configuration and satisfy mypy

### DIFF
--- a/patch_gui/ai_summaries.py
+++ b/patch_gui/ai_summaries.py
@@ -214,7 +214,9 @@ def _cache_key_for_payload(
     if session.summary_diff_digest:
         return session.summary_diff_digest
     try:
-        encoded = json.dumps(payload, sort_keys=True, ensure_ascii=False).encode("utf-8")
+        encoded = json.dumps(payload, sort_keys=True, ensure_ascii=False).encode(
+            "utf-8"
+        )
     except TypeError:  # pragma: no cover - payload contains unserialisable items
         return None
     digest = hashlib.sha256(encoded).hexdigest()
@@ -235,7 +237,10 @@ def _load_cache_entry(cache_key: str) -> Optional[tuple[AISummary, float]]:
     if cached is None:
         return None
     summary, timestamp = cached
-    return AISummary(overall=summary.overall, per_file=dict(summary.per_file)), timestamp
+    return (
+        AISummary(overall=summary.overall, per_file=dict(summary.per_file)),
+        timestamp,
+    )
 
 
 def _invoke_callback(callback: Optional[Callable[..., None]], *args: object) -> None:

--- a/patch_gui/binary_patch.py
+++ b/patch_gui/binary_patch.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Iterable, List, Mapping, Optional, Tuple, Literal
+from typing import Dict, Iterable, List, Mapping, Optional, Tuple, Literal, cast
 
 import zlib
 
 try:  # pragma: no cover - optional typing import
     from unidiff.patch import PatchedFile
 except Exception:  # pragma: no cover - during docs builds
-    PatchedFile = object  # type: ignore[misc,assignment]
+    PatchedFile = object
 
 from .localization import gettext as _
 
@@ -206,9 +206,13 @@ def _parse_binary_blocks(
                     while idx < total and lines[idx]:
                         encoded.append(lines[idx])
                         idx += 1
+                    if method not in {"literal", "delta"}:
+                        raise BinaryPatchError(
+                            _("Unsupported binary patch method: %s") % method
+                        )
                     hunks.append(
                         _BinaryHunk(
-                            method=method,
+                            method=cast(Literal["literal", "delta"], method),
                             expected_size=expected_size,
                             encoded_lines=tuple(encoded),
                         )

--- a/patch_gui/config.py
+++ b/patch_gui/config.py
@@ -178,7 +178,9 @@ class AppConfig:
             "exclude_dirs": list(self.exclude_dirs),
             "backup_base": str(self.backup_base),
             "log_level": str(self.log_level),
-            "theme": str(self.theme.value if isinstance(self.theme, Theme) else self.theme),
+            "theme": str(
+                self.theme.value if isinstance(self.theme, Theme) else self.theme
+            ),
             "dry_run_default": bool(self.dry_run_default),
             "write_reports": bool(self.write_reports),
             "log_file": str(self.log_file),

--- a/patch_gui/diff_search.py
+++ b/patch_gui/diff_search.py
@@ -191,11 +191,15 @@ class DiffSearchHelper(QtCore.QObject):
             cursor = QtGui.QTextCursor(self._editor.document())
             cursor.setPosition(match.start)
             cursor.setPosition(match.end, QtGui.QTextCursor.MoveMode.KeepAnchor)
-            selection.cursor = cursor
-            selection.format = (
-                self._current_format
-                if idx == self._current_index
-                else self._match_format
+            setattr(selection, "cursor", cursor)
+            setattr(
+                selection,
+                "format",
+                (
+                    self._current_format
+                    if idx == self._current_index
+                    else self._match_format
+                ),
             )
             selections.append(selection)
 

--- a/patch_gui/executor.py
+++ b/patch_gui/executor.py
@@ -233,9 +233,9 @@ def apply_patchset(
             resolved_strategy = _resolve_strategy(matching_strategy)
         except ValueError as exc:
             raise CLIError(
-                _(
-                    "Unsupported matching strategy: {strategy}."
-                ).format(strategy=matching_strategy)
+                _("Unsupported matching strategy: {strategy}.").format(
+                    strategy=matching_strategy
+                )
             ) from exc
     started_at = time.time()
     backup_base_arg = backup_base or resolved_config.backup_base
@@ -278,7 +278,9 @@ def apply_patchset(
     )
 
     configured_anchors = getattr(resolved_config, "use_structural_anchors", True)
-    anchors_enabled = configured_anchors if use_structural_anchors is None else use_structural_anchors
+    anchors_enabled = (
+        configured_anchors if use_structural_anchors is None else use_structural_anchors
+    )
 
     session = ApplySession(
         project_root=root,
@@ -837,9 +839,9 @@ def _apply_binary_patch_to_path(
         return fr
 
     method = getattr(binary_patch.forward, "method", "binary")
-    decision.message = _(
-        "Applied {method} binary patch ({size} bytes)"
-    ).format(method=method, size=len(new_bytes))
+    decision.message = _("Applied {method} binary patch ({size} bytes)").format(
+        method=method, size=len(new_bytes)
+    )
     fr.decisions.append(decision)
     fr.hunks_applied = 1
 
@@ -1193,9 +1195,7 @@ def _cli_manual_resolver(
         )
 
         snippet_start = max(0, cand.position - context_padding)
-        snippet_end = min(
-            len(lines), cand.position + highlight_width + context_padding
-        )
+        snippet_end = min(len(lines), cand.position + highlight_width + context_padding)
         highlight_start = cand.position
         highlight_end = min(len(lines), cand.position + highlight_width)
 

--- a/patch_gui/file_index.py
+++ b/patch_gui/file_index.py
@@ -102,7 +102,12 @@ class FileIndex:
         start = time.perf_counter()
         stripped = rel_path.strip()
         if not stripped:
-            return [], LookupEvent(rel_path=stripped, suffix_components=0, candidates_considered=0, duration=0.0)
+            return [], LookupEvent(
+                rel_path=stripped,
+                suffix_components=0,
+                candidates_considered=0,
+                duration=0.0,
+            )
 
         parts = tuple(part for part in Path(stripped).parts if part)
         name = parts[-1] if parts else stripped
@@ -118,7 +123,10 @@ class FileIndex:
             suffix_components = max(suffix_components, depth)
             for match in matches:
                 candidates[match] = (
-                    max(candidates.get(match, (0, self._mtimes.get(match, 0.0)))[0], depth),
+                    max(
+                        candidates.get(match, (0, self._mtimes.get(match, 0.0)))[0],
+                        depth,
+                    ),
                     self._mtimes.get(match, 0.0),
                 )
 
@@ -219,4 +227,3 @@ __all__ = [
     "FileLookupMetrics",
     "LookupEvent",
 ]
-

--- a/patch_gui/interactive_diff.py
+++ b/patch_gui/interactive_diff.py
@@ -302,6 +302,7 @@ QLabel#diffStatBadge[badgeType="neutral"] {{
 def _format_styles(template: str, **values: str) -> str:
     return template.format(**values)
 
+
 def _build_diff_palette(widget: QtWidgets.QWidget) -> _DiffPalette:
     palette = widget.palette()
 
@@ -377,7 +378,7 @@ def _build_diff_palette(widget: QtWidgets.QWidget) -> _DiffPalette:
     )
 
 
-class InteractiveDiffWidget(QtWidgets.QWidget):  # type: ignore[misc]
+class InteractiveDiffWidget(QtWidgets.QWidget):
     """Widget that shows diff blocks and allows reordering them interactively."""
 
     diffReordered = QtCore.Signal(str)
@@ -469,7 +470,9 @@ class InteractiveDiffWidget(QtWidgets.QWidget):  # type: ignore[misc]
         list_layout.addWidget(order_container)
 
         self._list_widget = QtWidgets.QListWidget()
-        self._list_widget.setDragDropMode(QtWidgets.QAbstractItemView.InternalMove)
+        self._list_widget.setDragDropMode(
+            QtWidgets.QAbstractItemView.DragDropMode.InternalMove
+        )
         self._list_widget.setDefaultDropAction(QtCore.Qt.DropAction.MoveAction)
         self._list_widget.setVerticalScrollMode(
             QtWidgets.QAbstractItemView.ScrollMode.ScrollPerPixel
@@ -515,9 +518,7 @@ class InteractiveDiffWidget(QtWidgets.QWidget):  # type: ignore[misc]
 
         self._theme_listener = theme_manager.add_listener(self._apply_theme)
         self._apply_theme(theme_manager.snapshot)
-        self.destroyed.connect(
-            lambda: theme_manager.remove_listener(self._apply_theme)
-        )
+        self.destroyed.connect(lambda: theme_manager.remove_listener(self._apply_theme))
 
     def _apply_theme(self, snapshot: ThemeSnapshot) -> None:
         qpalette = snapshot.palette or self.palette()
@@ -830,7 +831,9 @@ class InteractiveDiffWidget(QtWidgets.QWidget):  # type: ignore[misc]
                 else:
                     active_mask = list(mask_source)
                     if len(active_mask) < entry.hunk_count:
-                        active_mask.extend([True] * (entry.hunk_count - len(active_mask)))
+                        active_mask.extend(
+                            [True] * (entry.hunk_count - len(active_mask))
+                        )
                 selected = [
                     hunk
                     for idx, hunk in enumerate(entry.hunks)
@@ -927,7 +930,7 @@ class InteractiveDiffWidget(QtWidgets.QWidget):  # type: ignore[misc]
                 widget.updateGeometry()
 
 
-class _DiffListItemWidget(QtWidgets.QFrame):  # type: ignore[misc]
+class _DiffListItemWidget(QtWidgets.QFrame):
     """Custom widget for list items with colourful diff statistics."""
 
     def __init__(

--- a/patch_gui/matching.py
+++ b/patch_gui/matching.py
@@ -12,6 +12,17 @@ from typing import Any, Callable, Iterable, Sequence, cast
 
 from difflib import SequenceMatcher
 
+__all__ = [
+    "MatchingStrategy",
+    "MatchingOptions",
+    "CandidateMatch",
+    "MatchingStats",
+    "CandidateSearchResult",
+    "find_candidates",
+    "find_candidate_positions",
+    "SequenceMatcher",
+]
+
 _rapidfuzz_module: Any
 try:  # pragma: no cover - exercised through fallback tests
     _rapidfuzz_module = import_module("rapidfuzz.fuzz")

--- a/patch_gui/split_diff_view.py
+++ b/patch_gui/split_diff_view.py
@@ -20,7 +20,7 @@ from .localization import gettext as _
 _NUMBERED_RE = re.compile(r"^(?P<left>.{6}) │ (?P<right>.{6}) │ (?P<content>.*)$")
 
 
-class SplitDiffView(QtWidgets.QWidget):  # type: ignore[misc]
+class SplitDiffView(QtWidgets.QWidget):
     """Render hunks of a :class:`FileDiffEntry` in synchronized columns."""
 
     hunkToggled = QtCore.Signal(int, bool)
@@ -157,7 +157,7 @@ class SplitDiffView(QtWidgets.QWidget):  # type: ignore[misc]
         self.hunkToggled.emit(index, applied)
 
 
-class _HunkWidget(QtWidgets.QFrame):  # type: ignore[misc]
+class _HunkWidget(QtWidgets.QFrame):
     """Widget showing a single hunk with apply/skip controls."""
 
     hunkToggled = QtCore.Signal(int, bool)
@@ -241,7 +241,7 @@ class _HunkWidget(QtWidgets.QFrame):  # type: ignore[misc]
         self.hunkToggled.emit(self._index, applied)
 
 
-class _HunkColumns(QtWidgets.QWidget):  # type: ignore[misc]
+class _HunkColumns(QtWidgets.QWidget):
     """Two synchronized ``QPlainTextEdit`` widgets for a diff hunk."""
 
     def __init__(

--- a/patch_gui/theme.py
+++ b/patch_gui/theme.py
@@ -6,7 +6,7 @@ import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from types import MappingProxyType
+from types import MappingProxyType, MethodType
 from typing import Callable, Mapping, MutableMapping, TYPE_CHECKING
 from weakref import WeakMethod
 
@@ -183,7 +183,9 @@ def build_palette(theme: Theme) -> "QtGui.QPalette | None":
     palette.setColor(
         QtGui.QPalette.ColorRole.ToolTipText, QtGui.QColor(tokens["tooltip_fg"])
     )
-    palette.setColor(QtGui.QPalette.ColorRole.Text, QtGui.QColor(tokens["text_primary"]))
+    palette.setColor(
+        QtGui.QPalette.ColorRole.Text, QtGui.QColor(tokens["text_primary"])
+    )
     palette.setColor(
         QtGui.QPalette.ColorRole.Button, QtGui.QColor(tokens["background_surface"])
     )
@@ -202,7 +204,9 @@ def build_palette(theme: Theme) -> "QtGui.QPalette | None":
 
     disabled_group = QtGui.QPalette.ColorGroup.Disabled
     palette.setColor(
-        disabled_group, QtGui.QPalette.ColorRole.Text, QtGui.QColor(tokens["text_disabled"])
+        disabled_group,
+        QtGui.QPalette.ColorRole.Text,
+        QtGui.QColor(tokens["text_disabled"]),
     )
     palette.setColor(
         disabled_group,
@@ -215,7 +219,9 @@ def build_palette(theme: Theme) -> "QtGui.QPalette | None":
         QtGui.QColor(tokens["text_disabled"]),
     )
     palette.setColor(
-        disabled_group, QtGui.QPalette.ColorRole.Base, QtGui.QColor(tokens["background_disabled"])
+        disabled_group,
+        QtGui.QPalette.ColorRole.Base,
+        QtGui.QColor(tokens["background_disabled"]),
     )
     palette.setColor(
         disabled_group,
@@ -265,8 +271,7 @@ def build_stylesheet(theme: Theme) -> str:
         "    border: 1px solid %s;"
         "    border-radius: 6px;"
         "    padding: 6px;"
-        "}"
-        % (tokens["tooltip_fg"], tokens["tooltip_bg"], tokens["tooltip_border"])
+        "}" % (tokens["tooltip_fg"], tokens["tooltip_bg"], tokens["tooltip_border"])
         + "\n"
         "QMainWindow {"
         "    background-color: %s;"
@@ -285,8 +290,7 @@ def build_stylesheet(theme: Theme) -> str:
             tokens["selection_fg"],
         )
         + "\n"
-        "QLabel { color: %s; }" % tokens["text_primary"]
-        + "\n"
+        "QLabel { color: %s; }" % tokens["text_primary"] + "\n"
         "QPushButton {"
         "    background-color: %s;"
         "    border: 1px solid %s;"
@@ -303,13 +307,11 @@ def build_stylesheet(theme: Theme) -> str:
         "QPushButton:hover {"
         "    background-color: %s;"
         "    border-color: %s;"
-        "}" % (tokens["accent_hover"], tokens["accent"])
-        + "\n"
+        "}" % (tokens["accent_hover"], tokens["accent"]) + "\n"
         "QPushButton:pressed {"
         "    background-color: %s;"
         "    border-color: %s;"
-        "}" % (tokens["accent_pressed"], tokens["accent_pressed"])
-        + "\n"
+        "}" % (tokens["accent_pressed"], tokens["accent_pressed"]) + "\n"
         "QPushButton:disabled {"
         "    color: %s;"
         "    background-color: %s;"
@@ -336,15 +338,12 @@ def build_stylesheet(theme: Theme) -> str:
         + "\n"
         "QSpinBox, QDoubleSpinBox {"
         "    padding-right: 32px;"
-        "}"
-        + "\n"
+        "}" + "\n"
         "QLineEdit:focus, QPlainTextEdit:focus, QTextEdit:focus, QComboBox:focus,"
         " QSpinBox:focus, QDoubleSpinBox:focus {"
         "    border: 1px solid %s;"
         "    background-color: %s;"
-        "}"
-        % (tokens["border_focus"], tokens["background_input_focus"])
-        + "\n"
+        "}" % (tokens["border_focus"], tokens["background_input_focus"]) + "\n"
         "QSpinBox::up-button, QDoubleSpinBox::up-button {"
         "    subcontrol-origin: border;"
         "    subcontrol-position: top right;"
@@ -383,14 +382,12 @@ def build_stylesheet(theme: Theme) -> str:
         " QSpinBox::down-button:hover, QDoubleSpinBox::down-button:hover {"
         "    background-color: %s;"
         "    border-color: %s;"
-        "}" % (tokens["accent_hover"], tokens["accent"])
-        + "\n"
+        "}" % (tokens["accent_hover"], tokens["accent"]) + "\n"
         "QSpinBox::up-button:pressed, QDoubleSpinBox::up-button:pressed,"
         " QSpinBox::down-button:pressed, QDoubleSpinBox::down-button:pressed {"
         "    background-color: %s;"
         "    border-color: %s;"
-        "}" % (tokens["accent_pressed"], tokens["accent_pressed"])
-        + "\n"
+        "}" % (tokens["accent_pressed"], tokens["accent_pressed"]) + "\n"
         "QSpinBox::up-button:disabled, QDoubleSpinBox::up-button:disabled,"
         " QSpinBox::down-button:disabled, QDoubleSpinBox::down-button:disabled {"
         "    background-color: %s;"
@@ -405,22 +402,18 @@ def build_stylesheet(theme: Theme) -> str:
         '    image: url("%s");'
         "    width: 12px;"
         "    height: 12px;"
-        "}" % (_SPIN_UP_ICON,)
-        + "\n"
+        "}" % (_SPIN_UP_ICON,) + "\n"
         "QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {"
         '    image: url("%s");'
         "    width: 12px;"
         "    height: 12px;"
-        "}" % (_SPIN_DOWN_ICON,)
-        + "\n"
+        "}" % (_SPIN_DOWN_ICON,) + "\n"
         "QSpinBox::up-arrow:disabled, QDoubleSpinBox::up-arrow:disabled {"
         '    image: url("%s");'
-        "}" % (_SPIN_UP_ICON,)
-        + "\n"
+        "}" % (_SPIN_UP_ICON,) + "\n"
         "QSpinBox::down-arrow:disabled, QDoubleSpinBox::down-arrow:disabled {"
         '    image: url("%s");'
-        "}" % (_SPIN_DOWN_ICON,)
-        + "\n"
+        "}" % (_SPIN_DOWN_ICON,) + "\n"
         "QTreeWidget, QTreeView, QListWidget, QListView {"
         "    background-color: %s;"
         "    border: 1px solid %s;"
@@ -439,16 +432,14 @@ def build_stylesheet(theme: Theme) -> str:
         '    image: url("%s");'
         "    padding: 6px;"
         "    margin: 0px;"
-        "}" % (branch_closed_icon,)
-        + "\n"
+        "}" % (branch_closed_icon,) + "\n"
         "QTreeView::branch:has-children:!has-siblings:open,"
         "QTreeView::branch:has-children:!has-siblings:open:hover,"
         "QTreeView::branch:has-children:!has-siblings:open:pressed {"
         '    image: url("%s");'
         "    padding: 6px;"
         "    margin: 0px;"
-        "}" % (branch_open_icon,)
-        + "\n"
+        "}" % (branch_open_icon,) + "\n"
         "QHeaderView::section {"
         "    background-color: %s;"
         "    color: %s;"
@@ -467,18 +458,14 @@ def build_stylesheet(theme: Theme) -> str:
         "    border: 1px solid %s;"
         "    margin: 4px;"
         "    border-radius: 4px;"
-        "}"
-        % (tokens["splitter_handle_bg"], tokens["border"])
-        + "\n"
+        "}" % (tokens["splitter_handle_bg"], tokens["border"]) + "\n"
         "QSplitter::handle:hover {"
         "    background: %s;"
         "    border-color: %s;"
-        "}" % (tokens["accent"], tokens["accent"])
-        + "\n"
+        "}" % (tokens["accent"], tokens["accent"]) + "\n"
         "QSplitter::handle:pressed {"
         "    background: %s;"
-        "}" % (tokens["accent_pressed"],)
-        + "\n"
+        "}" % (tokens["accent_pressed"],) + "\n"
         "QProgressBar {"
         "    border: 1px solid %s;"
         "    border-radius: 8px;"
@@ -496,42 +483,34 @@ def build_stylesheet(theme: Theme) -> str:
         "QProgressBar::chunk {"
         "    background-color: %s;"
         "    border-radius: 6px;"
-        "}" % (tokens["progress_chunk"],)
-        + "\n"
+        "}" % (tokens["progress_chunk"],) + "\n"
         "QScrollBar:vertical {"
         "    background: %s;"
         "    width: 14px;"
         "    margin: 4px 2px 4px 2px;"
         "    border-radius: 6px;"
-        "}" % (tokens["scrollbar_bg"],)
-        + "\n"
+        "}" % (tokens["scrollbar_bg"],) + "\n"
         "QScrollBar::handle:vertical {"
         "    background: %s;"
         "    min-height: 24px;"
         "    border-radius: 6px;"
-        "}" % (tokens["scrollbar_handle"],)
-        + "\n"
+        "}" % (tokens["scrollbar_handle"],) + "\n"
         "QScrollBar::handle:vertical:hover {"
         "    background: %s;"
-        "}" % (tokens["scrollbar_handle_hover"],)
-        + "\n"
+        "}" % (tokens["scrollbar_handle_hover"],) + "\n"
         "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {"
         "    background: none;"
-        "}"
-        + "\n"
+        "}" + "\n"
         "QStatusBar {"
         "    background: %s;"
         "    color: %s;"
-        "}" % (tokens["status_bg"], tokens["text_primary"])
-        + "\n"
+        "}" % (tokens["status_bg"], tokens["text_primary"]) + "\n"
         "QGroupBox {"
         "    border: 1px solid %s;"
         "    border-radius: 8px;"
         "    margin-top: 16px;"
         "    padding: 10px;"
-        "}"
-        % (tokens["border"],)
-        + "\n"
+        "}" % (tokens["border"],) + "\n"
         "QGroupBox::title {"
         "    subcontrol-origin: margin;"
         "    subcontrol-position: top left;"
@@ -551,6 +530,10 @@ class ThemeSnapshot:
     stylesheet: str
 
 
+ThemeListener = Callable[["ThemeSnapshot"], None]
+WeakThemeListener = WeakMethod[ThemeListener]
+
+
 class ThemeManager:
     """Central theme registry used to broadcast palette changes."""
 
@@ -567,7 +550,7 @@ class ThemeManager:
             palette=None,
             stylesheet=build_stylesheet(Theme.DARK),
         )
-        self._listeners: list[Callable[[ThemeSnapshot], None] | WeakMethod] = []
+        self._listeners: list[ThemeListener | WeakThemeListener] = []
         self._log = logging.getLogger(__name__)
 
     @property
@@ -582,19 +565,20 @@ class ThemeManager:
     def palettes(self) -> Mapping[Theme, Mapping[str, str]]:
         return MappingProxyType(self._available_tokens)
 
-    def register_theme_tokens(
-        self, theme: Theme, overrides: Mapping[str, str]
-    ) -> None:
+    def register_theme_tokens(self, theme: Theme, overrides: Mapping[str, str]) -> None:
         tokens = dict(_BASE_TOKENS)
         tokens.update(overrides)
         self._available_tokens[theme] = MappingProxyType(tokens)
 
     def add_listener(
-        self, callback: Callable[[ThemeSnapshot], None], *, fire_immediately: bool = False
+        self,
+        callback: Callable[[ThemeSnapshot], None],
+        *,
+        fire_immediately: bool = False,
     ) -> Callable[[ThemeSnapshot], None]:
-        listener: Callable[[ThemeSnapshot], None] | WeakMethod
-        if hasattr(callback, "__self__") and getattr(callback, "__self__") is not None:
-            listener = WeakMethod(callback)  # type: ignore[arg-type]
+        listener: ThemeListener | WeakThemeListener
+        if isinstance(callback, MethodType):
+            listener = WeakMethod(callback)
         else:
             listener = callback
         self._listeners.append(listener)
@@ -606,7 +590,7 @@ class ThemeManager:
         return callback
 
     def remove_listener(self, callback: Callable[[ThemeSnapshot], None]) -> None:
-        retained: list[Callable[[ThemeSnapshot], None] | WeakMethod] = []
+        retained: list[ThemeListener | WeakThemeListener] = []
         for listener in self._listeners:
             if isinstance(listener, WeakMethod):
                 resolved = listener()
@@ -671,7 +655,7 @@ class ThemeManager:
 
     def _emit(self) -> None:
         snapshot = self._snapshot
-        retained: list[Callable[[ThemeSnapshot], None] | WeakMethod] = []
+        retained: list[ThemeListener | WeakThemeListener] = []
         for listener in list(self._listeners):
             if isinstance(listener, WeakMethod):
                 callback = listener()

--- a/scripts/benchmark_file_index.py
+++ b/scripts/benchmark_file_index.py
@@ -61,7 +61,9 @@ def run_benchmark(files: int, duplicates: int, lookups: int) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--files", type=int, default=5000, help="Number of files to generate")
+    parser.add_argument(
+        "--files", type=int, default=5000, help="Number of files to generate"
+    )
     parser.add_argument(
         "--duplicates",
         type=int,

--- a/scripts/build_packages.py
+++ b/scripts/build_packages.py
@@ -113,7 +113,9 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     except FileNotFoundError as error:
         missing = error.filename or str(error)
-        print(f"Errore: comando non trovato ({missing}). Installa il pacchetto richiesto.")
+        print(
+            f"Errore: comando non trovato ({missing}). Installa il pacchetto richiesto."
+        )
         return 1
     return 0
 

--- a/tests/test_ai_summaries.py
+++ b/tests/test_ai_summaries.py
@@ -1,12 +1,13 @@
 import threading
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
 from patch_gui.ai_summaries import AISummary, generate_session_summary
 from patch_gui.patcher import ApplySession
+from tests._pytest_typing import typed_fixture
 
 try:  # pragma: no cover - optional dependency
     from PySide6 import QtWidgets as _QtWidgets
@@ -14,7 +15,7 @@ except Exception as exc:  # pragma: no cover - PySide6 missing in environment
     QtWidgets: Any | None = None
     _QT_IMPORT_ERROR: Exception | None = exc
 else:  # pragma: no cover - executed when bindings are available
-    QtWidgets = _QtWidgets
+    QtWidgets = cast(Any, _QtWidgets)
     _QT_IMPORT_ERROR = None
 
 
@@ -31,7 +32,9 @@ def _build_session(tmp_path: Path) -> ApplySession:
     return session
 
 
-def test_generate_session_summary_uses_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_generate_session_summary_uses_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     import patch_gui.ai_summaries as summaries_module
 
     monkeypatch.setattr(summaries_module, "_SUMMARY_CACHE", {})
@@ -68,7 +71,7 @@ def test_generate_session_summary_uses_cache(monkeypatch: pytest.MonkeyPatch, tm
     assert len(calls) == 1
 
 
-@pytest.fixture()  # type: ignore[misc]
+@typed_fixture()
 def qt_app() -> Any:
     if QtWidgets is None:  # pragma: no cover - PySide6 missing
         pytest.skip(f"PySide6 non disponibile: {_QT_IMPORT_ERROR}")
@@ -129,7 +132,10 @@ def test_ai_summary_worker_non_blocking(
     worker.start()
 
     assert start_event.wait(1.0)
-    assert thread_name.get("name") and thread_name["name"] != threading.current_thread().name
+    assert (
+        thread_name.get("name")
+        and thread_name["name"] != threading.current_thread().name
+    )
     assert "summary" not in results
 
     release_event.set()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1948,7 +1948,7 @@ def test_run_restore_non_interactive(
     assert "Restored 1 files" in captured.out
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@typed_parametrize(
     "user_input, expected_applied, expected_completed, expected_pos",
     [("2", 1, True, 3), ("", 0, False, None)],
 )
@@ -2008,7 +2008,7 @@ def test_cli_manual_resolver_handles_fuzzy_candidates(
         assert decision.similarity is not None
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@typed_parametrize(
     "user_input, expected_applied, expected_completed, expected_pos",
     [("2", 1, True, 4), ("", 0, False, None)],
 )

--- a/tests/test_diff_search.py
+++ b/tests/test_diff_search.py
@@ -1,31 +1,37 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
+from tests._pytest_typing import typed_fixture
+
 try:  # pragma: no cover - optional dependency guard
-    from PySide6 import QtWidgets
+    from PySide6 import QtWidgets as _QtWidgets
 except Exception as exc:  # pragma: no cover - optional dependency
-    QtWidgets = None
+    QtWidgets: Any | None = None
     _QT_IMPORT_ERROR: Exception | None = exc
 else:  # pragma: no cover - exercised when bindings are available
+    QtWidgets = cast(Any, _QtWidgets)
     _QT_IMPORT_ERROR = None
 
 try:  # pragma: no cover - optional dependency guard
-    from patch_gui.diff_search import DiffSearchHelper
+    from patch_gui.diff_search import DiffSearchHelper as _DiffSearchHelper
 except Exception as exc:  # pragma: no cover - optional dependency
-    DiffSearchHelper = None
+    DiffSearchHelper: Any | None = None
     _DIFF_IMPORT_ERROR: Exception | None = exc
 else:  # pragma: no cover - exercised when bindings are available
+    DiffSearchHelper = cast(Any, _DiffSearchHelper)
     _DIFF_IMPORT_ERROR = None
 
 
-@pytest.fixture()
+@typed_fixture()
 def qt_app() -> Any:
     if QtWidgets is None or DiffSearchHelper is None:
         reason = _QT_IMPORT_ERROR if QtWidgets is None else _DIFF_IMPORT_ERROR
         pytest.skip(f"PySide6 non disponibile: {reason}")
+    assert QtWidgets is not None
+    assert DiffSearchHelper is not None
     app = QtWidgets.QApplication.instance()
     if app is None:
         app = QtWidgets.QApplication([])
@@ -36,6 +42,8 @@ def test_diff_search_helper_navigation(qt_app: Any) -> None:
     if QtWidgets is None or DiffSearchHelper is None:
         reason = _QT_IMPORT_ERROR if QtWidgets is None else _DIFF_IMPORT_ERROR
         pytest.skip(f"PySide6 non disponibile: {reason}")
+    assert QtWidgets is not None
+    assert DiffSearchHelper is not None
 
     editor = QtWidgets.QPlainTextEdit()
     editor.setPlainText("uno\nfoo\nFoo\nqualcosa\nfoo")
@@ -76,6 +84,8 @@ def test_diff_search_helper_updates_on_text_change(qt_app: Any) -> None:
     if QtWidgets is None or DiffSearchHelper is None:
         reason = _QT_IMPORT_ERROR if QtWidgets is None else _DIFF_IMPORT_ERROR
         pytest.skip(f"PySide6 non disponibile: {reason}")
+    assert QtWidgets is not None
+    assert DiffSearchHelper is not None
 
     editor = QtWidgets.QPlainTextEdit()
     editor.setPlainText("alpha\nbeta\ngamma")

--- a/tests/test_gui_patch_worker.py
+++ b/tests/test_gui_patch_worker.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from unidiff import PatchSet
@@ -11,6 +11,7 @@ from unidiff import PatchSet
 from patch_gui.binary_patch import attach_binary_patch_data
 from patch_gui.patcher import ApplySession, prepare_backup_dir
 from tests._binary_fixture import BINARY_DIFF, NEW_BYTES, OLD_BYTES
+from tests._pytest_typing import typed_fixture
 
 try:  # pragma: no cover - optional dependency
     from PySide6 import QtWidgets as _QtWidgets
@@ -18,7 +19,7 @@ except Exception as exc:  # pragma: no cover - PySide6 missing in environment
     QtWidgets: Any | None = None
     _QT_IMPORT_ERROR: Exception | None = exc
 else:  # pragma: no cover - executed when bindings are available
-    QtWidgets = _QtWidgets
+    QtWidgets = cast(Any, _QtWidgets)
     _QT_IMPORT_ERROR = None
 
 
@@ -45,7 +46,7 @@ OUTSIDE_DIFF = """--- /dev/null
 """
 
 
-@pytest.fixture()  # type: ignore[misc]
+@typed_fixture()
 def qt_app() -> Any:
     """Provide a ``QApplication`` instance for tests that need Qt."""
 

--- a/tests/test_interactive_diff_widget.py
+++ b/tests/test_interactive_diff_widget.py
@@ -1,24 +1,31 @@
+from typing import Any, cast
+
 import pytest
 from unidiff import PatchSet
 
-from patch_gui.diff_formatting import format_diff_with_line_numbers, render_diff_segments
+from patch_gui.diff_formatting import (
+    format_diff_with_line_numbers,
+    render_diff_segments,
+)
 from patch_gui.interactive_diff_model import FileDiffEntry
 from tests._pytest_typing import typed_fixture
 
 try:  # pragma: no cover - optional dependency
     from PySide6 import QtCore as _QtCore, QtWidgets as _QtWidgets
 except Exception as exc:  # pragma: no cover - missing bindings
-    QtWidgets = None
-    QtCore = None
+    QtWidgets: Any | None = None
+    QtCore: Any | None = None
     _QT_IMPORT_ERROR: Exception | None = exc
 else:  # pragma: no cover - bindings available
-    QtWidgets = _QtWidgets
-    QtCore = _QtCore
+    QtWidgets = cast(Any, _QtWidgets)
+    QtCore = cast(Any, _QtCore)
     _QT_IMPORT_ERROR = None
 
 try:  # pragma: no cover - optional dependency
     from patch_gui.split_diff_view import SplitDiffView as _SplitDiffView
-    from patch_gui.interactive_diff import InteractiveDiffWidget as _InteractiveDiffWidget
+    from patch_gui.interactive_diff import (
+        InteractiveDiffWidget as _InteractiveDiffWidget,
+    )
     from patch_gui.highlighter import build_diff_highlight_palette as _build_palette
 except Exception as exc:  # pragma: no cover - missing GUI deps
     SplitDiffView = None
@@ -33,10 +40,11 @@ else:  # pragma: no cover - bindings available
 
 
 @typed_fixture()
-def qt_app():
+def qt_app() -> Any:
     if QtWidgets is None or _WIDGET_IMPORT_ERROR is not None:
         reason = _QT_IMPORT_ERROR or _WIDGET_IMPORT_ERROR
         pytest.skip(f"PySide6 non disponibile: {reason}")
+    assert QtWidgets is not None
     app = QtWidgets.QApplication.instance()
     if app is None:
         app = QtWidgets.QApplication([])
@@ -117,28 +125,35 @@ def _long_diff() -> str:
 
 
 def _two_hunk_diff() -> str:
-    return "\n".join(
-        [
-            "diff --git a/demo.txt b/demo.txt",
-            "index 1111111..2222222 100644",
-            "--- a/demo.txt",
-            "+++ b/demo.txt",
-            "@@ -1,4 +1,4 @@",
-            " line a",
-            "-line b",
-            "+line bee",
-            " line c",
-            " line d",
-            "@@ -10,0 +10,2 @@",
-            "+tail one",
-            "+tail two",
-        ]
-    ) + "\n"
+    return (
+        "\n".join(
+            [
+                "diff --git a/demo.txt b/demo.txt",
+                "index 1111111..2222222 100644",
+                "--- a/demo.txt",
+                "+++ b/demo.txt",
+                "@@ -1,4 +1,4 @@",
+                " line a",
+                "-line b",
+                "+line bee",
+                " line c",
+                " line d",
+                "@@ -10,0 +10,2 @@",
+                "+tail one",
+                "+tail two",
+            ]
+        )
+        + "\n"
+    )
 
 
-def test_split_diff_view_synchronized_scroll(qt_app):
+def test_split_diff_view_synchronized_scroll(qt_app: Any) -> None:
     if SplitDiffView is None or QtWidgets is None:
-        pytest.skip(f"PySide6 non disponibile: {_WIDGET_IMPORT_ERROR or _QT_IMPORT_ERROR}")
+        pytest.skip(
+            f"PySide6 non disponibile: {_WIDGET_IMPORT_ERROR or _QT_IMPORT_ERROR}"
+        )
+    assert QtWidgets is not None
+    assert build_diff_highlight_palette is not None
     entry = _build_entry(_long_diff())
     palette_widget = QtWidgets.QWidget()
     palette = build_diff_highlight_palette(palette_widget.palette())
@@ -163,9 +178,13 @@ def test_split_diff_view_synchronized_scroll(qt_app):
     assert left_bar.value() == 0
 
 
-def test_interactive_diff_inline_toggle_emits_signal(qt_app):
+def test_interactive_diff_inline_toggle_emits_signal(qt_app: Any) -> None:
     if InteractiveDiffWidget is None or QtWidgets is None:
-        pytest.skip(f"PySide6 non disponibile: {_WIDGET_IMPORT_ERROR or _QT_IMPORT_ERROR}")
+        pytest.skip(
+            f"PySide6 non disponibile: {_WIDGET_IMPORT_ERROR or _QT_IMPORT_ERROR}"
+        )
+    assert QtWidgets is not None
+    assert QtCore is not None
     widget = InteractiveDiffWidget()
     patch_set = PatchSet(_two_hunk_diff())
     widget.set_patch(patch_set)
@@ -174,7 +193,7 @@ def test_interactive_diff_inline_toggle_emits_signal(qt_app):
     captured: list[str] = []
     widget.diffReordered.connect(captured.append)
 
-    split_view = widget._split_view  # type: ignore[attr-defined]
+    split_view = widget._split_view
     assert split_view.hunk_widgets
     first_hunk = split_view.hunk_widgets[0]
     skip_button = first_hunk.findChild(QtWidgets.QToolButton, "splitDiffSkipButton")
@@ -187,7 +206,7 @@ def test_interactive_diff_inline_toggle_emits_signal(qt_app):
     assert "@@ -1,4 +1,4 @@" not in last_diff
     assert "@@ -10,0 +10,2 @@" in last_diff
 
-    current_item = widget._list_widget.currentItem()  # type: ignore[attr-defined]
+    current_item = widget._list_widget.currentItem()
     assert current_item is not None
     current_entry = current_item.data(QtCore.Qt.ItemDataRole.UserRole)
     assert isinstance(current_entry, FileDiffEntry)
@@ -195,15 +214,19 @@ def test_interactive_diff_inline_toggle_emits_signal(qt_app):
     assert current_entry.hunk_apply_mask[0] is False
 
 
-def test_interactive_diff_export_respects_selection(qt_app):
+def test_interactive_diff_export_respects_selection(qt_app: Any) -> None:
     if InteractiveDiffWidget is None or QtWidgets is None:
-        pytest.skip(f"PySide6 non disponibile: {_WIDGET_IMPORT_ERROR or _QT_IMPORT_ERROR}")
+        pytest.skip(
+            f"PySide6 non disponibile: {_WIDGET_IMPORT_ERROR or _QT_IMPORT_ERROR}"
+        )
+    assert QtWidgets is not None
+    assert QtCore is not None
     widget = InteractiveDiffWidget()
     patch_set = PatchSet(_two_hunk_diff())
     widget.set_patch(patch_set)
     qt_app.processEvents()
 
-    split_view = widget._split_view  # type: ignore[attr-defined]
+    split_view = widget._split_view
     first_hunk = split_view.hunk_widgets[0]
     skip_button = first_hunk.findChild(QtWidgets.QToolButton, "splitDiffSkipButton")
     assert skip_button is not None

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -30,7 +30,9 @@ def test_auto_strategy_matches_legacy_results() -> None:
     assert auto == legacy
 
 
-def test_token_strategy_limits_sequence_matcher_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_token_strategy_limits_sequence_matcher_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     call_count = {"value": 0}
     original_matcher = matching.SequenceMatcher
 

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
 from patch_gui import theme as theme_module
 from patch_gui.config import Theme
+from tests._pytest_typing import typed_fixture
 
 try:  # pragma: no cover - optional dependency
     from PySide6 import QtGui as _QtGui
@@ -15,16 +16,17 @@ except Exception as exc:  # pragma: no cover - bindings missing at runtime
     QtWidgets: Any | None = None
     _QT_IMPORT_ERROR: Exception | None = exc
 else:  # pragma: no cover - executed when bindings are available
-    QtGui = _QtGui
-    QtWidgets = _QtWidgets
+    QtGui = cast(Any, _QtGui)
+    QtWidgets = cast(Any, _QtWidgets)
     _QT_IMPORT_ERROR = None
 
 
-@pytest.fixture()
+@typed_fixture()
 def themed_app() -> Any:
     if QtWidgets is None:
         pytest.skip(f"PySide6 non disponibile: {_QT_IMPORT_ERROR}")
     assert QtGui is not None
+    assert QtWidgets is not None
     app = QtWidgets.QApplication.instance()
     if app is None:
         app = QtWidgets.QApplication([])
@@ -44,9 +46,7 @@ def test_build_palette_high_contrast_uses_tokens() -> None:
     palette = theme_module.build_palette(Theme.HIGH_CONTRAST)
     assert palette is not None
     window_color = palette.color(QtGui.QPalette.ColorRole.Window).name().lower()
-    highlight_color = palette.color(
-        QtGui.QPalette.ColorRole.Highlight
-    ).name().lower()
+    highlight_color = palette.color(QtGui.QPalette.ColorRole.Highlight).name().lower()
     assert window_color == "#000000"
     assert highlight_color == "#ffd500"
 
@@ -62,7 +62,9 @@ def test_apply_modern_theme_updates_palette_and_stylesheet(themed_app: Any) -> N
     assert "#f5f7fa" in stylesheet
 
 
-def test_apply_modern_theme_gracefully_handles_missing_qt(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_apply_modern_theme_gracefully_handles_missing_qt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(theme_module, "QtWidgets", None)
     monkeypatch.setattr(theme_module, "QtGui", None)
     theme_module.apply_modern_theme(Theme.DARK, None)


### PR DESCRIPTION
## Summary
- add a RapidFuzz label to the settings dialog and tighten type usage in the app module
- harden binary patch parsing, matching helpers, and theme listener bookkeeping for mypy
- update Qt-dependent tests to use typed fixtures and explicit assertions so they type-check

## Testing
- `mypy`
- `pytest`
- `ruff check`


------
https://chatgpt.com/codex/tasks/task_e_68cd5cf769fc83268a1276f7d5140945