### PR TITLE
Limit interactive diff order summary height

### DIFF
--- a/patch_gui/interactive_diff.py
+++ b/patch_gui/interactive_diff.py
@@ -337,8 +337,32 @@ class InteractiveDiffWidget(QtWidgets.QWidget):  # type: ignore[misc]
         self._order_label = QtWidgets.QLabel("")
         self._order_label.setObjectName("interactiveDiffOrderLabel")
         self._order_label.setWordWrap(True)
+        self._order_label.setAlignment(
+            QtCore.Qt.AlignmentFlag.AlignTop
+            | QtCore.Qt.AlignmentFlag.AlignLeft
+        )
         self._order_label.setTextFormat(QtCore.Qt.TextFormat.RichText)
-        order_layout.addWidget(self._order_label)
+        self._order_label.setSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Preferred,
+            QtWidgets.QSizePolicy.Policy.Maximum,
+        )
+
+        order_scroll = QtWidgets.QScrollArea()
+        order_scroll.setWidgetResizable(True)
+        order_scroll.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
+        order_scroll.setHorizontalScrollBarPolicy(
+            QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+        )
+        order_scroll.setVerticalScrollBarPolicy(
+            QtCore.Qt.ScrollBarPolicy.ScrollBarAsNeeded
+        )
+        order_scroll.setMaximumHeight(200)
+        order_scroll.setStyleSheet(
+            "QScrollArea { background: transparent; border: none; }"
+        )
+        order_scroll.setWidget(self._order_label)
+
+        order_layout.addWidget(order_scroll)
 
         upper_layout.addWidget(order_container)
 


### PR DESCRIPTION
## Summary
- keep the interactive diff order summary text aligned to the top of its container
- wrap the order summary in a scroll area with a maximum height so the normal page layout no longer stretches endlessly

## Testing
- pytest tests/test_interactive_diff_formatting.py

------
https://chatgpt.com/codex/tasks/task_e_68e01978cba88326b855bec1a797f723