### PR TITLE
Fix mypy typing for Qt components and tests

### DIFF
--- a/patch_gui/diff_search.py
+++ b/patch_gui/diff_search.py
@@ -7,6 +7,8 @@ from typing import List, Sequence
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
+from .qt_types import QObjectBase
+
 __all__ = [
     "DiffSearchHelper",
     "DiffSearchMatch",
@@ -25,7 +27,7 @@ class DiffSearchMatch:
     text: str
 
 
-class DiffSearchHelper(QtCore.QObject):
+class DiffSearchHelper(QObjectBase):
     """Search controller that highlights matches inside ``QPlainTextEdit`` widgets."""
 
     resultsChanged = QtCore.Signal(int)

--- a/patch_gui/interactive_diff.py
+++ b/patch_gui/interactive_diff.py
@@ -17,6 +17,7 @@ from .interactive_diff_model import (
 )
 from .split_diff_view import SplitDiffView
 from .theme import ThemeSnapshot, theme_manager
+from .qt_types import QFrameBase, QWidgetBase
 
 
 @dataclass(frozen=True, slots=True)
@@ -378,7 +379,7 @@ def _build_diff_palette(widget: QtWidgets.QWidget) -> _DiffPalette:
     )
 
 
-class InteractiveDiffWidget(QtWidgets.QWidget):
+class InteractiveDiffWidget(QWidgetBase):
     """Widget that shows diff blocks and allows reordering them interactively."""
 
     diffReordered = QtCore.Signal(str)
@@ -930,7 +931,7 @@ class InteractiveDiffWidget(QtWidgets.QWidget):
                 widget.updateGeometry()
 
 
-class _DiffListItemWidget(QtWidgets.QFrame):
+class _DiffListItemWidget(QFrameBase):
     """Custom widget for list items with colourful diff statistics."""
 
     def __init__(

--- a/patch_gui/qt_types.py
+++ b/patch_gui/qt_types.py
@@ -1,0 +1,27 @@
+"""Helper types that provide stable Qt base classes for type-checking."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from PySide6.QtCore import QObject
+from PySide6.QtWidgets import QFrame, QWidget
+
+__all__ = ["QObjectBase", "QWidgetBase", "QFrameBase"]
+
+
+if TYPE_CHECKING:
+    class QObjectBase(QObject):
+        """Concrete ``QObject`` subclass recognised by static type checkers."""
+
+    class QWidgetBase(QWidget):
+        """Concrete ``QWidget`` subclass recognised by static type checkers."""
+
+    class QFrameBase(QFrame):
+        """Concrete ``QFrame`` subclass recognised by static type checkers."""
+
+else:
+    QObjectBase = QObject
+    QWidgetBase = QWidget
+    QFrameBase = QFrame
+

--- a/patch_gui/split_diff_view.py
+++ b/patch_gui/split_diff_view.py
@@ -15,12 +15,13 @@ from .highlighter import (
 from .diff_formatting import RenderedHunk
 from .interactive_diff_model import FileDiffEntry
 from .localization import gettext as _
+from .qt_types import QFrameBase, QWidgetBase
 
 
 _NUMBERED_RE = re.compile(r"^(?P<left>.{6}) │ (?P<right>.{6}) │ (?P<content>.*)$")
 
 
-class SplitDiffView(QtWidgets.QWidget):
+class SplitDiffView(QWidgetBase):
     """Render hunks of a :class:`FileDiffEntry` in synchronized columns."""
 
     hunkToggled = QtCore.Signal(int, bool)
@@ -157,7 +158,7 @@ class SplitDiffView(QtWidgets.QWidget):
         self.hunkToggled.emit(index, applied)
 
 
-class _HunkWidget(QtWidgets.QFrame):
+class _HunkWidget(QFrameBase):
     """Widget showing a single hunk with apply/skip controls."""
 
     hunkToggled = QtCore.Signal(int, bool)
@@ -241,7 +242,7 @@ class _HunkWidget(QtWidgets.QFrame):
         self.hunkToggled.emit(self._index, applied)
 
 
-class _HunkColumns(QtWidgets.QWidget):
+class _HunkColumns(QWidgetBase):
     """Two synchronized ``QPlainTextEdit`` widgets for a diff hunk."""
 
     def __init__(

--- a/scripts/benchmark_matching.py
+++ b/scripts/benchmark_matching.py
@@ -8,7 +8,7 @@ import random
 import time
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any, Iterator, cast
 
 from patch_gui import matching
 from patch_gui.matching import MatchingStrategy
@@ -30,11 +30,11 @@ def _count_sequence_calls() -> Iterator[dict[str, int]]:
         def __getattr__(self, name: str) -> Any:  # pragma: no cover - defensive
             return getattr(self._delegate, name)
 
-    matching.SequenceMatcher = CountingMatcher  # type: ignore[assignment]
+    cast(Any, matching).SequenceMatcher = CountingMatcher
     try:
         yield counter
     finally:
-        matching.SequenceMatcher = original_matcher  # type: ignore[assignment]
+        cast(Any, matching).SequenceMatcher = original_matcher
 
 
 def _load_lines(path: Path, encoding: str | None) -> list[str]:

--- a/tests/test_interactive_diff_widget.py
+++ b/tests/test_interactive_diff_widget.py
@@ -1,4 +1,6 @@
-from typing import Any, cast
+from __future__ import annotations
+
+from typing import Any, Callable, cast
 
 import pytest
 from unidiff import PatchSet
@@ -9,6 +11,10 @@ from patch_gui.diff_formatting import (
 )
 from patch_gui.interactive_diff_model import FileDiffEntry
 from tests._pytest_typing import typed_fixture
+
+SplitDiffView: type[Any] | None
+InteractiveDiffWidget: type[Any] | None
+build_diff_highlight_palette: Callable[..., Any] | None
 
 try:  # pragma: no cover - optional dependency
     from PySide6 import QtCore as _QtCore, QtWidgets as _QtWidgets
@@ -33,9 +39,9 @@ except Exception as exc:  # pragma: no cover - missing GUI deps
     build_diff_highlight_palette = None
     _WIDGET_IMPORT_ERROR: Exception | None = exc
 else:  # pragma: no cover - bindings available
-    SplitDiffView = _SplitDiffView
-    InteractiveDiffWidget = _InteractiveDiffWidget
-    build_diff_highlight_palette = _build_palette
+    SplitDiffView = cast(type[Any], _SplitDiffView)
+    InteractiveDiffWidget = cast(type[Any], _InteractiveDiffWidget)
+    build_diff_highlight_palette = cast(Callable[..., Any], _build_palette)
     _WIDGET_IMPORT_ERROR = None
 
 

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any, Callable, TypeVar, cast
 
 import pytest
 
@@ -18,7 +18,14 @@ except Exception as exc:  # pragma: no cover - bindings missing at runtime
 else:  # pragma: no cover - executed when bindings are available
     QtGui = cast(Any, _QtGui)
     QtWidgets = cast(Any, _QtWidgets)
-    _QT_IMPORT_ERROR = None
+_QT_IMPORT_ERROR = None
+
+_F = TypeVar("_F", bound=Callable[..., object])
+
+
+def typed_skipif(condition: bool, *, reason: str) -> Callable[[_F], _F]:
+    decorator = pytest.mark.skipif(condition, reason=reason)
+    return cast(Callable[[_F], _F], decorator)
 
 
 @typed_fixture()
@@ -40,7 +47,7 @@ def themed_app() -> Any:
         app.setStyle(original_style_name)
 
 
-@pytest.mark.skipif(QtWidgets is None, reason="PySide6 non disponibile")
+@typed_skipif(QtWidgets is None, reason="PySide6 non disponibile")
 def test_build_palette_high_contrast_uses_tokens() -> None:
     assert QtGui is not None
     palette = theme_module.build_palette(Theme.HIGH_CONTRAST)
@@ -51,7 +58,7 @@ def test_build_palette_high_contrast_uses_tokens() -> None:
     assert highlight_color == "#ffd500"
 
 
-@pytest.mark.skipif(QtWidgets is None, reason="PySide6 non disponibile")
+@typed_skipif(QtWidgets is None, reason="PySide6 non disponibile")
 def test_apply_modern_theme_updates_palette_and_stylesheet(themed_app: Any) -> None:
     assert QtGui is not None
     theme_module.apply_modern_theme(Theme.LIGHT, themed_app)
@@ -79,7 +86,7 @@ def test_theme_manager_exposes_core_palettes() -> None:
     assert "background_window" in palettes[Theme.DARK]
 
 
-@pytest.mark.skipif(QtWidgets is None, reason="PySide6 non disponibile")
+@typed_skipif(QtWidgets is None, reason="PySide6 non disponibile")
 def test_theme_manager_notifies_listeners(themed_app: Any) -> None:
     assert QtGui is not None
     previous = theme_module.theme_manager.snapshot


### PR DESCRIPTION
## Summary
- add reusable Qt base classes that provide stable types for mypy
- update Qt widgets and helper utilities to inherit from the typed bases
- tighten test helpers and benchmark monkeypatching to keep mypy happy

## Testing
- mypy
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd65afb41883268551cc793c138b6c